### PR TITLE
Enlarge an xUnit collection to include all `ModelMetadataProviders.Current` readers

### DIFF
--- a/test/System.Web.Mvc.Test/Html/Test/DefaultDisplayTemplatesTest.cs
+++ b/test/System.Web.Mvc.Test/Html/Test/DefaultDisplayTemplatesTest.cs
@@ -13,6 +13,7 @@ using Moq;
 
 namespace System.Web.Mvc.Html.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class DefaultDisplayTemplatesTest
     {
         // BooleanTemplate

--- a/test/System.Web.Mvc.Test/Test/AssociatedValidatorProviderTest.cs
+++ b/test/System.Web.Mvc.Test/Test/AssociatedValidatorProviderTest.cs
@@ -9,6 +9,7 @@ using Moq;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class AssociatedValidatorProviderTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/CompareAttributeAdapterTest.cs
+++ b/test/System.Web.Mvc.Test/Test/CompareAttributeAdapterTest.cs
@@ -9,6 +9,7 @@ using MyResources = System.Web.Properties.Resources;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class CompareAttributeAdapterTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/CompareAttributeTest.cs
+++ b/test/System.Web.Mvc.Test/Test/CompareAttributeTest.cs
@@ -8,6 +8,7 @@ using Moq;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class CompareAttributeTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/ControllerActionInvokerTest.cs
+++ b/test/System.Web.Mvc.Test/Test/ControllerActionInvokerTest.cs
@@ -18,6 +18,7 @@ using Moq;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class ControllerActionInvokerTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/DataAnnotationsModelValidatorProviderTest.cs
+++ b/test/System.Web.Mvc.Test/Test/DataAnnotationsModelValidatorProviderTest.cs
@@ -11,6 +11,7 @@ using DataAnnotationsCompareAttribute = System.ComponentModel.DataAnnotations.Co
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class DataAnnotationsModelValidatorProviderTest
     {
         // Validation attribute adapter registration

--- a/test/System.Web.Mvc.Test/Test/DataAnnotationsModelValidatorTest.cs
+++ b/test/System.Web.Mvc.Test/Test/DataAnnotationsModelValidatorTest.cs
@@ -10,6 +10,7 @@ using Moq.Protected;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class DataAnnotationsModelValidatorTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/DefaultModelBinderTest.cs
+++ b/test/System.Web.Mvc.Test/Test/DefaultModelBinderTest.cs
@@ -15,6 +15,7 @@ using Moq.Protected;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class DefaultModelBinderTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/MaxLengthAttributeAdapterTest.cs
+++ b/test/System.Web.Mvc.Test/Test/MaxLengthAttributeAdapterTest.cs
@@ -2,11 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using Microsoft.TestCommon;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class MaxLengthAttributeAdapterTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/MinLengthAttributeAdapterTest.cs
+++ b/test/System.Web.Mvc.Test/Test/MinLengthAttributeAdapterTest.cs
@@ -2,11 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using Microsoft.TestCommon;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class MinLengthAttributeAdapterTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/ModelBindingContextTest.cs
+++ b/test/System.Web.Mvc.Test/Test/ModelBindingContextTest.cs
@@ -7,6 +7,7 @@ using Microsoft.Web.UnitTestUtil;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class ModelBindingContextTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/ModelMetadataTest.cs
+++ b/test/System.Web.Mvc.Test/Test/ModelMetadataTest.cs
@@ -10,6 +10,7 @@ using Moq;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class ModelMetadataTest
     {
         // Guard clauses
@@ -826,7 +827,7 @@ namespace System.Web.Mvc.Test
                     Assert.Equal(derivedModel.GetType(), type);
                     Assert.Equal("MyProperty", propertyName);
                 })
-                .Returns<Func<object>, Type, string>((accessor, type, propertyName) => 
+                .Returns<Func<object>, Type, string>((accessor, type, propertyName) =>
                 {
                     return new ModelMetadata(provider.Object, derivedModel.GetType(), accessor, type, propertyName);
                 })

--- a/test/System.Web.Mvc.Test/Test/ModelValidatorTest.cs
+++ b/test/System.Web.Mvc.Test/Test/ModelValidatorTest.cs
@@ -8,6 +8,7 @@ using Microsoft.TestCommon;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class ModelValidatorTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/RangeAttributeAdapterTest.cs
+++ b/test/System.Web.Mvc.Test/Test/RangeAttributeAdapterTest.cs
@@ -7,6 +7,7 @@ using Microsoft.TestCommon;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class RangeAttributeAdapterTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/RegularExpressionAttributeAdapterTest.cs
+++ b/test/System.Web.Mvc.Test/Test/RegularExpressionAttributeAdapterTest.cs
@@ -7,6 +7,7 @@ using Microsoft.TestCommon;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class RegularExpressionAttributeAdapterTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/RemoteAttributeTest.cs
+++ b/test/System.Web.Mvc.Test/Test/RemoteAttributeTest.cs
@@ -9,6 +9,7 @@ using Moq;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class RemoteAttributeTest
     {
         // Good route name, bad route name
@@ -261,7 +262,7 @@ namespace System.Web.Mvc.Test
         [Fact]
         public void ActionController_InArea_RemoteFindsControllerInCurrentArea()
         {
-            // Arrange 
+            // Arrange
             ModelMetadata metadata = ModelMetadataProviders.Current.GetMetadataForProperty(modelAccessor: null,
                 containerType: typeof(string), propertyName: "Length");
             TestableRemoteAttribute attribute = new TestableRemoteAttribute("Action", "Controller");

--- a/test/System.Web.Mvc.Test/Test/RequiredAttributeAdapterTest.cs
+++ b/test/System.Web.Mvc.Test/Test/RequiredAttributeAdapterTest.cs
@@ -7,6 +7,7 @@ using Microsoft.TestCommon;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class RequiredAttributeAdapterTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/StringLengthAttributeAdapterTest.cs
+++ b/test/System.Web.Mvc.Test/Test/StringLengthAttributeAdapterTest.cs
@@ -7,6 +7,7 @@ using Microsoft.TestCommon;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class StringLengthAttributeAdapterTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/ValidatableObjectAdapterTest.cs
+++ b/test/System.Web.Mvc.Test/Test/ValidatableObjectAdapterTest.cs
@@ -9,6 +9,7 @@ using Moq;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class ValidatableObjectAdapterTest
     {
         // IValidatableObject support

--- a/test/System.Web.Mvc.Test/Test/ViewDataDictionaryTest.cs
+++ b/test/System.Web.Mvc.Test/Test/ViewDataDictionaryTest.cs
@@ -9,6 +9,7 @@ using Microsoft.TestCommon;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class ViewDataDictionaryTest
     {
         [Fact]


### PR DESCRIPTION
- #41
  - have not seen similar `InvalidOperationException`s in other test classes
- `DisplayExtensionsTest` and `EditorExtensionsTest` are already in this increasingly-poorly named collection
  - they temporarily change `ModelMetadataProviders.Current` to reference a `Mock<ModelMetadataProvider>`

This is a **temporary** fix: should use `[CollectionDefinition(DisableParallelization = true)]` xUnit v2.3.0
  - i.e. create an isolated collection containing just `DisplayExtensionsTest` and `EditorExtensionsTest`