### PR TITLE
Added FormUrlEncodedMediaTypeFormatter to .NetStandard version of System.Net.Http.Formatting

### DIFF
--- a/src/System.Net.Http.Formatting.NetCore/System.Net.Http.Formatting.NetCore.csproj
+++ b/src/System.Net.Http.Formatting.NetCore/System.Net.Http.Formatting.NetCore.csproj
@@ -60,6 +60,9 @@
     <Compile Include="..\System.Net.Http.Formatting\Formatting\FormUrlEncodedJson.cs">
       <Link>Formatting\FormUrlEncodedJson.cs</Link>
     </Compile>
+    <Compile Include="..\System.Net.Http.Formatting\Formatting\FormUrlEncodedMediaTypeFormatter.cs">
+      <Link>Formatting\FormUrlEncodedMediaTypeFormatter.cs</Link>
+    </Compile>
     <Compile Include="..\System.Net.Http.Formatting\Formatting\IFormatterLogger.cs">
       <Link>Formatting\IFormatterLogger.cs</Link>
     </Compile>
@@ -116,6 +119,9 @@
     </Compile>
     <Compile Include="..\System.Net.Http.Formatting\Formatting\XmlMediaTypeFormatter.cs">
       <Link>Formatting\XmlMediaTypeFormatter.cs</Link>
+    </Compile>
+    <Compile Include="..\System.Net.Http.Formatting\HttpContentFormDataExtensions.cs">
+      <Link>HttpContentFormDataExtensions.cs</Link>
     </Compile>
     <Compile Include="..\System.Net.Http.Formatting\Internal\HttpValueCollection.cs">
       <Link>HttpValueCollection.cs</Link>

--- a/src/System.Net.Http.Formatting.NetStandard/System.Net.Http.Formatting.NetStandard.csproj
+++ b/src/System.Net.Http.Formatting.NetStandard/System.Net.Http.Formatting.NetStandard.csproj
@@ -59,6 +59,9 @@
     <Compile Include="..\System.Net.Http.Formatting\Formatting\FormUrlEncodedJson.cs">
       <Link>Formatting\FormUrlEncodedJson.cs</Link>
     </Compile>
+    <Compile Include="..\System.Net.Http.Formatting\Formatting\FormUrlEncodedMediaTypeFormatter.cs">
+      <Link>Formatting\FormUrlEncodedMediaTypeFormatter.cs</Link>
+    </Compile>
     <Compile Include="..\System.Net.Http.Formatting\Formatting\IFormatterLogger.cs">
       <Link>Formatting\IFormatterLogger.cs</Link>
     </Compile>
@@ -115,6 +118,9 @@
     </Compile>
     <Compile Include="..\System.Net.Http.Formatting\Formatting\XmlMediaTypeFormatter.cs">
       <Link>Formatting\XmlMediaTypeFormatter.cs</Link>
+    </Compile>
+    <Compile Include="..\System.Net.Http.Formatting\HttpContentFormDataExtensions.cs">
+      <Link>HttpContentFormDataExtensions.cs</Link>
     </Compile>
     <Compile Include="..\System.Net.Http.Formatting\Internal\HttpValueCollection.cs">
       <Link>Internal\HttpValueCollection.cs</Link>

--- a/src/System.Net.Http.Formatting/Formatting/MediaTypeFormatterCollection.cs
+++ b/src/System.Net.Http.Formatting/Formatting/MediaTypeFormatterCollection.cs
@@ -59,7 +59,6 @@ namespace System.Net.Http.Formatting
             get { return Items.OfType<JsonMediaTypeFormatter>().FirstOrDefault(); }
         }
 
-#if !NETFX_CORE // FormUrlEncodedMediaTypeFormatter is not supported in portable library.
         /// <summary>
         /// Gets the <see cref="MediaTypeFormatter"/> to use for <c>application/x-www-form-urlencoded</c> data.
         /// </summary>
@@ -67,7 +66,6 @@ namespace System.Net.Http.Formatting
         {
             get { return Items.OfType<FormUrlEncodedMediaTypeFormatter>().FirstOrDefault(); }
         }
-#endif
 
         internal MediaTypeFormatter[] WritingFormatters
         {
@@ -202,8 +200,8 @@ namespace System.Net.Http.Formatting
             return
 #if !NETFX_CORE
                 typeof(XmlNode).IsAssignableFrom(type) ||
-                typeof(FormDataCollection).IsAssignableFrom(type) ||
 #endif
+                typeof(FormDataCollection).IsAssignableFrom(type) ||
                 FormattingUtilities.IsJTokenType(type) ||
                 typeof(XObject).IsAssignableFrom(type) ||
                 typeof(Type).IsAssignableFrom(type) ||
@@ -260,9 +258,7 @@ namespace System.Net.Http.Formatting
             {
                 new JsonMediaTypeFormatter(),
                 new XmlMediaTypeFormatter(),
-#if !NETFX_CORE
                 new FormUrlEncodedMediaTypeFormatter()
-#endif
             };
         }
 

--- a/src/System.Net.Http.Formatting/HttpContentFormDataExtensions.cs
+++ b/src/System.Net.Http.Formatting/HttpContentFormDataExtensions.cs
@@ -8,6 +8,9 @@ using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Http;
+#if NETFX_CORE
+using NameValueCollection = System.Net.Http.Formatting.HttpValueCollection;
+#endif
 
 namespace System.Net.Http
 {

--- a/test/System.Net.Http.Formatting.NetCore.Test/System.Net.Http.Formatting.NetCore.Test.csproj
+++ b/test/System.Net.Http.Formatting.NetCore.Test/System.Net.Http.Formatting.NetCore.Test.csproj
@@ -60,14 +60,26 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\System.Net.Http.Formatting.Test\DataSets\Types\DerivedFormUrlEncodedMediaTypeFormatter.cs">
+      <Link>DataSets\Types\DerivedFormUrlEncodedMediaTypeFormatter.cs</Link>
+    </Compile>
     <Compile Include="..\System.Net.Http.Formatting.Test\Formatting\BsonMediaTypeFormatterTests.cs">
       <Link>Formatting\BsonMediaTypeFormatterTests.cs</Link>
     </Compile>
     <Compile Include="..\System.Net.Http.Formatting.Test\Formatting\FormDataCollectionTests.cs">
       <Link>Internal\FormDataCollectionTests.cs</Link>
     </Compile>
+    <Compile Include="..\System.Net.Http.Formatting.Test\Formatting\FormUrlEncodedFromContentTests.cs">
+      <Link>Formatting\FormUrlEncodedFromContentTests.cs</Link>
+    </Compile>
+    <Compile Include="..\System.Net.Http.Formatting.Test\Formatting\FormUrlEncodedFromUriQueryTests.cs">
+      <Link>Formatting\FormUrlEncodedFromUriQueryTests.cs</Link>
+    </Compile>
     <Compile Include="..\System.Net.Http.Formatting.Test\Formatting\FormUrlEncodedJsonTests.cs">
       <Link>Internal\FormUrlEncodedJsonTests.cs</Link>
+    </Compile>
+    <Compile Include="..\System.Net.Http.Formatting.Test\Formatting\FormUrlEncodedMediaTypeFormatterTests.cs">
+      <Link>Formatting\FormUrlEncodedMediaTypeFormatterTests.cs</Link>
     </Compile>
     <Compile Include="..\System.Net.Http.Formatting.Test\Formatting\JsonNetSerializationTest.cs">
       <Link>Formatting\JsonNetSerializationTest.cs</Link>
@@ -77,6 +89,9 @@
     </Compile>
     <Compile Include="..\System.Net.Http.Formatting.Test\Formatting\Parsers\FormUrlEncodedParserTests.cs">
       <Link>Internal\FormUrlEncodedParserTests.cs</Link>
+    </Compile>
+    <Compile Include="..\System.Net.Http.Formatting.Test\HttpContentFormDataExtensionsTest.cs">
+      <Link>HttpContentFormDataExtensionsTest.cs</Link>
     </Compile>
     <Compile Include="..\System.Net.Http.Formatting.Test\Internal\HttpValueCollectionTest.cs">
       <Link>HttpValueCollectionTest.cs</Link>

--- a/test/System.Net.Http.Formatting.NetStandard.Test/System.Net.Http.Formatting.NetStandard.Test.csproj
+++ b/test/System.Net.Http.Formatting.NetStandard.Test/System.Net.Http.Formatting.NetStandard.Test.csproj
@@ -53,14 +53,26 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\System.Net.Http.Formatting.Test\DataSets\Types\DerivedFormUrlEncodedMediaTypeFormatter.cs">
+      <Link>DataSets\Types\DerivedFormUrlEncodedMediaTypeFormatter.cs</Link>
+    </Compile>
     <Compile Include="..\System.Net.Http.Formatting.Test\Formatting\BsonMediaTypeFormatterTests.cs">
       <Link>Formatting\BsonMediaTypeFormatterTests.cs</Link>
     </Compile>
     <Compile Include="..\System.Net.Http.Formatting.Test\Formatting\FormDataCollectionTests.cs">
       <Link>Internal\FormDataCollectionTests.cs</Link>
     </Compile>
+    <Compile Include="..\System.Net.Http.Formatting.Test\Formatting\FormUrlEncodedFromContentTests.cs">
+      <Link>Formatting\FormUrlEncodedFromContentTests.cs</Link>
+    </Compile>
+    <Compile Include="..\System.Net.Http.Formatting.Test\Formatting\FormUrlEncodedFromUriQueryTests.cs">
+      <Link>Formatting\FormUrlEncodedFromUriQueryTests.cs</Link>
+    </Compile>
     <Compile Include="..\System.Net.Http.Formatting.Test\Formatting\FormUrlEncodedJsonTests.cs">
       <Link>Internal\FormUrlEncodedJsonTests.cs</Link>
+    </Compile>
+    <Compile Include="..\System.Net.Http.Formatting.Test\Formatting\FormUrlEncodedMediaTypeFormatterTests.cs">
+      <Link>Formatting\FormUrlEncodedMediaTypeFormatterTests.cs</Link>
     </Compile>
     <Compile Include="..\System.Net.Http.Formatting.Test\Formatting\JsonNetSerializationTest.cs">
       <Link>Formatting\JsonNetSerializationTest.cs</Link>
@@ -70,6 +82,9 @@
     </Compile>
     <Compile Include="..\System.Net.Http.Formatting.Test\Formatting\Parsers\FormUrlEncodedParserTests.cs">
       <Link>Internal\FormUrlEncodedParserTests.cs</Link>
+    </Compile>
+    <Compile Include="..\System.Net.Http.Formatting.Test\HttpContentFormDataExtensionsTest.cs">
+      <Link>HttpContentFormDataExtensionsTest.cs</Link>
     </Compile>
     <Compile Include="..\System.Net.Http.Formatting.Test\Internal\HttpValueCollectionTest.cs">
       <Link>HttpValueCollectionTest.cs</Link>

--- a/test/System.Net.Http.Formatting.Test/DataSets/HttpTestData.cs
+++ b/test/System.Net.Http.Formatting.Test/DataSets/HttpTestData.cs
@@ -498,9 +498,7 @@ namespace System.Net.Http.Formatting.DataSets
                 {
                     new XmlMediaTypeFormatter(),
                     new JsonMediaTypeFormatter(),
-#if !NETFX_CORE // not present in portable library version
                     new FormUrlEncodedMediaTypeFormatter()
-#endif
                 });
             }
         }
@@ -521,9 +519,7 @@ namespace System.Net.Http.Formatting.DataSets
                 {
                     new DerivedXmlMediaTypeFormatter(),
                     new DerivedJsonMediaTypeFormatter(),
-#if !NETFX_CORE // not present in portable library version
                     new DerivedFormUrlEncodedMediaTypeFormatter(),
-#endif
                 });
             }
         }

--- a/test/System.Net.Http.Formatting.Test/Formatting/MediaTypeFormatterCollectionTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/MediaTypeFormatterCollectionTests.cs
@@ -27,16 +27,11 @@ namespace System.Net.Http.Formatting
         public void Constructor()
         {
             MediaTypeFormatterCollection collection = new MediaTypeFormatterCollection();
-#if !NETFX_CORE // No FormUrlEncodedMediaTypeFormatter in portable library version
+
             Assert.Equal(3, collection.Count);
-#else
-            Assert.Equal(2, collection.Count);
-#endif
             Assert.NotNull(collection.XmlFormatter);
             Assert.NotNull(collection.JsonFormatter);
-#if !NETFX_CORE // No FormUrlEncodedMediaTypeFormatter in portable library version
             Assert.NotNull(collection.FormUrlEncodedFormatter);
-#endif
         }
 
         [Fact]
@@ -101,14 +96,11 @@ namespace System.Net.Http.Formatting
             {
                 new XmlMediaTypeFormatter(),
                 new JsonMediaTypeFormatter(),
-#if !NETFX_CORE // No FormUrlEncodedMediaTypeFormatter in portable library version
                 new FormUrlEncodedMediaTypeFormatter(),
-#endif
+
                 new XmlMediaTypeFormatter(),
                 new JsonMediaTypeFormatter(),
-#if !NETFX_CORE // No FormUrlEncodedMediaTypeFormatter in portable library version
                 new FormUrlEncodedMediaTypeFormatter(),
-#endif
             };
 
             MediaTypeFormatterCollection collection = new MediaTypeFormatterCollection(formatters);
@@ -185,7 +177,6 @@ namespace System.Net.Http.Formatting
             Assert.Null(collection.JsonFormatter);
         }
 
-#if !NETFX_CORE // No FormUrlEncodedMediaTypeFormatter in portable library version
         [Fact]
         public void FormUrlEncodedFormatter_SetByCtor()
         {
@@ -200,8 +191,7 @@ namespace System.Net.Http.Formatting
             MediaTypeFormatterCollection collection = new MediaTypeFormatterCollection(new MediaTypeFormatter[0]);
             Assert.Null(collection.FormUrlEncodedFormatter);
         }
-#endif
-
+        
         [Fact]
         public void Remove_SetsXmlFormatter()
         {
@@ -371,8 +361,8 @@ namespace System.Net.Http.Formatting
         [InlineData(typeof(byte[]))]
 #if !NETFX_CORE
         [InlineData(typeof(XmlElement))]
-        [InlineData(typeof(FormDataCollection))]
 #endif
+        [InlineData(typeof(FormDataCollection))]
         public void IsTypeExcludedFromValidation_ReturnsTrueForExcludedTypes(Type type)
         {
             Assert.True(MediaTypeFormatterCollection.IsTypeExcludedFromValidation(type));


### PR DESCRIPTION
FYI only. Just doing CI builds and double-checking a small change on top of what @YakhontovYaroslav did (thanks @YakhontovYaroslav!) in #76.