### PR TITLE
Simplify the Custom repository path

### DIFF
--- a/src/System.Web.Mvc/RazorViewEngine.cs
+++ b/src/System.Web.Mvc/RazorViewEngine.cs
@@ -17,46 +17,46 @@ namespace System.Web.Mvc
         {
             AreaViewLocationFormats = new[]
             {
-                "~/Areas/{2}/Views/{1}/{0}.cshtml",
-                "~/Areas/{2}/Views/{1}/{0}.vbhtml",
-                "~/Areas/{2}/Views/Shared/{0}.cshtml",
-                "~/Areas/{2}/Views/Shared/{0}.vbhtml"
+                string.Format("~/{3}/{2}/{4}/{1}/{0}.cshtml","{0}","{1}","{2}",DefaultAreaFolder,DefaultViewFolder),
+                string.Format("~/{3}/{2}/{4}/{1}/{0}.vbhtml","{0}","{1}","{2}",DefaultAreaFolder,DefaultViewFolder),
+                string.Format("~/{3}/{2}/{4}/{5}/{1}/{0}.cshtml","{0}","{1}","{2}",DefaultAreaFolder,DefaultViewFolder, DefaultSharedViewFolder),
+                string.Format("~/{3}/{2}/{4}/{5}/{1}/{0}.vbhtml","{0}","{1}","{2}",DefaultAreaFolder,DefaultViewFolder, DefaultSharedViewFolder)
             };
             AreaMasterLocationFormats = new[]
             {
-                "~/Areas/{2}/Views/{1}/{0}.cshtml",
-                "~/Areas/{2}/Views/{1}/{0}.vbhtml",
-                "~/Areas/{2}/Views/Shared/{0}.cshtml",
-                "~/Areas/{2}/Views/Shared/{0}.vbhtml"
+                string.Format("~/{3}/{2}/{4}/{1}/{0}.cshtml","{0}","{1}","{2}",DefaultAreaFolder,DefaultViewFolder),
+                string.Format("~/{3}/{2}/{4}/{1}/{0}.vbhtml","{0}","{1}","{2}",DefaultAreaFolder,DefaultViewFolder),
+                string.Format("~/{3}/{2}/{4}/{5}/{1}/{0}.cshtml","{0}","{1}","{2}",DefaultAreaFolder,DefaultViewFolder, DefaultSharedViewFolder),
+                string.Format("~/{3}/{2}/{4}/{5}/{1}/{0}.vbhtml","{0}","{1}","{2}",DefaultAreaFolder,DefaultViewFolder, DefaultSharedViewFolder)
             };
             AreaPartialViewLocationFormats = new[]
             {
-                "~/Areas/{2}/Views/{1}/{0}.cshtml",
-                "~/Areas/{2}/Views/{1}/{0}.vbhtml",
-                "~/Areas/{2}/Views/Shared/{0}.cshtml",
-                "~/Areas/{2}/Views/Shared/{0}.vbhtml"
+                string.Format("~/{3}/{2}/{4}/{1}/{0}.cshtml","{0}","{1}","{2}",DefaultAreaFolder,DefaultViewFolder),
+                string.Format("~/{3}/{2}/{4}/{1}/{0}.vbhtml","{0}","{1}","{2}",DefaultAreaFolder,DefaultViewFolder),
+                string.Format("~/{3}/{2}/{4}/{5}/{1}/{0}.cshtml","{0}","{1}","{2}",DefaultAreaFolder,DefaultViewFolder, DefaultSharedViewFolder),
+                string.Format("~/{3}/{2}/{4}/{5}/{1}/{0}.vbhtml","{0}","{1}","{2}",DefaultAreaFolder,DefaultViewFolder, DefaultSharedViewFolder)
             };
 
             ViewLocationFormats = new[]
             {
-                "~/Views/{1}/{0}.cshtml",
-                "~/Views/{1}/{0}.vbhtml",
-                "~/Views/Shared/{0}.cshtml",
-                "~/Views/Shared/{0}.vbhtml"
+                string.Format("~/{3}/{2}/{1}/{0}.cshtml","{0}","{1}","{2}",DefaultViewFolder),
+                string.Format("~/{3}/{2}/{1}/{0}.vbhtml","{0}","{1}","{2}",DefaultViewFolder),
+                string.Format("~/{1}/{2}/{0}.cshtml","{0}",DefaultViewFolder, DefaultSharedViewFolder),
+                string.Format("~/{1}/{2}/{0}.vbhtml","{0}",DefaultViewFolder, DefaultSharedViewFolder),
             };
             MasterLocationFormats = new[]
             {
-                "~/Views/{1}/{0}.cshtml",
-                "~/Views/{1}/{0}.vbhtml",
-                "~/Views/Shared/{0}.cshtml",
-                "~/Views/Shared/{0}.vbhtml"
+                string.Format("~/{3}/{2}/{1}/{0}.cshtml","{0}","{1}","{2}",DefaultViewFolder),
+                string.Format("~/{3}/{2}/{1}/{0}.vbhtml","{0}","{1}","{2}",DefaultViewFolder),
+                string.Format("~/{1}/{2}/{0}.cshtml","{0}",DefaultViewFolder, DefaultSharedViewFolder),
+                string.Format("~/{1}/{2}/{0}.vbhtml","{0}",DefaultViewFolder, DefaultSharedViewFolder),
             };
             PartialViewLocationFormats = new[]
             {
-                "~/Views/{1}/{0}.cshtml",
-                "~/Views/{1}/{0}.vbhtml",
-                "~/Views/Shared/{0}.cshtml",
-                "~/Views/Shared/{0}.vbhtml"
+                string.Format("~/{3}/{2}/{1}/{0}.cshtml","{0}","{1}","{2}",DefaultViewFolder),
+                string.Format("~/{3}/{2}/{1}/{0}.vbhtml","{0}","{1}","{2}",DefaultViewFolder),
+                string.Format("~/{1}/{2}/{0}.cshtml","{0}",DefaultViewFolder, DefaultSharedViewFolder),
+                string.Format("~/{1}/{2}/{0}.vbhtml","{0}",DefaultViewFolder, DefaultSharedViewFolder),
             };
 
             FileExtensions = new[]

--- a/src/System.Web.Mvc/ViewContext.cs
+++ b/src/System.Web.Mvc/ViewContext.cs
@@ -52,19 +52,19 @@ window.mvcClientValidationMetadata.push({0});
             {
                 throw new ArgumentNullException("controllerContext");
             }
-            if (view == null)
+            else if (view == null)
             {
                 throw new ArgumentNullException("view");
             }
-            if (viewData == null)
+            else if (viewData == null)
             {
                 throw new ArgumentNullException("viewData");
             }
-            if (tempData == null)
+            else if (tempData == null)
             {
                 throw new ArgumentNullException("tempData");
             }
-            if (writer == null)
+            else if (writer == null)
             {
                 throw new ArgumentNullException("writer");
             }

--- a/src/System.Web.Mvc/VirtualPathProviderViewEngine.cs
+++ b/src/System.Web.Mvc/VirtualPathProviderViewEngine.cs
@@ -25,6 +25,10 @@ namespace System.Web.Mvc
         internal Func<string, string> GetExtensionThunk = VirtualPathUtility.GetExtension;
         private IViewLocationCache _viewLocationCache;
 
+        private string _DefaultSharedViewFolder ;
+        private string _DefaultAreaFolder ;
+        private string _DefaultViewFolder ;
+
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "This is a shipped API")]
         public string[] AreaMasterLocationFormats { get; set; }
 
@@ -42,6 +46,54 @@ namespace System.Web.Mvc
 
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays", Justification = "This is a shipped API")]
         public string[] PartialViewLocationFormats { get; set; }
+
+        public string DefaultSharedViewFolder
+        {
+            get
+            {
+                if (string.IsNullOrWhiteSpace(_DefaultSharedViewFolder))
+                {
+                    _DefaultSharedViewFolder = "Shared";
+                }
+                return _DefaultSharedViewFolder;
+            }
+            set
+            {
+                _DefaultSharedViewFolder = value;
+            }
+        }
+        public string DefaultViewFolder
+        {
+            get
+            {
+                if (string.IsNullOrWhiteSpace(_DefaultViewFolder))
+                {
+                    _DefaultViewFolder = "Views";
+                }
+                return _DefaultViewFolder;
+            }
+            set
+            {
+                _DefaultViewFolder = value;
+            }
+        }
+
+        public string DefaultAreaFolder
+        {
+            get
+            {
+                if (string.IsNullOrWhiteSpace(_DefaultAreaFolder))
+                {
+                    _DefaultAreaFolder = "Areas";
+                }
+                return _DefaultAreaFolder;
+            }
+            set
+            {
+                _DefaultAreaFolder = value;
+            }
+        }
+
 
         // Neither DefaultViewLocationCache.Null nor a DefaultViewLocationCache instance maintain internal state. Fine
         // if multiple threads race to initialize _viewLocationCache.


### PR DESCRIPTION
Instead of overriding the view engine class , we can define the repository path before registering the ViewEngine in the application context

