### PR TITLE
Correcting multiple X-Frame-Options header

### DIFF
--- a/src/System.Web.WebPages/Helpers/AntiXsrf/AntiForgeryWorker.cs
+++ b/src/System.Web.WebPages/Helpers/AntiXsrf/AntiForgeryWorker.cs
@@ -104,7 +104,7 @@ namespace System.Web.Helpers.AntiXsrf
                 // Adding X-Frame-Options header to prevent ClickJacking. See
                 // http://tools.ietf.org/html/draft-ietf-websec-x-frame-options-10
                 // for more information.
-                var xFrameHeaderName = "X-Frame-Options";
+                const string xFrameHeaderName = "X-Frame-Options";
                 if (httpContext.Response.Headers[xFrameHeaderName] == null)
                 {
                     httpContext.Response.AddHeader(xFrameHeaderName, "SAMEORIGIN");

--- a/src/System.Web.WebPages/Helpers/AntiXsrf/AntiForgeryWorker.cs
+++ b/src/System.Web.WebPages/Helpers/AntiXsrf/AntiForgeryWorker.cs
@@ -104,7 +104,11 @@ namespace System.Web.Helpers.AntiXsrf
                 // Adding X-Frame-Options header to prevent ClickJacking. See
                 // http://tools.ietf.org/html/draft-ietf-websec-x-frame-options-10
                 // for more information.
-                httpContext.Response.AddHeader("X-Frame-Options", "SAMEORIGIN");
+                var xFrameHeaderName = "X-Frame-Options";
+                if (httpContext.Response.Headers[xFrameHeaderName] == null)
+                {
+                    httpContext.Response.AddHeader(xFrameHeaderName, "SAMEORIGIN");
+                }
             }
 
             // <input type="hidden" name="__AntiForgeryToken" value="..." />

--- a/src/System.Web.WebPages/Helpers/AntiXsrf/AntiForgeryWorker.cs
+++ b/src/System.Web.WebPages/Helpers/AntiXsrf/AntiForgeryWorker.cs
@@ -104,10 +104,10 @@ namespace System.Web.Helpers.AntiXsrf
                 // Adding X-Frame-Options header to prevent ClickJacking. See
                 // http://tools.ietf.org/html/draft-ietf-websec-x-frame-options-10
                 // for more information.
-                const string xFrameHeaderName = "X-Frame-Options";
-                if (httpContext.Response.Headers[xFrameHeaderName] == null)
+                const string frameHeaderName = "X-Frame-Options";
+                if (httpContext.Response.Headers[frameHeaderName] == null)
                 {
-                    httpContext.Response.AddHeader(xFrameHeaderName, "SAMEORIGIN");
+                    httpContext.Response.AddHeader(frameHeaderName, "SAMEORIGIN");
                 }
             }
 

--- a/src/System.Web.WebPages/Helpers/AntiXsrf/AntiForgeryWorker.cs
+++ b/src/System.Web.WebPages/Helpers/AntiXsrf/AntiForgeryWorker.cs
@@ -104,10 +104,10 @@ namespace System.Web.Helpers.AntiXsrf
                 // Adding X-Frame-Options header to prevent ClickJacking. See
                 // http://tools.ietf.org/html/draft-ietf-websec-x-frame-options-10
                 // for more information.
-                const string frameHeaderName = "X-Frame-Options";
-                if (httpContext.Response.Headers[frameHeaderName] == null)
+                const string FrameHeaderName = "X-Frame-Options";
+                if (httpContext.Response.Headers[FrameHeaderName] == null)
                 {
-                    httpContext.Response.AddHeader(frameHeaderName, "SAMEORIGIN");
+                    httpContext.Response.AddHeader(FrameHeaderName, "SAMEORIGIN");
                 }
             }
 


### PR DESCRIPTION
According to RFC7034, only these three values, DENY, SAMEORIGIN and ALLOW FROM are valid values and they are mutually exclusive; that is, the header field must be set to exactly one of these three values.   This will prevent the CSRF code from inserting it multiple times as well as duplicating it if it was already set elsewhere (e.g. IIS Header)

Addresses #7