### PR TITLE
Add support for new style Roslyn dotless commits.

### DIFF
--- a/test/System.Web.Razor.Test/Parser/PartialParsing/CSharpPartialParsingTest.cs
+++ b/test/System.Web.Razor.Test/Parser/PartialParsing/CSharpPartialParsingTest.cs
@@ -59,6 +59,159 @@ namespace System.Web.Razor.Test.Parser.PartialParsing
                     factory.Markup(" baz")), additionalFlags: PartialParseResult.Provisional);
         }
 
+        [Fact]
+        public void ImplicitExpressionAcceptsWholeIdentifierReplacement()
+        {
+            // Arrange
+            SpanFactory factory = SpanFactory.CreateCsHtml();
+            StringTextBuffer old = new StringTextBuffer("foo @date baz");
+            StringTextBuffer changed = new StringTextBuffer("foo @DateTime baz");
+
+            // Act and Assert
+            RunPartialParseTest(new TextChange(5, 4, old, 8, changed),
+                new MarkupBlock(
+                    factory.Markup("foo "),
+                    new ExpressionBlock(
+                        factory.CodeTransition(),
+                        factory.Code("DateTime").AsImplicitExpression(CSharpCodeParser.DefaultKeywords).Accepts(AcceptedCharacters.NonWhiteSpace)),
+                    factory.Markup(" baz")));
+        }
+
+        [Fact]
+        public void ImplicitExpressionRejectsWholeIdentifierReplacementToKeyword()
+        {
+            // Arrange
+            RazorEngineHost host = CreateHost();
+            RazorEditorParser parser = new RazorEditorParser(host, @"C:\This\Is\A\Test\Path");
+
+            using (TestParserManager manager = new TestParserManager(parser))
+            {
+                StringTextBuffer old = new StringTextBuffer("foo @date baz");
+                StringTextBuffer changed = new StringTextBuffer("foo @if baz");
+                TextChange textChange = new TextChange(5, 4, old, 2, changed);
+                manager.InitializeWithDocument(old);
+
+                // Act
+                PartialParseResult result = manager.CheckForStructureChangesAndWait(textChange);
+
+                // Assert
+                Assert.Equal(PartialParseResult.Rejected, result);
+                Assert.Equal(2, manager.ParseCount);
+            }
+        }
+
+        [Fact]
+        public void ImplicitExpressionRejectsWholeIdentifierReplacementToDirective()
+        {
+            // Arrange
+            RazorEngineHost host = CreateHost();
+            RazorEditorParser parser = new RazorEditorParser(host, @"C:\This\Is\A\Test\Path");
+
+            using (var manager = new TestParserManager(parser))
+            {
+                StringTextBuffer old = new StringTextBuffer("foo @date baz");
+                StringTextBuffer changed = new StringTextBuffer("foo @inherits baz");
+                TextChange textChange = new TextChange(5, 4, old, 8, changed);
+                manager.InitializeWithDocument(old);
+
+                // Act
+                PartialParseResult result = manager.CheckForStructureChangesAndWait(textChange);
+
+                // Assert
+                Assert.Equal(PartialParseResult.Rejected | PartialParseResult.SpanContextChanged, result);
+                Assert.Equal(2, manager.ParseCount);
+            }
+        }
+
+        [Fact]
+        public void ImplicitExpressionAcceptsPrefixIdentifierReplacements_SingleSymbol()
+        {
+            // Arrange
+            SpanFactory factory = SpanFactory.CreateCsHtml();
+            StringTextBuffer old = new StringTextBuffer("foo @dTime baz");
+            StringTextBuffer changed = new StringTextBuffer("foo @DateTime baz");
+
+            // Act and Assert
+            RunPartialParseTest(new TextChange(5, 1, old, 4, changed),
+                new MarkupBlock(
+                    factory.Markup("foo "),
+                    new ExpressionBlock(
+                        factory.CodeTransition(),
+                        factory.Code("DateTime").AsImplicitExpression(CSharpCodeParser.DefaultKeywords).Accepts(AcceptedCharacters.NonWhiteSpace)),
+                    factory.Markup(" baz")));
+        }
+
+        [Fact]
+        public void ImplicitExpressionAcceptsPrefixIdentifierReplacements_MultipleSymbols()
+        {
+            // Arrange
+            SpanFactory factory = SpanFactory.CreateCsHtml();
+            StringTextBuffer old = new StringTextBuffer("foo @dTime.Now baz");
+            StringTextBuffer changed = new StringTextBuffer("foo @DateTime.Now baz");
+
+            // Act and Assert
+            RunPartialParseTest(new TextChange(5, 1, old, 4, changed),
+                new MarkupBlock(
+                    factory.Markup("foo "),
+                    new ExpressionBlock(
+                        factory.CodeTransition(),
+                        factory.Code("DateTime.Now").AsImplicitExpression(CSharpCodeParser.DefaultKeywords).Accepts(AcceptedCharacters.NonWhiteSpace)),
+                    factory.Markup(" baz")));
+        }
+
+        [Fact]
+        public void ImplicitExpressionAcceptsSuffixIdentifierReplacements_SingleSymbol()
+        {
+            // Arrange
+            SpanFactory factory = SpanFactory.CreateCsHtml();
+            StringTextBuffer old = new StringTextBuffer("foo @Datet baz");
+            StringTextBuffer changed = new StringTextBuffer("foo @DateTime baz");
+
+            // Act and Assert
+            RunPartialParseTest(new TextChange(9, 1, old, 4, changed),
+                new MarkupBlock(
+                    factory.Markup("foo "),
+                    new ExpressionBlock(
+                        factory.CodeTransition(),
+                        factory.Code("DateTime").AsImplicitExpression(CSharpCodeParser.DefaultKeywords).Accepts(AcceptedCharacters.NonWhiteSpace)),
+                    factory.Markup(" baz")));
+        }
+
+        [Fact]
+        public void ImplicitExpressionAcceptsSuffixIdentifierReplacements_MultipleSymbols()
+        {
+            // Arrange
+            SpanFactory factory = SpanFactory.CreateCsHtml();
+            StringTextBuffer old = new StringTextBuffer("foo @DateTime.n baz");
+            StringTextBuffer changed = new StringTextBuffer("foo @DateTime.Now baz");
+
+            // Act and Assert
+            RunPartialParseTest(new TextChange(14, 1, old, 3, changed),
+                new MarkupBlock(
+                    factory.Markup("foo "),
+                    new ExpressionBlock(
+                        factory.CodeTransition(),
+                        factory.Code("DateTime.Now").AsImplicitExpression(CSharpCodeParser.DefaultKeywords).Accepts(AcceptedCharacters.NonWhiteSpace)),
+                    factory.Markup(" baz")));
+        }
+
+        [Fact]
+        public void ImplicitExpressionAcceptsSurroundedIdentifierReplacements()
+        {
+            // Arrange
+            SpanFactory factory = SpanFactory.CreateCsHtml();
+            StringTextBuffer old = new StringTextBuffer("foo @DateTime.n.ToString() baz");
+            StringTextBuffer changed = new StringTextBuffer("foo @DateTime.Now.ToString() baz");
+
+            // Act and Assert
+            RunPartialParseTest(new TextChange(14, 1, old, 3, changed),
+                new MarkupBlock(
+                    factory.Markup("foo "),
+                    new ExpressionBlock(
+                        factory.CodeTransition(),
+                        factory.Code("DateTime.Now.ToString()").AsImplicitExpression(CSharpCodeParser.DefaultKeywords).Accepts(AcceptedCharacters.NonWhiteSpace)),
+                    factory.Markup(" baz")));
+        }
 
         [Fact]
         public void ImplicitExpressionAcceptsDotlessCommitInsertionsInStatementBlockAfterIdentifiers()
@@ -244,6 +397,61 @@ namespace System.Web.Razor.Test.Parser.PartialParsing
             textChange = new TextChange(14, 0, old, 3, changed);
 
             applyAndVerifyPartialChange(textChange, PartialParseResult.Accepted | PartialParseResult.Provisional, "DateTime.Now.");
+        }
+
+        [Fact]
+        public void ImplicitExpressionProvisionallyAcceptsCaseInsensitiveDotlessCommitInsertions_NewRoslynIntegration()
+        {
+            SpanFactory factory = SpanFactory.CreateCsHtml();
+            StringTextBuffer old = new StringTextBuffer("foo @date baz");
+            StringTextBuffer changed = new StringTextBuffer("foo @date. baz");
+            TextChange textChange = new TextChange(9, 0, old, 1, changed);
+            using (TestParserManager manager = CreateParserManager())
+            {
+                Action<TextChange, PartialParseResult, string> applyAndVerifyPartialChange = (changeToApply, expectedResult, expectedCode) =>
+                {
+                    PartialParseResult result = manager.CheckForStructureChangesAndWait(textChange);
+
+                    // Assert
+                    Assert.Equal(expectedResult, result);
+                    Assert.Equal(1, manager.ParseCount);
+
+                    ParserTestBase.EvaluateParseTree(manager.Parser.CurrentParseTree, new MarkupBlock(
+                        factory.Markup("foo "),
+                        new ExpressionBlock(
+                            factory.CodeTransition(),
+                            factory.Code(expectedCode).AsImplicitExpression(CSharpCodeParser.DefaultKeywords).Accepts(AcceptedCharacters.NonWhiteSpace)),
+                        factory.Markup(" baz")));
+                };
+
+                manager.InitializeWithDocument(textChange.OldBuffer);
+
+                // This is the process of a dotless commit when doing "." insertions to commit intellisense changes.
+
+                // @date => @date.
+                applyAndVerifyPartialChange(textChange, PartialParseResult.Accepted | PartialParseResult.Provisional, "date.");
+
+                old = changed;
+                changed = new StringTextBuffer("foo @date baz");
+                textChange = new TextChange(9, 1, old, 0, changed);
+
+                // @date. => @date
+                applyAndVerifyPartialChange(textChange, PartialParseResult.Accepted, "date");
+
+                old = changed;
+                changed = new StringTextBuffer("foo @DateTime baz");
+                textChange = new TextChange(5, 4, old, 8, changed);
+
+                // @date => @DateTime
+                applyAndVerifyPartialChange(textChange, PartialParseResult.Accepted, "DateTime");
+
+                old = changed;
+                changed = new StringTextBuffer("foo @DateTime. baz");
+                textChange = new TextChange(13, 0, old, 1, changed);
+
+                // @DateTime => @DateTime.
+                applyAndVerifyPartialChange(textChange, PartialParseResult.Accepted | PartialParseResult.Provisional, "DateTime.");
+            }
         }
 
         [Fact]


### PR DESCRIPTION
- Roslyn swapped the way they performed dotless commit insertions. They went from:
date => date. => DateTime.  to
date => date. => date => DateTime => DateTime.
The problem with the new approach is that date => DateTime would be rejected and therefore force the editor to reparse and reclassify any dots as HTML giving improper IntelliSense.
- Updated Razor implicit expression edit handling to allow identifier => identifier replacements as long as the identifiers didn't result in keyword or directives.
- Added tests to verify the scenarios impacted.

Here's the corresponding core commit that was signed off on: https://github.com/aspnet/Razor/pull/946