### PR TITLE
Do not use C# 6.0 features

### DIFF
--- a/test/Microsoft.TestCommon/FactDiscoverer.cs
+++ b/test/Microsoft.TestCommon/FactDiscoverer.cs
@@ -42,13 +42,13 @@ namespace Microsoft.TestCommon
             IAttributeInfo factAttribute)
         {
             var baseCases = base.Discover(discoveryOptions, testMethod, factAttribute);
-            if (!String.IsNullOrEmpty(factAttribute.GetNamedArgument<string>(nameof(FactAttribute.Skip))))
+            if (!String.IsNullOrEmpty(factAttribute.GetNamedArgument<string>("Skip")))
             {
                 // No need to change skipped tests.
                 return baseCases;
             }
 
-            var platforms = factAttribute.GetNamedArgument<Platform>(nameof(FactAttribute.Platforms));
+            var platforms = factAttribute.GetNamedArgument<Platform>("Platforms");
             if ((platforms & Platform) != 0)
             {
                 // No need to change tests that should run on the current platform.
@@ -71,7 +71,7 @@ namespace Microsoft.TestCommon
             }
 
             // Replace test with its skipped equivalent.
-            var platformJustification = factAttribute.GetNamedArgument<string>(nameof(FactAttribute.PlatformJustification));
+            var platformJustification = factAttribute.GetNamedArgument<string>("PlatformJustification");
             var skipReason = String.Format(platformJustification, platforms.ToString().Replace(", ", " | "), Platform);
             var testCase = new SkippedXunitTestCase(
                 _diagnosticMessageSink,

--- a/test/Microsoft.TestCommon/PortReserver.cs
+++ b/test/Microsoft.TestCommon/PortReserver.cs
@@ -143,7 +143,8 @@ namespace Microsoft.TestCommon
             Mutex mutex = new Mutex(initiallyOwned: false, name: "WebStack-RandomPortAcquisition");
             if (!mutex.WaitOne(TimeSpan.FromSeconds(timeoutInSeconds)))
             {
-                throw new InvalidOperationException($"Unable to reserve global Mutex within {timeoutInSeconds} seconds.");
+                throw new InvalidOperationException(
+                    String.Format("Unable to reserve global Mutex within {0} seconds.", timeoutInSeconds));
             }
 
             return mutex;

--- a/test/Microsoft.TestCommon/TheoryDiscoverer.cs
+++ b/test/Microsoft.TestCommon/TheoryDiscoverer.cs
@@ -40,13 +40,13 @@ namespace Microsoft.TestCommon
             IAttributeInfo theoryAttribute)
         {
             var baseCases = base.Discover(discoveryOptions, testMethod, theoryAttribute);
-            if (!String.IsNullOrEmpty(theoryAttribute.GetNamedArgument<string>(nameof(TheoryAttribute.Skip))))
+            if (!String.IsNullOrEmpty(theoryAttribute.GetNamedArgument<string>("Skip")))
             {
                 // No need to change skipped tests.
                 return baseCases;
             }
 
-            var platforms = theoryAttribute.GetNamedArgument<Platform>(nameof(TheoryAttribute.Platforms));
+            var platforms = theoryAttribute.GetNamedArgument<Platform>("Platforms");
             if ((platforms & Platform) != 0)
             {
                 // No need to change tests that should run on the current platform.
@@ -55,7 +55,7 @@ namespace Microsoft.TestCommon
 
             // Update the individual test cases as needed: Skip test cases that would otherwise run.
             var testCases = new List<IXunitTestCase>();
-            var platformJustification = theoryAttribute.GetNamedArgument<string>(nameof(TheoryAttribute.PlatformJustification));
+            var platformJustification = theoryAttribute.GetNamedArgument<string>("PlatformJustification");
             var skipReason = String.Format(platformJustification, platforms.ToString().Replace(", ", " | "), Platform);
             foreach (var baseCase in baseCases)
             {

--- a/tools/WebStack.settings.targets
+++ b/tools/WebStack.settings.targets
@@ -36,6 +36,9 @@
     <!-- Target 4.5 by default -->
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
 
+    <!-- Disable C# 6.0 features in Visual Studio since those features are not always available in command-line builds. -->
+    <LangVersion Condition=" '$(MSBuildProjectExtension)' == '.csproj' ">5</LangVersion>
+
     <!-- Everything is delay signed by default -->
     <SignAssembly>true</SignAssembly>
     <DelaySign>true</DelaySign>


### PR DESCRIPTION
- relates to #3
- FYI CI build was fine w/ `nameof()` but disallowed `string` interpolation
- also disable these features; don't want VS offering features that won't always work
