### PR TITLE
Avoid inconsistent NRE in our FxCop rules

### DIFF
--- a/src/Strict.ruleset
+++ b/src/Strict.ruleset
@@ -6,6 +6,5 @@
   <IncludeAll Action="Error" />
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1062" Action="None" />
-    <Rule Id="MW1200" Action="None" />
   </Rules>
 </RuleSet>

--- a/src/System.Net.Http.Formatting/UriExtensions.cs
+++ b/src/System.Net.Http.Formatting/UriExtensions.cs
@@ -6,9 +6,6 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http.Formatting;
-#if !NETFX_CORE
-using System.Net.Http.Formatting.Internal;
-#endif
 using System.Web.Http;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -70,7 +67,6 @@ namespace System.Net.Http
         /// <param name="value">An object to be initialized with this instance or null if the conversion cannot be performed.</param>
         /// <returns><c>true</c> if the query component can be read as the specified type; otherwise <c>false</c>.</returns>
         [SuppressMessage("Microsoft.Design", "CA1007:UseGenericsWhereAppropriate", Justification = "This is the non-generic version.")]
-        [SuppressMessage("Microsoft.Web.FxCop", "MW1201", Justification = "Avoid an NRE in our custom rule (see AspNetWebStack#16). Occurs while handling JTokenReader.Dispose().")]
         public static bool TryReadQueryAs(this Uri address, Type type, out object value)
         {
             if (address == null)

--- a/src/System.Web.Http/Routing/AttributeRoutingMapper.cs
+++ b/src/System.Web.Http/Routing/AttributeRoutingMapper.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Web.Http.Controllers;
@@ -15,7 +16,7 @@ namespace System.Web.Http.Routing
     /// </remarks>
     internal static class AttributeRoutingMapper
     {
-        // Attribute routing will inject a single top-level route into the route table. 
+        // Attribute routing will inject a single top-level route into the route table.
         private const string AttributeRouteName = "MS_attributerouteWebApi";
 
         public static void MapAttributeRoutes(
@@ -69,7 +70,7 @@ namespace System.Web.Http.Routing
                 };
         }
 
-        // Add generation hooks for the Attribute-routing subroutes. 
+        // Add generation hooks for the Attribute-routing subroutes.
         // This lets us generate urls for routes supplied by attr-based routing.
         private static void AddGenerationHooksForSubRoutes(HttpRouteCollection routeTable,
             IEnumerable<RouteEntry> entries)
@@ -90,8 +91,10 @@ namespace System.Web.Http.Routing
             }
         }
 
+        [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling",
+            Justification = "This method is a coordinator, so this coupling is expected. Also fine unless building Debug configuration.")]
         private static void AddRouteEntries(
-            SubRouteCollection collector, 
+            SubRouteCollection collector,
             HttpConfiguration configuration,
             IInlineConstraintResolver constraintResolver,
             IDirectRouteProvider directRouteProvider)
@@ -149,7 +152,7 @@ namespace System.Web.Http.Routing
                         else
                         {
                             routeControllerDescriptor.SetIsAttributeRouted(true);
-                        }                        
+                        }
                     }
 
                     collector.AddRange(newEntries);

--- a/src/System.Web.Http/Routing/HttpParsedRoute.cs
+++ b/src/System.Web.Http/Routing/HttpParsedRoute.cs
@@ -23,6 +23,8 @@ namespace System.Web.Http.Routing
 
         [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity", Justification = "Not changing original algorithm")]
         [SuppressMessage("Microsoft.Maintainability", "CA1505:AvoidUnmaintainableCode", Justification = "Not changing original algorithm")]
+        [SuppressMessage("Microsoft.Performance", "CA1809:AvoidExcessiveLocals",
+            Justification = "Not changing original algorithm. Also fine unless building Debug configuration.")]
         public BoundRouteTemplate Bind(IDictionary<string, object> currentValues, IDictionary<string, object> values, HttpRouteValueDictionary defaultValues, HttpRouteValueDictionary constraints)
         {
             if (currentValues == null)

--- a/src/System.Web.Mvc/Async/TaskAsyncActionDescriptor.cs
+++ b/src/System.Web.Mvc/Async/TaskAsyncActionDescriptor.cs
@@ -150,11 +150,11 @@ namespace System.Web.Mvc.Async
             Task taskUser = dispatcher.Execute(controllerContext.Controller, parametersArray) as Task;
             Action cleanupAtEndExecute = () =>
             {
-                // Cleanup code that's run in EndExecute, after we've waited on the task value. 
+                // Cleanup code that's run in EndExecute, after we've waited on the task value.
 
                 if (taskCancelledTimer != null)
                 {
-                    // Timer callback may still fire after Dispose is called. 
+                    // Timer callback may still fire after Dispose is called.
                     taskCancelledTimer.Dispose();
                 }
 
@@ -166,8 +166,8 @@ namespace System.Web.Mvc.Async
                         tokenSource.Dispose();
                         if (tokenSource.IsCancellationRequested)
                         {
-                            // Give Timeout exceptions higher priority over other exceptions, mainly OperationCancelled exceptions 
-                            // that were signaled with out timeout token.                             
+                            // Give Timeout exceptions higher priority over other exceptions, mainly OperationCancelled exceptions
+                            // that were signaled with out timeout token.
                             throw new TimeoutException();
                         }
                     }
@@ -176,7 +176,7 @@ namespace System.Web.Mvc.Async
 
             TaskWrapperAsyncResult result = new TaskWrapperAsyncResult(taskUser, state, cleanupAtEndExecute);
 
-            // if user supplied a callback, invoke that when their task has finished running. 
+            // if user supplied a callback, invoke that when their task has finished running.
             if (callback != null)
             {
                 if (taskUser.IsCompleted)

--- a/src/System.Web.Razor/Parser/RazorParser.cs
+++ b/src/System.Web.Razor/Parser/RazorParser.cs
@@ -113,7 +113,7 @@ namespace System.Web.Razor.Parser
                 }
                 catch (OperationCanceledException)
                 {
-                    return; // Just return if we're cancelled.
+                    return; // Just return if we're canceled.
                 }
             });
         }

--- a/tools/src/Microsoft.Web.FxCop/TypeNodeExtensions.cs
+++ b/tools/src/Microsoft.Web.FxCop/TypeNodeExtensions.cs
@@ -21,6 +21,18 @@ namespace Microsoft.Web.FxCop
 
         public static bool IsTask(this TypeNode type)
         {
+            if (type.IsAbstract)
+            {
+                // Short-circuit because Task is not an abstract type.
+                //
+                // This also avoids NREs when the passed type is an interface. May be passed an interface when caller
+                // encounters a method that is explicitly implemented e.g. Dispose() is not visible directly on
+                // JsonReader though JsonReader implements System.IDisposable. Interfaces such as IDisposable are
+                // defined very low in the module hierarchy, leading to NREs in GetTaskAssembly(). Therefore, use only
+                // concrete types to initialize the fields.
+                return false;
+            }
+
             EnsureTaskTypesInitialized(type);
             return IsTaskCore(type);
         }


### PR DESCRIPTION
- #16
- remove temporary suppression for this rule
- add suppressions for a couple of rules violated only in Debug builds

Tested to confirm all MW120x rule suppresions are needed and therefore that rules work fine.
- removed global override for MW1200; already suppressed in one place it's needed (`RazorParser`)
