### PR TITLE
Move to MSBuild v15.0 and latest xUnit MSBuild runner

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.Web.SkipStrongNames" version="1.0.0" />
   <package id="Microsoft.Web.StyleCop" version="1.0.0" />
   <package id="StyleCop" version="5.0.0" />
-  <package id="xunit.runner.msbuild" version="2.2.0-beta2-build3300" targetFramework="net45" />
+  <package id="xunit.runner.msbuild" version="2.3.1-rc2-build3844" targetFramework="net452" />
 </packages>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,3 @@
+<Project>
+  <!-- Stop MsBuild searching parent directories for this file. -->
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,3 +1,8 @@
 <Project>
-  <!-- Stop MsBuild searching parent directories for this file. -->
+  <!-- Also stop MsBuild searching parent directories for this file. -->
+
+  <PropertyGroup>
+    <!-- Require VS2017 so VS builds also use MSBuild v15.0. -->
+    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,3 @@
+<Project>
+  <!-- Stop MsBuild searching parent directories for this file. -->
+</Project>

--- a/Runtime.msbuild
+++ b/Runtime.msbuild
@@ -11,6 +11,7 @@
     <BuildPortable Condition=" '$(BuildPortable)' == '' ">true</BuildPortable>
     <BuildInParallel Condition=" '$(BuildInParallel)' == '' And $(MSBuildNodeCount) &gt; 1 ">true</BuildInParallel>
     <BuildInParallel Condition=" '$(BuildInParallel)' == '' ">false</BuildInParallel>
+    <TestInParallel Condition=" '$(TestInParallel)' == '' ">$(BuildInParallel)</TestInParallel>
     <TestResultsDirectory>$(MSBuildThisFileDirectory)bin\$(Configuration)\test\TestResults\</TestResultsDirectory>
     <SkipStrongNamesExe>$(MSBuildThisFileDirectory)packages\Microsoft.Web.SkipStrongNames.1.0.0\tools\SkipStrongNames.exe</SkipStrongNamesExe>
     <SkipStrongNamesXml>$(MSBuildThisFileDirectory)tools\SkipStrongNames.xml</SkipStrongNamesXml>
@@ -107,7 +108,7 @@
     <RemoveDir Directories="$(TestResultsDirectory)" />
     <MakeDir Directories="$(TestResultsDirectory)" />
 
-    <MSBuild Projects="@(XunitProject)" BuildInParallel="$(BuildInParallel)" Targets="Xunit" />
+    <MSBuild Projects="@(XunitProject)" BuildInParallel="$(TestInParallel)" Targets="Xunit" />
   </Target>
 
   <Target Name="CheckSkipStrongNames" DependsOnTargets="RestoreSkipStrongNames">

--- a/Runtime.sln
+++ b/Runtime.sln
@@ -1,8 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30501.0
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.27016.1
+MinimumVisualStudioVersion = 15.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A9836F9E-6DB3-4D9F-ADCA-CF42D8C8BA93}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{C40883CD-366D-4534-8B58-3EA0D13136DF}"
@@ -475,5 +475,8 @@ Global
 		{1E89A3E9-0A7F-418F-B4BE-6E38A6315373} = {C40883CD-366D-4534-8B58-3EA0D13136DF}
 		{821A136C-7C6F-44C6-A9E6-C39B5BFB1483} = {A9836F9E-6DB3-4D9F-ADCA-CF42D8C8BA93}
 		{C3BEF382-C7C4-454D-B017-1EAC03E9A82C} = {C40883CD-366D-4534-8B58-3EA0D13136DF}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A855CFDC-9BEE-43A9-A3EA-4C4624A747DB}
 	EndGlobalSection
 EndGlobal

--- a/RuntimePortable.sln
+++ b/RuntimePortable.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 15
+VisualStudioVersion = 15.0.27016.1
+MinimumVisualStudioVersion = 15.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A9836F9E-6DB3-4D9F-ADCA-CF42D8C8BA93}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{C40883CD-366D-4534-8B58-3EA0D13136DF}"
@@ -14,6 +16,11 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Net.Http.Formatting.NetStandard", "src\System.Net.Http.Formatting.NetStandard\System.Net.Http.Formatting.NetStandard.csproj", "{636CA76A-C85C-42E2-B4AA-88046279B3CA}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Net.Http.Formatting.NetStandard.Test", "test\System.Net.Http.Formatting.NetStandard.Test\System.Net.Http.Formatting.NetStandard.Test.csproj", "{DECB05DF-B33A-44A0-B5DE-B14A8CE0740F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A72045D4-B048-4697-9535-C3A6EDCA85B9}"
+	ProjectSection(SolutionItems) = preProject
+		global.json = global.json
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -57,10 +64,13 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{C7060639-719B-4BD2-8A37-2F146B5A0668} = {A9836F9E-6DB3-4D9F-ADCA-CF42D8C8BA93}
 		{FCCC4CB7-BAF7-4A57-9F89-E5766FE536C0} = {C40883CD-366D-4534-8B58-3EA0D13136DF}
+		{C7060639-719B-4BD2-8A37-2F146B5A0668} = {A9836F9E-6DB3-4D9F-ADCA-CF42D8C8BA93}
 		{8DA61DAC-FF7E-4CA1-93A0-6148DB66FD08} = {C40883CD-366D-4534-8B58-3EA0D13136DF}
 		{636CA76A-C85C-42E2-B4AA-88046279B3CA} = {A9836F9E-6DB3-4D9F-ADCA-CF42D8C8BA93}
 		{DECB05DF-B33A-44A0-B5DE-B14A8CE0740F} = {C40883CD-366D-4534-8B58-3EA0D13136DF}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {2A542E86-4A12-4997-B307-DEA9C7EE6539}
 	EndGlobalSection
 EndGlobal

--- a/Tools.sln
+++ b/Tools.sln
@@ -1,8 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.27016.1
+MinimumVisualStudioVersion = 15.0
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Web.FxCop", "tools\src\Microsoft.Web.FxCop\Microsoft.Web.FxCop.csproj", "{F439D4E6-3FAC-4C30-9585-6D258133A2BF}"
 EndProject
 Global
@@ -18,5 +18,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F8728741-0321-4EF6-9359-7DF2DCE6E99E}
 	EndGlobalSection
 EndGlobal

--- a/src/System.Net.Http.Formatting.NetCore/System.Net.Http.Formatting.NetCore.csproj
+++ b/src/System.Net.Http.Formatting.NetCore/System.Net.Http.Formatting.NetCore.csproj
@@ -16,7 +16,6 @@
     <DefineConstants>$(DefineConstants);NETFX_CORE;ASPNETMVC;NOT_CLS_COMPLIANT</DefineConstants>
     <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <NoWarn>1591</NoWarn>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>

--- a/src/System.Net.Http.Formatting.NetStandard/System.Net.Http.Formatting.NetStandard.csproj
+++ b/src/System.Net.Http.Formatting.NetStandard/System.Net.Http.Formatting.NetStandard.csproj
@@ -15,7 +15,6 @@
     <CodeAnalysisSearchGlobalAssemblyCache>false</CodeAnalysisSearchGlobalAssemblyCache>
     <DefineConstants>$(DefineConstants);NETFX_CORE;ASPNETMVC;NOT_CLS_COMPLIANT;NETSTANDARD1_1</DefineConstants>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <NoWarn>1591</NoWarn>
     <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
   </PropertyGroup>

--- a/src/WebApiHelpPage/WebApiHelpPageMsBuildTasks.targets
+++ b/src/WebApiHelpPage/WebApiHelpPageMsBuildTasks.targets
@@ -1,13 +1,5 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\tools\WebStack.tasks.targets"/>
-  <PropertyGroup>
-    <CodeTaskFactoryAssemblyFile Condition=" '$(CodeTaskFactoryAssemblyFile)' == '' And '$(MSBuildToolsVersion)' == '14.0' ">$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll</CodeTaskFactoryAssemblyFile>
-    <CodeTaskFactoryAssemblyFile Condition=" '$(CodeTaskFactoryAssemblyFile)' == '' And '$(MSBuildToolsVersion)' != '' ">$(MSBuildToolsPath)\Microsoft.Build.Tasks.v$(MSBuildToolsVersion).dll</CodeTaskFactoryAssemblyFile>
-    <CodeTaskFactoryAssemblyFile Condition=" '$(CodeTaskFactoryAssemblyFile)' == '' ">$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll</CodeTaskFactoryAssemblyFile>
-    <BuildTaskAssemblyReference Condition=" '$(BuildTaskAssemblyReference)' == '' And '$(MSBuildToolsVersion)' == '14.0' ">Microsoft.Build.Tasks.Core</BuildTaskAssemblyReference>
-    <BuildTaskAssemblyReference Condition=" '$(BuildTaskAssemblyReference)' == '' And '$(MSBuildToolsVersion)' != '' ">Microsoft.Build.Tasks.v$(MSBuildToolsVersion)</BuildTaskAssemblyReference>
-    <BuildTaskAssemblyReference Condition=" '$(BuildTaskAssemblyReference)' == '' ">Microsoft.Build.Tasks.v4.0</BuildTaskAssemblyReference>
-  </PropertyGroup>
   <UsingTask TaskName="NuGetPack" TaskFactory="CodeTaskFactory" AssemblyFile="$(CodeTaskFactoryAssemblyFile)">
     <ParameterGroup>
       <NuGetExe ParameterType="System.String" Required="true" />

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -1,0 +1,13 @@
+<Project>
+  <Import Project="..\Directory.Build.targets"/>
+  <Import Project="..\packages\**\xunit.runner.msbuild.props"/>
+
+  <Target Name="Test">
+    <ItemGroup Condition=" '@(TestAssembly)' == '' ">
+      <TestAssembly Include="$(TargetPath)"/>
+    </ItemGroup>
+
+    <!-- Override AppDomains default (set in xunit.runner.json). Need them with this runner. -->
+    <xunit AppDomains="true" Assemblies="@(TestAssembly)"/>
+  </Target>
+</Project>

--- a/test/System.Web.Mvc.Test/Html/Test/DefaultDisplayTemplatesTest.cs
+++ b/test/System.Web.Mvc.Test/Html/Test/DefaultDisplayTemplatesTest.cs
@@ -13,6 +13,7 @@ using Moq;
 
 namespace System.Web.Mvc.Html.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class DefaultDisplayTemplatesTest
     {
         // BooleanTemplate

--- a/test/System.Web.Mvc.Test/Test/AssociatedValidatorProviderTest.cs
+++ b/test/System.Web.Mvc.Test/Test/AssociatedValidatorProviderTest.cs
@@ -9,6 +9,7 @@ using Moq;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class AssociatedValidatorProviderTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/CompareAttributeAdapterTest.cs
+++ b/test/System.Web.Mvc.Test/Test/CompareAttributeAdapterTest.cs
@@ -9,6 +9,7 @@ using MyResources = System.Web.Properties.Resources;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class CompareAttributeAdapterTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/CompareAttributeTest.cs
+++ b/test/System.Web.Mvc.Test/Test/CompareAttributeTest.cs
@@ -8,6 +8,7 @@ using Moq;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class CompareAttributeTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/ControllerActionInvokerTest.cs
+++ b/test/System.Web.Mvc.Test/Test/ControllerActionInvokerTest.cs
@@ -18,6 +18,7 @@ using Moq;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class ControllerActionInvokerTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/DataAnnotationsModelValidatorProviderTest.cs
+++ b/test/System.Web.Mvc.Test/Test/DataAnnotationsModelValidatorProviderTest.cs
@@ -11,6 +11,7 @@ using DataAnnotationsCompareAttribute = System.ComponentModel.DataAnnotations.Co
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class DataAnnotationsModelValidatorProviderTest
     {
         // Validation attribute adapter registration

--- a/test/System.Web.Mvc.Test/Test/DataAnnotationsModelValidatorTest.cs
+++ b/test/System.Web.Mvc.Test/Test/DataAnnotationsModelValidatorTest.cs
@@ -10,6 +10,7 @@ using Moq.Protected;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class DataAnnotationsModelValidatorTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/DefaultModelBinderTest.cs
+++ b/test/System.Web.Mvc.Test/Test/DefaultModelBinderTest.cs
@@ -15,6 +15,7 @@ using Moq.Protected;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class DefaultModelBinderTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/MaxLengthAttributeAdapterTest.cs
+++ b/test/System.Web.Mvc.Test/Test/MaxLengthAttributeAdapterTest.cs
@@ -2,11 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using Microsoft.TestCommon;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class MaxLengthAttributeAdapterTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/MinLengthAttributeAdapterTest.cs
+++ b/test/System.Web.Mvc.Test/Test/MinLengthAttributeAdapterTest.cs
@@ -2,11 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using Microsoft.TestCommon;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class MinLengthAttributeAdapterTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/ModelBindingContextTest.cs
+++ b/test/System.Web.Mvc.Test/Test/ModelBindingContextTest.cs
@@ -7,6 +7,7 @@ using Microsoft.Web.UnitTestUtil;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class ModelBindingContextTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/ModelMetadataTest.cs
+++ b/test/System.Web.Mvc.Test/Test/ModelMetadataTest.cs
@@ -10,6 +10,7 @@ using Moq;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class ModelMetadataTest
     {
         // Guard clauses
@@ -826,7 +827,7 @@ namespace System.Web.Mvc.Test
                     Assert.Equal(derivedModel.GetType(), type);
                     Assert.Equal("MyProperty", propertyName);
                 })
-                .Returns<Func<object>, Type, string>((accessor, type, propertyName) => 
+                .Returns<Func<object>, Type, string>((accessor, type, propertyName) =>
                 {
                     return new ModelMetadata(provider.Object, derivedModel.GetType(), accessor, type, propertyName);
                 })

--- a/test/System.Web.Mvc.Test/Test/ModelValidatorTest.cs
+++ b/test/System.Web.Mvc.Test/Test/ModelValidatorTest.cs
@@ -8,6 +8,7 @@ using Microsoft.TestCommon;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class ModelValidatorTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/RangeAttributeAdapterTest.cs
+++ b/test/System.Web.Mvc.Test/Test/RangeAttributeAdapterTest.cs
@@ -7,6 +7,7 @@ using Microsoft.TestCommon;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class RangeAttributeAdapterTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/RegularExpressionAttributeAdapterTest.cs
+++ b/test/System.Web.Mvc.Test/Test/RegularExpressionAttributeAdapterTest.cs
@@ -7,6 +7,7 @@ using Microsoft.TestCommon;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class RegularExpressionAttributeAdapterTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/RemoteAttributeTest.cs
+++ b/test/System.Web.Mvc.Test/Test/RemoteAttributeTest.cs
@@ -9,6 +9,7 @@ using Moq;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class RemoteAttributeTest
     {
         // Good route name, bad route name
@@ -261,7 +262,7 @@ namespace System.Web.Mvc.Test
         [Fact]
         public void ActionController_InArea_RemoteFindsControllerInCurrentArea()
         {
-            // Arrange 
+            // Arrange
             ModelMetadata metadata = ModelMetadataProviders.Current.GetMetadataForProperty(modelAccessor: null,
                 containerType: typeof(string), propertyName: "Length");
             TestableRemoteAttribute attribute = new TestableRemoteAttribute("Action", "Controller");

--- a/test/System.Web.Mvc.Test/Test/RequiredAttributeAdapterTest.cs
+++ b/test/System.Web.Mvc.Test/Test/RequiredAttributeAdapterTest.cs
@@ -7,6 +7,7 @@ using Microsoft.TestCommon;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class RequiredAttributeAdapterTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/StringLengthAttributeAdapterTest.cs
+++ b/test/System.Web.Mvc.Test/Test/StringLengthAttributeAdapterTest.cs
@@ -7,6 +7,7 @@ using Microsoft.TestCommon;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class StringLengthAttributeAdapterTest
     {
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/ValidatableObjectAdapterTest.cs
+++ b/test/System.Web.Mvc.Test/Test/ValidatableObjectAdapterTest.cs
@@ -9,6 +9,7 @@ using Moq;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class ValidatableObjectAdapterTest
     {
         // IValidatableObject support

--- a/test/System.Web.Mvc.Test/Test/ViewDataDictionaryTest.cs
+++ b/test/System.Web.Mvc.Test/Test/ViewDataDictionaryTest.cs
@@ -9,6 +9,7 @@ using Microsoft.TestCommon;
 
 namespace System.Web.Mvc.Test
 {
+    [Xunit.Collection("Uses ScopeStorage or ViewEngines.Engines")] // Uses ModelMetadataProviders.Current
     public class ViewDataDictionaryTest
     {
         [Fact]

--- a/test/System.Web.WebPages.Test/Utils/CultureUtilTest.cs
+++ b/test/System.Web.WebPages.Test/Utils/CultureUtilTest.cs
@@ -13,11 +13,12 @@ namespace System.Web.WebPages.Test
     public class CultureUtilTest
     {
         [Fact]
+        [ReplaceCulture(Culture = "es-PR", UICulture = "es-PR")]
         public void SetAutoCultureWithNoUserLanguagesDoesNothing()
         {
             // Arrange
             var context = GetContextForSetCulture(null);
-            Thread thread = GetThread();
+            Thread thread = Thread.CurrentThread;
             CultureInfo culture = thread.CurrentCulture;
 
             // Act
@@ -28,11 +29,12 @@ namespace System.Web.WebPages.Test
         }
 
         [Fact]
+        [ReplaceCulture(Culture = "es-PR", UICulture = "es-PR")]
         public void SetAutoUICultureWithNoUserLanguagesDoesNothing()
         {
             // Arrange
             var context = GetContextForSetCulture(null);
-            Thread thread = GetThread();
+            Thread thread = Thread.CurrentThread;
             CultureInfo culture = thread.CurrentUICulture;
 
             // Act
@@ -43,11 +45,12 @@ namespace System.Web.WebPages.Test
         }
 
         [Fact]
+        [ReplaceCulture(Culture = "es-PR", UICulture = "es-PR")]
         public void SetAutoCultureWithEmptyUserLanguagesDoesNothing()
         {
             // Arrange
             var context = GetContextForSetCulture(Enumerable.Empty<string>());
-            Thread thread = GetThread();
+            Thread thread = Thread.CurrentThread;
             CultureInfo culture = thread.CurrentCulture;
 
             // Act
@@ -58,11 +61,12 @@ namespace System.Web.WebPages.Test
         }
 
         [Fact]
+        [ReplaceCulture(Culture = "es-PR", UICulture = "es-PR")]
         public void SetAutoUICultureWithEmptyUserLanguagesDoesNothing()
         {
             // Arrange
             var context = GetContextForSetCulture(Enumerable.Empty<string>());
-            Thread thread = GetThread();
+            Thread thread = Thread.CurrentThread;
             CultureInfo culture = thread.CurrentUICulture;
 
             // Act
@@ -73,11 +77,12 @@ namespace System.Web.WebPages.Test
         }
 
         [Fact]
+        [ReplaceCulture(Culture = "es-PR", UICulture = "es-PR")]
         public void SetAutoCultureWithBlankUserLanguagesDoesNothing()
         {
             // Arrange
             var context = GetContextForSetCulture(new[] { " " });
-            Thread thread = GetThread();
+            Thread thread = Thread.CurrentThread;
             CultureInfo culture = thread.CurrentCulture;
 
             // Act
@@ -88,11 +93,12 @@ namespace System.Web.WebPages.Test
         }
 
         [Fact]
+        [ReplaceCulture(Culture = "es-PR", UICulture = "es-PR")]
         public void SetAutoUICultureWithBlankUserLanguagesDoesNothing()
         {
             // Arrange
             var context = GetContextForSetCulture(new[] { " " });
-            Thread thread = GetThread();
+            Thread thread = Thread.CurrentThread;
             CultureInfo culture = thread.CurrentUICulture;
 
             // Act
@@ -103,12 +109,13 @@ namespace System.Web.WebPages.Test
         }
 
         [Fact]
+        [ReplaceCulture(Culture = "es-PR", UICulture = "es-PR")]
         public void SetAutoCultureWithInvalidLanguageDoesNothing()
         {
             // Arrange
             // "sans-culture" is an invalid culture name everywhere -- even on Windows 10.
             var context = GetContextForSetCulture(new[] { "sans-culture", "bb-BB", "cc-CC" });
-            Thread thread = GetThread();
+            Thread thread = Thread.CurrentThread;
             CultureInfo culture = thread.CurrentCulture;
 
             // Act
@@ -119,12 +126,13 @@ namespace System.Web.WebPages.Test
         }
 
         [Fact]
+        [ReplaceCulture(Culture = "es-PR", UICulture = "es-PR")]
         public void SetAutoUICultureWithInvalidLanguageDoesNothing()
         {
             // Arrange
             // "sans-culture" is an invalid culture name everywhere -- even on Windows 10.
             var context = GetContextForSetCulture(new[] { "sans-culture", "bb-BB", "cc-CC" });
-            Thread thread = GetThread();
+            Thread thread = Thread.CurrentThread;
             CultureInfo culture = thread.CurrentUICulture;
 
             // Act
@@ -135,11 +143,12 @@ namespace System.Web.WebPages.Test
         }
 
         [Fact]
+        [ReplaceCulture(Culture = "es-PR", UICulture = "es-PR")]
         public void SetAutoCultureDetectsUserLanguageCulture()
         {
             // Arrange
             var context = GetContextForSetCulture(new[] { "en-GB", "en-US", "ar-eg" });
-            Thread thread = GetThread();
+            Thread thread = Thread.CurrentThread;
 
             // Act
             CultureUtil.SetCulture(thread, context, "auto");
@@ -150,11 +159,12 @@ namespace System.Web.WebPages.Test
         }
 
         [Fact]
+        [ReplaceCulture(Culture = "es-PR", UICulture = "es-PR")]
         public void SetAutoUICultureDetectsUserLanguageCulture()
         {
             // Arrange
             var context = GetContextForSetCulture(new[] { "en-GB", "en-US", "ar-eg" });
-            Thread thread = GetThread();
+            Thread thread = Thread.CurrentThread;
 
             // Act
             CultureUtil.SetUICulture(thread, context, "auto");
@@ -165,11 +175,12 @@ namespace System.Web.WebPages.Test
         }
 
         [Fact]
+        [ReplaceCulture(Culture = "es-PR", UICulture = "es-PR")]
         public void SetAutoCultureUserLanguageWithQParameterCulture()
         {
             // Arrange
             var context = GetContextForSetCulture(new[] { "en-GB;q=0.3", "en-US", "ar-eg;q=0.5" });
-            Thread thread = GetThread();
+            Thread thread = Thread.CurrentThread;
 
             // Act
             CultureUtil.SetCulture(thread, context, "auto");
@@ -180,11 +191,12 @@ namespace System.Web.WebPages.Test
         }
 
         [Fact]
+        [ReplaceCulture(Culture = "es-PR", UICulture = "es-PR")]
         public void SetAutoUICultureDetectsUserLanguageWithQParameterCulture()
         {
             // Arrange
             var context = GetContextForSetCulture(new[] { "en-GB;q=0.3", "en-US", "ar-eg;q=0.5" });
-            Thread thread = GetThread();
+            Thread thread = Thread.CurrentThread;
 
             // Act
             CultureUtil.SetUICulture(thread, context, "auto");
@@ -195,33 +207,36 @@ namespace System.Web.WebPages.Test
         }
 
         [Fact]
+        [ReplaceCulture(Culture = "es-PR", UICulture = "es-PR")]
         public void SetCultureWithInvalidCultureThrows()
         {
             // Arrange
             var context = GetContextForSetCulture();
-            Thread thread = GetThread();
+            Thread thread = Thread.CurrentThread;
 
             // Act and Assert
             Assert.Throws<CultureNotFoundException>(() => CultureUtil.SetCulture(thread, context, "sans-culture"));
         }
 
         [Fact]
+        [ReplaceCulture(Culture = "es-PR", UICulture = "es-PR")]
         public void SetUICultureWithInvalidCultureThrows()
         {
             // Arrange
             var context = GetContextForSetCulture();
-            Thread thread = GetThread();
+            Thread thread = Thread.CurrentThread;
 
             // Act and Assert
             Assert.Throws<CultureNotFoundException>(() => CultureUtil.SetUICulture(thread, context, "sans-culture"));
         }
 
         [Fact]
+        [ReplaceCulture(Culture = "es-PR", UICulture = "es-PR")]
         public void SetCultureWithValidCulture()
         {
             // Arrange
             var context = GetContextForSetCulture();
-            Thread thread = GetThread();
+            Thread thread = Thread.CurrentThread;
 
             // Act
             CultureUtil.SetCulture(thread, context, "en-GB");
@@ -232,11 +247,12 @@ namespace System.Web.WebPages.Test
         }
 
         [Fact]
+        [ReplaceCulture(Culture = "es-PR", UICulture = "es-PR")]
         public void SetUICultureWithValidCulture()
         {
             // Arrange
             var context = GetContextForSetCulture();
-            Thread thread = GetThread();
+            Thread thread = Thread.CurrentThread;
 
             // Act
             CultureUtil.SetUICulture(thread, context, "en-GB");
@@ -244,11 +260,6 @@ namespace System.Web.WebPages.Test
             // Assert
             Assert.Equal(CultureInfo.GetCultureInfo("en-GB"), thread.CurrentUICulture);
             Assert.Equal("05/01/1979", new DateTime(1979, 1, 5).ToString("d", thread.CurrentUICulture));
-        }
-
-        private static Thread GetThread()
-        {
-            return new Thread(() => { });
         }
 
         private static HttpContextBase GetContextForSetCulture(IEnumerable<string> userLanguages = null)

--- a/tools/WebStack.settings.targets
+++ b/tools/WebStack.settings.targets
@@ -10,11 +10,11 @@
     <!-- Use CustomAfterMicrosoftCommonTargets property (defined in Microsoft.Common.targets) to
              inject post-Common targets files without requiring the inclusion -->
     <CustomAfterMicrosoftCommonTargets>$(WebStackToolsPath)WebStack.targets</CustomAfterMicrosoftCommonTargets>
-    
+
     <!-- Force rebuild if this file changes -->
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
-  
+
   <!-- Project Defaults -->
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -36,7 +36,7 @@
     <!-- Target 4.5 by default -->
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
 
-    <!-- Disable C# 6.0 features in Visual Studio since those features are not always available in command-line builds. -->
+    <!-- Disable C# 6.0 features in Visual Studio. -->
     <LangVersion Condition=" '$(MSBuildProjectExtension)' == '.csproj' ">5</LangVersion>
 
     <!-- Everything is delay signed by default -->

--- a/tools/WebStack.tasks.targets
+++ b/tools/WebStack.tasks.targets
@@ -1,7 +1,16 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BuildTaskAssemblyReference Condition=" '$(BuildTaskAssemblyReference)' == '' And Exists('$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll') ">Microsoft.Build.Tasks.Core</BuildTaskAssemblyReference>
+    <BuildTaskAssemblyReference Condition=" '$(BuildTaskAssemblyReference)' == '' And Exists('$(MSBuildToolsPath)\Microsoft.Build.Tasks.v$(MSBuildToolsVersion).dll') ">Microsoft.Build.Tasks.v$(MSBuildToolsVersion)</BuildTaskAssemblyReference>
+    <BuildTaskAssemblyReference Condition=" '$(BuildTaskAssemblyReference)' == '' And Exists('$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll') ">Microsoft.Build.Tasks.v4.0</BuildTaskAssemblyReference>
+    <!-- Know this file does not exist. But, error message will contain meaningful information. -->
+    <BuildTaskAssemblyReference Condition=" '$(BuildTaskAssemblyReference)' == '' ">Microsoft.Build.Tasks.Core</BuildTaskAssemblyReference>
+    <CodeTaskFactoryAssemblyFile Condition=" '$(CodeTaskFactoryAssemblyFile)' == '' ">$(MSBuildToolsPath)\$(BuildTaskAssemblyReference).dll</CodeTaskFactoryAssemblyFile>
+  </PropertyGroup>
+
   <!-- This task does not support concurrent execution from multiple project files. Its use is only appropriate when
         NuGet.exe is not in use. -->
-  <UsingTask TaskName="DownloadNuGet" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+  <UsingTask TaskName="DownloadNuGet" TaskFactory="CodeTaskFactory" AssemblyFile="$(CodeTaskFactoryAssemblyFile)">
     <ParameterGroup>
       <OutputFileName ParameterType="System.String" Required="true" />
       <MinimumVersion ParameterType="System.String" Required="true" />
@@ -82,7 +91,7 @@
     </Task>
   </UsingTask>
 
-  <UsingTask TaskName="RegexReplace" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+  <UsingTask TaskName="RegexReplace" TaskFactory="CodeTaskFactory" AssemblyFile="$(CodeTaskFactoryAssemblyFile)">
     <ParameterGroup>
       <Files ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
       <Find ParameterType="System.String" Required="true" />
@@ -134,7 +143,7 @@
     </Task>
   </UsingTask>
 
-  <UsingTask TaskName="PrintTestRunSummary" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+  <UsingTask TaskName="PrintTestRunSummary" TaskFactory="CodeTaskFactory" AssemblyFile="$(CodeTaskFactoryAssemblyFile)">
     <ParameterGroup>
       <TestResultsDirectory ParameterType="System.String" Required="true" />
     </ParameterGroup>

--- a/tools/WebStack.tasks.targets
+++ b/tools/WebStack.tasks.targets
@@ -26,24 +26,24 @@
       <Code Type="Fragment" Language="cs">
         <![CDATA[
                 Version minimumRequiredVersion;
-                
+
                 if (!Version.TryParse(MinimumVersion, out minimumRequiredVersion))
                 {
                     Log.LogError("MinimumVersion '{0}' is not a valid Version.", MinimumVersion);
                 }
-        
+
                 try
                 {
                     OutputFileName = Path.GetFullPath(OutputFileName);
-                    
+
                     if (File.Exists(OutputFileName))
                     {
                         // If NuGet.exe exists but is less than the minimum required version, delete it so that the
                         // latest version will be downloaded.
                         FileVersionInfo versionInfo = FileVersionInfo.GetVersionInfo(OutputFileName);
-                        
+
                         string toParse;
-                        
+
                         if (versionInfo != null && versionInfo.ProductVersion != null)
                         {
                             toParse = versionInfo.ProductVersion;
@@ -52,10 +52,10 @@
                         {
                             toParse = null;
                         }
-                        
+
                         Version current;
                         Version parsed;
-                        
+
                         if (toParse != null && Version.TryParse(toParse, out parsed))
                         {
                             current = parsed;
@@ -65,13 +65,13 @@
                             // Treat a missing or invalid version like V0.0 (which will trigger a delete and download).
                             current = new Version(0, 0);
                         }
-                        
+
                         if (current < minimumRequiredVersion)
                         {
                             File.Delete(OutputFileName);
                         }
                     }
-                    
+
                     if (!File.Exists(OutputFileName))
                     {
                         Log.LogMessage("Downloading latest version of NuGet.exe...");
@@ -187,7 +187,7 @@
 
                             if (failures > 0)
                             {
-                                foreach (XElement classWithFailure in assembly.Elements(XName.Get("class"))
+                                foreach (XElement classWithFailure in assembly.Elements(XName.Get("collection"))
                                     .Where(c => Int32.Parse(c.Attribute(XName.Get("failed")).Value) > 0))
                                 {
                                     foreach (XElement failure in classWithFailure.Elements(XName.Get("test"))

--- a/tools/WebStack.xunit.targets
+++ b/tools/WebStack.xunit.targets
@@ -3,15 +3,13 @@
 
     <!-- This is a separate MSBuild file so that we can survive upgrades of the xunit NuGet package
          and also still work with NuGet Package Restore. -->
-    <ItemGroup>
-        <XunitMsBuildRunner Include="..\packages\**\xunit.runner.msbuild.dll"/>
-    </ItemGroup>
-    <UsingTask TaskName="Xunit.Runner.MSBuild.xunit" AssemblyFile="@(XunitMsBuildRunner)"/>
+    <Import Project="..\packages\**\xunit.runner.msbuild.props"/>
 
     <Target Name="Xunit">
         <!-- Override AppDomains default (set in xunit.runner.json). Need them with this runner. -->
-        <xunit AppDomains="true" Assemblies="$(TestAssembly)" XmlV1="$(XmlPath)"/>
-        <!-- Replace potentially illegal escaped characters (if they get through validations done during Save) -->
+        <xunit AppDomains="true" Assemblies="$(TestAssembly)" Xml="$(XmlPath)"/>
+
+        <!-- Replace potentially illegal escaped characters (if they get through validations done during Save). -->
         <RegexReplace
             Files="$(XmlPath)"
             Find="&amp;#x(?&lt;char&gt;[0-9A-Fa-f]+);"

--- a/tools/src/Microsoft.Web.FxCop/Microsoft.Web.FxCop.csproj
+++ b/tools/src/Microsoft.Web.FxCop/Microsoft.Web.FxCop.csproj
@@ -31,7 +31,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <FxCopLocation>$(MSBuildExtensionsPath)\..\Team Tools\Static Analysis Tools\FxCop\</FxCopLocation>
+    <FxCopLocation>$(VsInstallRoot)\Team Tools\Static Analysis Tools\FxCop\</FxCopLocation>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FxCopSdk">

--- a/tools/src/Microsoft.Web.FxCop/Microsoft.Web.FxCop.csproj
+++ b/tools/src/Microsoft.Web.FxCop/Microsoft.Web.FxCop.csproj
@@ -31,7 +31,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <FxCopLocation>$(MSBuildProgramFiles32)\Microsoft Visual Studio $(VisualStudioVersion)\Team Tools\Static Analysis Tools\FxCop\</FxCopLocation>
+    <FxCopLocation>$(MSBuildExtensionsPath)\..\Team Tools\Static Analysis Tools\FxCop\</FxCopLocation>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="FxCopSdk">


### PR DESCRIPTION
- move to MSBuild v15.0
- use only VS 2017 or later
- move to latest version of the xUnit MSBuild runner

See descriptions of individual commits for details.