### PR TITLE
Correct bad merge in 10ac900

### DIFF
--- a/test/System.Web.Http.Test/Controllers/ApiControllerTest.cs
+++ b/test/System.Web.Http.Test/Controllers/ApiControllerTest.cs
@@ -96,7 +96,7 @@ namespace System.Web.Http
                 CancellationToken.None);
 
             // Assert
-            Assert.Equal("User deleted", await message.Content.ReadAsStringAsync());
+            Assert.Equal("User Deleted", await message.Content.ReadAsStringAsync());
         }
 
         [Fact]


### PR DESCRIPTION
FYI only. Will merge one-`char` change immediately.
