### PR TITLE
Make `PrintTestRunSummary` task more resilient

### DIFF
--- a/Runtime.msbuild
+++ b/Runtime.msbuild
@@ -68,15 +68,15 @@
     <Exec Command='"$(NuGetExe)" restore "%(SolutionsToBuild.Identity)" -PackagesDirectory packages -NonInteractive -Verbosity quiet -ConfigFile "$(MsBuildThisFileDirectory)\.nuget\NuGet.Config"' />
     <!-- Pick the right Microsoft.Web.FxCop package to use and copy it to a standard location. -->
   </Target>
-  
+
   <Target Name="BuildTools">
     <PropertyGroup>
         <FxCopProjectLocation>$(MsBuildThisFileDirectory)tools\src\Microsoft.Web.FxCop\</FxCopProjectLocation>
         <CustomFxCopRulesPath>$(MsBuildThisFileDirectory)packages\CustomFxCopRules</CustomFxCopRulesPath>
     </PropertyGroup>
-    <MsBuild 
+    <MsBuild
           Condition=" '$(CodeAnalysis)' == 'true' "
-          Projects="$(FxCopProjectLocation)\Microsoft.Web.FxCop.csproj" 
+          Projects="$(FxCopProjectLocation)\Microsoft.Web.FxCop.csproj"
           Properties="Configuration=Release;OutputPath=$(CustomFxCopRulesPath)" />
   </Target>
 
@@ -98,17 +98,20 @@
 
   <Target Name="RunTests" DependsOnTargets="CheckSkipStrongNames">
     <ItemGroup>
-      <TestDLLsXunit Include="bin\$(Configuration)\test\*.Test.dll;bin\$(Configuration)\test\*.Test.*.dll;bin\$(Configuration)\Test\NetCore\*.Test.dll;bin\$(Configuration)\Test\NetStandard\*.Test.dll" />
-      <XunitProject Include="tools\WebStack.xunit.targets">
-        <Properties>TestAssembly=%(TestDLLsXunit.FullPath);XmlPath=$(TestResultsDirectory)%(TestDLLsXunit.FileName)-XunitResults.xml</Properties>
-      </XunitProject>
+      <_TestDLLsXunit Include="bin\$(Configuration)\test\*.Test.dll" />
+      <_TestDLLsXunit Include="bin\$(Configuration)\test\*.Test.*.dll" />
+      <_TestDLLsXunit Include="bin\$(Configuration)\Test\NetCore\*.Test.dll" />
+      <_TestDLLsXunit Include="bin\$(Configuration)\Test\NetStandard\*.Test.dll" />
+      <_XunitProject Include="tools\WebStack.xunit.targets">
+        <Properties>TestAssembly=%(_TestDLLsXunit.FullPath);XmlPath=$(TestResultsDirectory)%(_TestDLLsXunit.FileName)-XunitResults.xml</Properties>
+      </_XunitProject>
     </ItemGroup>
 
-    <!-- Re-create the test results directory so that print summary doesn't run on old test results -->
+    <!-- Recreate the test results directory so that print summary doesn't run on old test results. -->
     <RemoveDir Directories="$(TestResultsDirectory)" />
     <MakeDir Directories="$(TestResultsDirectory)" />
 
-    <MSBuild Projects="@(XunitProject)" BuildInParallel="$(TestInParallel)" Targets="Xunit" />
+    <MSBuild Projects="@(_XunitProject)" BuildInParallel="$(TestInParallel)" Targets="Xunit" />
   </Target>
 
   <Target Name="CheckSkipStrongNames" DependsOnTargets="RestoreSkipStrongNames">

--- a/tools/WebStack.tasks.targets
+++ b/tools/WebStack.tasks.targets
@@ -178,10 +178,23 @@
                         var assemblies = xml.Elements(XName.Get("assembly"));
                         foreach (XElement assembly in assemblies)
                         {
-                            int failures = Int32.Parse(assembly.Attribute(XName.Get("failed")).Value);
+                            XAttribute failed = assembly.Attribute(XName.Get("failed"));
+                            if (failed == null)
+                            {
+                                // Occasionally xUnit does not write information about test assembly completion.
+                                XAttribute name = assembly.Attribute(XName.Get("name"));
+                                Log.LogWarning(
+                                    "No results in {0} for {1}.",
+                                    testResultFile,
+                                    name == null ? "unknown assembly" : name.Value);
+
+                                continue;
+                            }
+
+                            int failures = Int32.Parse(failed.Value);
+                            testsFailed += failures;
 
                             testsPassed += Int32.Parse(assembly.Attribute(XName.Get("passed")).Value);
-                            testsFailed += failures;
                             testsSkipped += Int32.Parse(assembly.Attribute(XName.Get("skipped")).Value);
                             timeSpent += Decimal.Parse(assembly.Attribute(XName.Get("time")).Value);
 


### PR DESCRIPTION
- handle the nearly-empty `<assembly/>` elements xUnit sometimes writes to the results file

nit:
- use leading-underscore convention for private items in the `RunTests` target
- make `@(_TestDLLsXunit)` items a bit easier to read