### PR TITLE
Add xUnit analyzers and take fixer suggestions (1 of 5): Common to System.Web.Cors.Test

### DIFF
--- a/test/Common/AttributeListTest.cs
+++ b/test/Common/AttributeListTest.cs
@@ -54,14 +54,14 @@ namespace System.ComponentModel
         public void AttributeListContainsWrappedTrue()
         {
             Attribute presentAttribute = _collection[2];
-            Assert.True(_list.Contains(presentAttribute));
+            Assert.Contains(presentAttribute, _list);
         }
 
         [Fact]
         public void AttributeListContainsMissingFalse()
         {
             Attribute missingAttribute = new MissingAttribute();
-            Assert.False(_list.Contains(missingAttribute));
+            Assert.DoesNotContain(missingAttribute, _list);
         }
 
         [Fact]

--- a/test/Common/CollectionExtensionsTest.cs
+++ b/test/Common/CollectionExtensionsTest.cs
@@ -16,8 +16,8 @@ namespace System.Collections.Generic
 
             string[] emptyAppended = empty.AppendAndReallocate("AppendedEmpty");
 
-            Assert.Equal(1, emptyAppended.Length);
-            Assert.Equal("AppendedEmpty", emptyAppended[0]);
+            string singleAppended = Assert.Single(emptyAppended);
+            Assert.Equal("AppendedEmpty", singleAppended);
         }
 
         [Fact]
@@ -107,7 +107,7 @@ namespace System.Collections.Generic
             Assert.Equal(expected, enumerableAsIList);
             Assert.NotSame(expected, enumerableAsIList);
         }
-        
+
         [Fact]
         public void AsList_List_ReturnsSameInstance()
         {
@@ -131,6 +131,7 @@ namespace System.Collections.Generic
             Assert.NotSame(array, arrayAsList);
         }
 
+        [Fact]
         public void AsList_ListWrapperCollection_ReturnsSameInstance()
         {
             List<object> list = new List<object> { new object(), new object() };
@@ -270,7 +271,7 @@ namespace System.Collections.Generic
             Assert.Equal(hasNulls[2], hasNullsResult[1]);
         }
 
-        [Fact] 
+        [Fact]
         public void ToDictionaryFastArray2Element()
         {
             string[] input = new string[] {"AA", "BB"};
@@ -283,7 +284,7 @@ namespace System.Collections.Generic
             Assert.Equal(StringComparer.OrdinalIgnoreCase, result.Comparer);
         }
 
-        [Fact] 
+        [Fact]
         public void ToDictionaryFastIListList2Element()
         {
             string[] input = new string[] {"AA", "BB"};
@@ -311,7 +312,7 @@ namespace System.Collections.Generic
             Assert.Equal(StringComparer.OrdinalIgnoreCase, arrayResult.Comparer);
         }
 
-        [Fact] 
+        [Fact]
         public void ToDictionaryFastIEnumerableArray2Element()
         {
             string[] input = new string[] {"AA", "BB"};

--- a/test/Common/Routing/DefaultInlineConstraintResolverTest.cs
+++ b/test/Common/Routing/DefaultInlineConstraintResolverTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 #if ASPNETWEBAPI
 using System.Web.Http.Routing.Constraints;
 #else
@@ -104,8 +103,8 @@ namespace System.Web.Mvc.Routing
         {
             var constraint = new DefaultInlineConstraintResolver().ResolveConstraint("length(5)");
 
-            Assert.IsType<LengthRouteConstraint>(constraint);
-            Assert.Equal(5, ((LengthRouteConstraint)constraint).Length);
+            var lengthRouteConstraint = Assert.IsType<LengthRouteConstraint>(constraint);
+            Assert.Equal(5, lengthRouteConstraint.Length);
         }
 
         [Fact]
@@ -113,8 +112,7 @@ namespace System.Web.Mvc.Routing
         {
             var constraint = new DefaultInlineConstraintResolver().ResolveConstraint("length(5, 10)");
 
-            Assert.IsType<LengthRouteConstraint>(constraint);
-            LengthRouteConstraint lengthConstraint = (LengthRouteConstraint)constraint;
+            LengthRouteConstraint lengthConstraint = Assert.IsType<LengthRouteConstraint>(constraint);
             Assert.Equal(5, lengthConstraint.MinLength);
             Assert.Equal(10, lengthConstraint.MaxLength);
         }
@@ -132,8 +130,8 @@ namespace System.Web.Mvc.Routing
         {
             var constraint = new DefaultInlineConstraintResolver().ResolveConstraint("max(10)");
 
-            Assert.IsType<MaxRouteConstraint>(constraint);
-            Assert.Equal(10, ((MaxRouteConstraint)constraint).Max);
+            var maxRouteConstraint = Assert.IsType<MaxRouteConstraint>(constraint);
+            Assert.Equal(10, maxRouteConstraint.Max);
         }
 
         [Fact]
@@ -141,8 +139,8 @@ namespace System.Web.Mvc.Routing
         {
             var constraint = new DefaultInlineConstraintResolver().ResolveConstraint("maxlength(10)");
 
-            Assert.IsType<MaxLengthRouteConstraint>(constraint);
-            Assert.Equal(10, ((MaxLengthRouteConstraint)constraint).MaxLength);
+            var maxLengthRouteConstraint = Assert.IsType<MaxLengthRouteConstraint>(constraint);
+            Assert.Equal(10, maxLengthRouteConstraint.MaxLength);
         }
 
         [Fact]
@@ -150,8 +148,8 @@ namespace System.Web.Mvc.Routing
         {
             var constraint = new DefaultInlineConstraintResolver().ResolveConstraint("min(3)");
 
-            Assert.IsType<MinRouteConstraint>(constraint);
-            Assert.Equal(3, ((MinRouteConstraint)constraint).Min);
+            var minRouteConstraint = Assert.IsType<MinRouteConstraint>(constraint);
+            Assert.Equal(3, minRouteConstraint.Min);
         }
 
         [Fact]
@@ -159,8 +157,8 @@ namespace System.Web.Mvc.Routing
         {
             var constraint = new DefaultInlineConstraintResolver().ResolveConstraint("minlength(3)");
 
-            Assert.IsType<MinLengthRouteConstraint>(constraint);
-            Assert.Equal(3, ((MinLengthRouteConstraint)constraint).MinLength);
+            var minLengthRouteConstraint = Assert.IsType<MinLengthRouteConstraint>(constraint);
+            Assert.Equal(3, minLengthRouteConstraint.MinLength);
         }
 
         [Fact]
@@ -174,8 +172,7 @@ namespace System.Web.Mvc.Routing
         {
             var constraint = new DefaultInlineConstraintResolver().ResolveConstraint("range(5, 10)");
 
-            Assert.IsType<RangeRouteConstraint>(constraint);
-            RangeRouteConstraint rangeConstraint = (RangeRouteConstraint)constraint;
+            RangeRouteConstraint rangeConstraint = Assert.IsType<RangeRouteConstraint>(constraint);
             Assert.Equal(5, rangeConstraint.Min);
             Assert.Equal(10, rangeConstraint.Max);
         }
@@ -185,8 +182,7 @@ namespace System.Web.Mvc.Routing
         {
             var constraint = new DefaultInlineConstraintResolver().ResolveConstraint("regex(abc,defg)");
 
-            Assert.IsType<RegexRouteConstraint>(constraint);
-            RegexRouteConstraint regexConstraint = (RegexRouteConstraint)constraint;
+            RegexRouteConstraint regexConstraint = Assert.IsType<RegexRouteConstraint>(constraint);
             Assert.Equal("abc,defg", regexConstraint.Pattern);
         }
 

--- a/test/Common/Routing/InlineRouteTemplateParserTests.cs
+++ b/test/Common/Routing/InlineRouteTemplateParserTests.cs
@@ -41,8 +41,8 @@ namespace System.Web.Mvc.Routing
 
             Assert.Equal("hello/{param}", result.RouteUrl);
             Assert.Equal("111111", result.Defaults["param"]);
-            Assert.IsType<RegexRouteConstraint>(result.Constraints["param"]);
-            Assert.Equal(@"\d+", ((RegexRouteConstraint)result.Constraints["param"]).Pattern);
+            var regexRouteConstraint = Assert.IsType<RegexRouteConstraint>(result.Constraints["param"]);
+            Assert.Equal(@"\d+", regexRouteConstraint.Pattern);
         }
 
         [Fact]
@@ -54,8 +54,7 @@ namespace System.Web.Mvc.Routing
 
             Assert.Equal(OptionalParameter, result.Defaults["param"]);
 
-            Assert.IsType<OptionalRouteConstraint>(result.Constraints["param"]);
-            var constraint = (OptionalRouteConstraint)result.Constraints["param"];
+            var constraint = Assert.IsType<OptionalRouteConstraint>(result.Constraints["param"]);
             Assert.IsType<IntRouteConstraint>(constraint.InnerConstraint);
         }
 
@@ -68,9 +67,8 @@ namespace System.Web.Mvc.Routing
 
             Assert.Equal(OptionalParameter, result.Defaults["param"]);
 
-            Assert.IsType<OptionalRouteConstraint>(result.Constraints["param"]);
-            var constraint = (OptionalRouteConstraint)result.Constraints["param"];
-            Assert.Equal(@"\d+", ((RegexRouteConstraint)constraint.InnerConstraint).Pattern);
+            var constraint = Assert.IsType<OptionalRouteConstraint>(result.Constraints["param"]);
+            Assert.Equal(@"\d+", Assert.IsType<RegexRouteConstraint>(constraint.InnerConstraint).Pattern);
         }
 
         [Fact]
@@ -80,10 +78,9 @@ namespace System.Web.Mvc.Routing
 
             Assert.Equal("hello/{param}", result.RouteUrl);
 
-            Assert.IsType<CompoundRouteConstraint>(result.Constraints["param"]);
-            CompoundRouteConstraint constraint = (CompoundRouteConstraint)result.Constraints["param"];
-            Assert.Equal(@"\d+", ((RegexRouteConstraint)constraint.Constraints.ElementAt(0)).Pattern);
-            Assert.Equal(@"\w+", ((RegexRouteConstraint)constraint.Constraints.ElementAt(1)).Pattern);
+            CompoundRouteConstraint constraint = Assert.IsType<CompoundRouteConstraint>(result.Constraints["param"]);
+            Assert.Equal(@"\d+", Assert.IsType<RegexRouteConstraint>(constraint.Constraints.ElementAt(0)).Pattern);
+            Assert.Equal(@"\w+", Assert.IsType<RegexRouteConstraint>(constraint.Constraints.ElementAt(1)).Pattern);
         }
 
         [Fact]
@@ -93,8 +90,8 @@ namespace System.Web.Mvc.Routing
 
             Assert.Equal("hello/{param}", result.RouteUrl);
 
-            Assert.IsType<RegexRouteConstraint>(result.Constraints["param"]);
-            Assert.Equal(@"\d+", ((RegexRouteConstraint)result.Constraints["param"]).Pattern);
+            var constraint = Assert.IsType<RegexRouteConstraint>(result.Constraints["param"]);
+            Assert.Equal(@"\d+", constraint.Pattern);
         }
 
         [Fact]
@@ -108,8 +105,7 @@ namespace System.Web.Mvc.Routing
             Assert.Equal("abc", result.Defaults["p2"]);
             Assert.Equal(OptionalParameter, result.Defaults["p3"]);
 
-            Assert.IsType<CompoundRouteConstraint>(result.Constraints["p1"]);
-            CompoundRouteConstraint constraint = (CompoundRouteConstraint)result.Constraints["p1"];
+            CompoundRouteConstraint constraint = Assert.IsType<CompoundRouteConstraint>(result.Constraints["p1"]);
             Assert.IsType<AlphaRouteConstraint>(constraint.Constraints.ElementAt(0));
             Assert.IsType<LengthRouteConstraint>(constraint.Constraints.ElementAt(1));
         }
@@ -147,8 +143,8 @@ namespace System.Web.Mvc.Routing
 
             Assert.Equal("hello/{param}", result.RouteUrl);
 
-            Assert.IsType<RegexRouteConstraint>(result.Constraints["param"]);
-            Assert.Equal(@"\}", ((RegexRouteConstraint)result.Constraints["param"]).Pattern);
+            var constraint = Assert.IsType<RegexRouteConstraint>(result.Constraints["param"]);
+            Assert.Equal(@"\}", constraint.Pattern);
         }
 
         [Fact]
@@ -158,8 +154,8 @@ namespace System.Web.Mvc.Routing
 
             Assert.Equal("hello/{param}", result.RouteUrl);
 
-            Assert.IsType<RegexRouteConstraint>(result.Constraints["param"]);
-            Assert.Equal(@"\)", ((RegexRouteConstraint)result.Constraints["param"]).Pattern);
+            var constraint = Assert.IsType<RegexRouteConstraint>(result.Constraints["param"]);
+            Assert.Equal(@"\)", constraint.Pattern);
         }
 
         [Fact]
@@ -168,8 +164,8 @@ namespace System.Web.Mvc.Routing
             var result = Act(@"hello/{param:regex(:)}");
 
             Assert.Equal("hello/{param}", result.RouteUrl);
-            Assert.IsType<RegexRouteConstraint>(result.Constraints["param"]);
-            Assert.Equal(@":", ((RegexRouteConstraint)result.Constraints["param"]).Pattern);
+            var constraint = Assert.IsType<RegexRouteConstraint>(result.Constraints["param"]);
+            Assert.Equal(@":", constraint.Pattern);
         }
 
         [Fact]
@@ -178,8 +174,8 @@ namespace System.Web.Mvc.Routing
             var result = Act(@"hello/{param:regex(\w,\w)}");
 
             Assert.Equal("hello/{param}", result.RouteUrl);
-            Assert.IsType<RegexRouteConstraint>(result.Constraints["param"]);
-            Assert.Equal(@"\w,\w", ((RegexRouteConstraint)result.Constraints["param"]).Pattern);
+            var constraint = Assert.IsType<RegexRouteConstraint>(result.Constraints["param"]);
+            Assert.Equal(@"\w,\w", constraint.Pattern);
         }
 
         [Fact]
@@ -190,8 +186,8 @@ namespace System.Web.Mvc.Routing
             Assert.Equal("hello/{param}", result.RouteUrl);
 
             Assert.DoesNotContain("param", result.Defaults.Keys);
-            Assert.IsType<RegexRouteConstraint>(result.Constraints["param"]);
-            Assert.Equal(@"=", ((RegexRouteConstraint)result.Constraints["param"]).Pattern);
+            var constraint = Assert.IsType<RegexRouteConstraint>(result.Constraints["param"]);
+            Assert.Equal(@"=", constraint.Pattern);
         }
 
         [Fact]
@@ -200,8 +196,8 @@ namespace System.Web.Mvc.Routing
             var result = Act(@"hello/{param:regex(\{)}");
 
             Assert.Equal("hello/{param}", result.RouteUrl);
-            Assert.IsType<RegexRouteConstraint>(result.Constraints["param"]);
-            Assert.Equal(@"\{", ((RegexRouteConstraint)result.Constraints["param"]).Pattern);
+            var constraint = Assert.IsType<RegexRouteConstraint>(result.Constraints["param"]);
+            Assert.Equal(@"\{", constraint.Pattern);
         }
 
         [Fact]
@@ -210,8 +206,8 @@ namespace System.Web.Mvc.Routing
             var result = Act(@"hello/{param:regex(\()}");
 
             Assert.Equal("hello/{param}", result.RouteUrl);
-            Assert.IsType<RegexRouteConstraint>(result.Constraints["param"]);
-            Assert.Equal(@"\(", ((RegexRouteConstraint)result.Constraints["param"]).Pattern);
+            var constraint = Assert.IsType<RegexRouteConstraint>(result.Constraints["param"]);
+            Assert.Equal(@"\(", constraint.Pattern);
         }
 
         [Fact]
@@ -221,8 +217,8 @@ namespace System.Web.Mvc.Routing
 
             Assert.Equal("hello/{param}", result.RouteUrl);
             Assert.DoesNotContain("param", result.Defaults.Keys);
-            Assert.IsType<RegexRouteConstraint>(result.Constraints["param"]);
-            Assert.Equal(@"\?", ((RegexRouteConstraint)result.Constraints["param"]).Pattern);
+            var constraint = Assert.IsType<RegexRouteConstraint>(result.Constraints["param"]);
+            Assert.Equal(@"\?", constraint.Pattern);
         }
 
 

--- a/test/Common/Routing/RouteFactoryAttributeTests.cs
+++ b/test/Common/Routing/RouteFactoryAttributeTests.cs
@@ -500,8 +500,8 @@ namespace System.Web.Mvc.Routing
             // Assert
             Assert.NotNull(usage);
             Assert.Equal(AttributeTargets.Class | AttributeTargets.Method, usage.ValidOn);
-            Assert.Equal(false, usage.Inherited);
-            Assert.Equal(true, usage.AllowMultiple);
+            Assert.False(usage.Inherited);
+            Assert.True(usage.AllowMultiple);
         }
 
         private static IDirectRouteBuilder CreateBuilder(Func<RouteEntry> build)

--- a/test/Common/UriQueryUtilityTest.cs
+++ b/test/Common/UriQueryUtilityTest.cs
@@ -52,12 +52,12 @@ namespace System.Net.Http
                 Assert.NotNull(result);
 
                 // Because this is a NameValueCollection, the same name appears only once
-                Assert.Equal(1, result.Count);
+                Assert.Single(result);
 
                 // Values should be a comma separated list of empty strings
                 string[] values = result[""].Split(new char[] { ',' });
 
-                // We expect length+1 segment as the final '&' counts as a segment 
+                // We expect length+1 segment as the final '&' counts as a segment
                 Assert.Equal(index + 1, values.Length);
                 foreach (var value in values)
                 {
@@ -84,7 +84,7 @@ namespace System.Net.Http
                 Assert.NotNull(result);
 
                 // Because this is a NameValueCollection, the same name appears only once
-                Assert.Equal(1, result.Count);
+                Assert.Single(result);
 
                 // Values should be a comma separated list of resultValue
                 string[] values = result[resultName].Split(new char[] { ',' });

--- a/test/Microsoft.AspNet.Facebook.Test/FacebookAuthorizeFilterHookTest.cs
+++ b/test/Microsoft.AspNet.Facebook.Test/FacebookAuthorizeFilterHookTest.cs
@@ -169,7 +169,7 @@ namespace Microsoft.AspNet.Facebook.Test
             }
 
             // Assert
-            Assert.Equal(false, authorizeFilter.DeniedPermissionPromptHookTriggered);
+            Assert.False(authorizeFilter.DeniedPermissionPromptHookTriggered);
 
             // Act 2
             // We're making a "second" request essentially

--- a/test/Microsoft.AspNet.Facebook.Test/Microsoft.AspNet.Facebook.Test.csproj
+++ b/test/Microsoft.AspNet.Facebook.Test/Microsoft.AspNet.Facebook.Test.csproj
@@ -128,6 +128,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/Microsoft.AspNet.Facebook.Test/packages.config
+++ b/test/Microsoft.AspNet.Facebook.Test/packages.config
@@ -4,7 +4,9 @@
   <package id="Facebook" version="6.4.2" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />

--- a/test/Microsoft.TestCommon/Microsoft.TestCommon.csproj
+++ b/test/Microsoft.TestCommon/Microsoft.TestCommon.csproj
@@ -112,6 +112,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>
     <VisualStudio>

--- a/test/Microsoft.TestCommon/Microsoft/TestCommon/DataSets/TestData.cs
+++ b/test/Microsoft.TestCommon/Microsoft/TestCommon/DataSets/TestData.cs
@@ -368,7 +368,6 @@ namespace Microsoft.TestCommon
         private static readonly Type OpenIQueryableType = typeof(IQueryable<>);
         private static readonly Type OpenDictionaryType = typeof(Dictionary<,>);
         private static readonly Type OpenTestDataHolderType = typeof(TestDataHolder<>);
-        private int dictionaryKey;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TestData&lt;T&gt;"/> class.
@@ -444,9 +443,9 @@ namespace Microsoft.TestCommon
         public Dictionary<string, T> GetTestDataAsDictionary()
         {
             // Some TestData collections contain duplicates e.g. UintTestData contains both 0 and UInt32.MinValue.
-            // Therefore use dictionaryKey, not _unused.ToString().  Reset key to keep dictionaries consistent if used
-            // multiple times.
-            dictionaryKey = 0;
+            // Therefore use dictionaryKey, not _unused.ToString(). Do not reuse key to keep dictionaries consistent
+            // if enumerated multiple times.
+            int dictionaryKey = 0;
             return this.GetTypedTestData().ToDictionary(_unused => (dictionaryKey++).ToString());
         }
 

--- a/test/Microsoft.TestCommon/Microsoft/TestCommon/GenericTypeAssert.cs
+++ b/test/Microsoft.TestCommon/Microsoft/TestCommon/GenericTypeAssert.cs
@@ -178,7 +178,7 @@ namespace Microsoft.TestCommon
         /// <returns>An instance of type <typeparamref name="T"/>.</returns>
         public T InvokeConstructor<T>(Type genericBaseType, Type genericParameterType, params object[] parameterValues)
         {
-            Assert.NotNull(genericBaseType == null);
+            Assert.NotNull(genericBaseType);
             Assert.True(genericBaseType.IsGenericTypeDefinition);
             Assert.NotNull(genericParameterType);
 
@@ -217,14 +217,14 @@ namespace Microsoft.TestCommon
         /// <typeparam name="T">The type of instance.</typeparam>
         /// <param name="instance">The instance to test.</param>
         /// <param name="genericTypeParameter">The type of the generic parameter to which the instance's generic type should have been bound.</param>
-        public void IsCorrectGenericType<T>(T instance, Type genericTypeParameter)
+        public void IsCorrectGenericType<T>(T instance, Type genericTypeParameter) where T : class
         {
             Assert.NotNull(instance);
             Assert.NotNull(genericTypeParameter);
             Assert.True(instance.GetType().IsGenericType);
             Type[] genericArguments = instance.GetType().GetGenericArguments();
-            Assert.Equal(1, genericArguments.Length);
-            Assert.Equal(genericTypeParameter, genericArguments[0]);
+            Type genericArgument = Assert.Single(genericArguments);
+            Assert.Equal(genericTypeParameter, genericArgument);
         }
 
         /// <summary>

--- a/test/Microsoft.TestCommon/Microsoft/TestCommon/HttpAssert.cs
+++ b/test/Microsoft.TestCommon/Microsoft/TestCommon/HttpAssert.cs
@@ -109,8 +109,6 @@ namespace Microsoft.TestCommon
             foreach (KeyValuePair<string, IEnumerable<string>> expectedHeader in expectedHeaders)
             {
                 KeyValuePair<string, IEnumerable<string>> actualHeader = actualHeaders.FirstOrDefault(h => h.Key == expectedHeader.Key);
-                Assert.NotNull(actualHeader);
-
                 if (expectedHeader.Key == "Date")
                 {
                     HandleDateHeader(expectedHeader.Value.ToArray(), actualHeader.Value.ToArray());

--- a/test/Microsoft.TestCommon/packages.config
+++ b/test/Microsoft.TestCommon/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.execution" version="2.3.0" targetFramework="net452" />

--- a/test/Microsoft.Web.Helpers.Test/LinkShareTest.cs
+++ b/test/Microsoft.Web.Helpers.Test/LinkShareTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Web.Helpers.Test
             string twitterTag = String.Empty;
             string actual;
             actual = LinkShare.GetHtml(pageTitle, pageLinkBack, twitterUserName, twitterTag, LinkShareSite.Facebook, LinkShareSite.All).ToString();
-            Assert.True(actual.Contains("twitter.com"));
+            Assert.Contains("twitter.com", actual);
             int pos = actual.IndexOf("facebook.com");
             Assert.True(pos > 0);
             int pos2 = actual.IndexOf("reddit.com");

--- a/test/Microsoft.Web.Helpers.Test/Microsoft.Web.Helpers.Test.csproj
+++ b/test/Microsoft.Web.Helpers.Test/Microsoft.Web.Helpers.Test.csproj
@@ -92,6 +92,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/Microsoft.Web.Helpers.Test/PreAppStartCodeTest.cs
+++ b/test/Microsoft.Web.Helpers.Test/PreAppStartCodeTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Linq;
 using System.Web.WebPages.Razor;
 using System.Web.WebPages.TestUtils;
 using Microsoft.TestCommon;
@@ -21,7 +20,7 @@ namespace Microsoft.Web.Helpers.Test
 
                 // Assert
                 var imports = WebPageRazorHost.GetGlobalImports();
-                Assert.True(imports.Any(ns => ns.Equals("Microsoft.Web.Helpers")));
+                Assert.Contains(imports, ns => ns.Equals("Microsoft.Web.Helpers"));
             });
         }
 

--- a/test/Microsoft.Web.Helpers.Test/ThemesTest.cs
+++ b/test/Microsoft.Web.Helpers.Test/ThemesTest.cs
@@ -99,9 +99,9 @@ namespace Microsoft.Web.Helpers.Test
             themesImpl.Initialize(themeDirectory: themeDirectory, defaultTheme: defaultTheme);
 
             // Ensure Theme use scope storage to store properties
-            Assert.Equal(scope[ThemesImplementation.ThemesInitializedKey], true);
-            Assert.Equal(scope[ThemesImplementation.ThemeDirectoryKey], themeDirectory);
-            Assert.Equal(scope[ThemesImplementation.DefaultThemeKey], defaultTheme);
+            Assert.Equal((object)true, scope[ThemesImplementation.ThemesInitializedKey]);
+            Assert.Equal(themeDirectory, scope[ThemesImplementation.ThemeDirectoryKey]);
+            Assert.Equal(defaultTheme, scope[ThemesImplementation.DefaultThemeKey]);
         }
 
         [Fact]
@@ -191,7 +191,7 @@ namespace Microsoft.Web.Helpers.Test
             var themePath = themesImpl.GetResourcePath(fileName: "wp7.css");
 
             // Assert
-            Assert.Equal(themePath, @"themes/mobile/wp7.css");
+            Assert.Equal(@"themes/mobile/wp7.css", themePath);
         }
 
         [Fact]
@@ -207,7 +207,7 @@ namespace Microsoft.Web.Helpers.Test
             var themePath = themesImpl.GetResourcePath(folder: "styles", fileName: "wp7.css");
 
             // Assert
-            Assert.Equal(themePath, @"themes/mobile/styles/wp7.css");
+            Assert.Equal(@"themes/mobile/styles/wp7.css", themePath);
         }
 
         [Fact]
@@ -223,7 +223,7 @@ namespace Microsoft.Web.Helpers.Test
             var themePath = themesImpl.GetResourcePath(folder: "styles", fileName: "main.css");
 
             // Assert
-            Assert.Equal(themePath, @"themes/default/styles/main.css");
+            Assert.Equal(@"themes/default/styles/main.css", themePath);
         }
 
         [Fact]
@@ -270,9 +270,9 @@ namespace Microsoft.Web.Helpers.Test
 
             // Assert
             Assert.Equal(3, themes.Count);
-            Assert.Equal(themes[0], "default");
-            Assert.Equal(themes[1], "mobile");
-            Assert.Equal(themes[2], "rotary-phone");
+            Assert.Equal("default", themes[0]);
+            Assert.Equal("mobile", themes[1]);
+            Assert.Equal("rotary-phone", themes[2]);
         }
 
         /// <remarks>

--- a/test/Microsoft.Web.Helpers.Test/VideoTest.cs
+++ b/test/Microsoft.Web.Helpers.Test/VideoTest.cs
@@ -24,13 +24,12 @@ namespace Microsoft.Web.Helpers.Test
         public void FlashDefaults()
         {
             string html = Video.Flash(GetContext(), _pathUtility, "http://foo.bar.com/foo.swf").ToString().Replace("\r\n", "");
-            Assert.True(html.StartsWith(
-                "<object classid=\"clsid:d27cdb6e-ae6d-11cf-96b8-444553540000\" " +
-                "codebase=\"http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab\" type=\"application/x-oleobject\" >"
-                            ));
-            Assert.True(html.Contains("<param name=\"movie\" value=\"http://foo.bar.com/foo.swf\" />"));
-            Assert.True(html.Contains("<embed src=\"http://foo.bar.com/foo.swf\" type=\"application/x-shockwave-flash\" />"));
-            Assert.True(html.EndsWith("</object>"));
+            Assert.StartsWith("<object classid=\"clsid:d27cdb6e-ae6d-11cf-96b8-444553540000\" " +
+                "codebase=\"http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab\" type=\"application/x-oleobject\" >",
+                html);
+            Assert.Contains("<param name=\"movie\" value=\"http://foo.bar.com/foo.swf\" />", html);
+            Assert.Contains("<embed src=\"http://foo.bar.com/foo.swf\" type=\"application/x-shockwave-flash\" />", html);
+            Assert.EndsWith("</object>", html);
         }
 
         [Fact]
@@ -52,39 +51,38 @@ namespace Microsoft.Web.Helpers.Test
                                       play: false, loop: false, menu: false, backgroundColor: "#000", quality: "Q", scale: "S", windowMode: "WM",
                                       baseUrl: "http://foo.bar.com/", version: "1.0.0.0", htmlAttributes: new { id = "fl" }, embedName: "efl").ToString().Replace("\r\n", "");
 
-            Assert.True(html.StartsWith(
-                "<object classid=\"clsid:d27cdb6e-ae6d-11cf-96b8-444553540000\" " +
+            Assert.StartsWith("<object classid=\"clsid:d27cdb6e-ae6d-11cf-96b8-444553540000\" " +
                 "codebase=\"http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=1,0,0,0\" " +
-                "height=\"100px\" id=\"fl\" type=\"application/x-oleobject\" width=\"100px\" >"
-                            ));
-            Assert.True(html.Contains("<param name=\"play\" value=\"False\" />"));
-            Assert.True(html.Contains("<param name=\"loop\" value=\"False\" />"));
-            Assert.True(html.Contains("<param name=\"menu\" value=\"False\" />"));
-            Assert.True(html.Contains("<param name=\"bgColor\" value=\"#000\" />"));
-            Assert.True(html.Contains("<param name=\"quality\" value=\"Q\" />"));
-            Assert.True(html.Contains("<param name=\"scale\" value=\"S\" />"));
-            Assert.True(html.Contains("<param name=\"wmode\" value=\"WM\" />"));
-            Assert.True(html.Contains("<param name=\"base\" value=\"http://foo.bar.com/\" />"));
+                "height=\"100px\" id=\"fl\" type=\"application/x-oleobject\" width=\"100px\" >",
+                html);
+            Assert.Contains("<param name=\"play\" value=\"False\" />", html);
+            Assert.Contains("<param name=\"loop\" value=\"False\" />", html);
+            Assert.Contains("<param name=\"menu\" value=\"False\" />", html);
+            Assert.Contains("<param name=\"bgColor\" value=\"#000\" />", html);
+            Assert.Contains("<param name=\"quality\" value=\"Q\" />", html);
+            Assert.Contains("<param name=\"scale\" value=\"S\" />", html);
+            Assert.Contains("<param name=\"wmode\" value=\"WM\" />", html);
+            Assert.Contains("<param name=\"base\" value=\"http://foo.bar.com/\" />", html);
 
             var embed = new Regex("<embed.*/>").Match(html);
             Assert.True(embed.Success);
-            Assert.True(embed.Value.StartsWith("<embed src=\"http://foo.bar.com/foo.swf\" width=\"100px\" height=\"100px\" name=\"efl\" type=\"application/x-shockwave-flash\" "));
-            Assert.True(embed.Value.Contains("play=\"False\""));
-            Assert.True(embed.Value.Contains("loop=\"False\""));
-            Assert.True(embed.Value.Contains("menu=\"False\""));
-            Assert.True(embed.Value.Contains("bgColor=\"#000\""));
-            Assert.True(embed.Value.Contains("quality=\"Q\""));
-            Assert.True(embed.Value.Contains("scale=\"S\""));
-            Assert.True(embed.Value.Contains("wmode=\"WM\""));
-            Assert.True(embed.Value.Contains("base=\"http://foo.bar.com/\""));
+            Assert.StartsWith("<embed src=\"http://foo.bar.com/foo.swf\" width=\"100px\" height=\"100px\" name=\"efl\" type=\"application/x-shockwave-flash\" ", embed.Value);
+            Assert.Contains("play=\"False\"", embed.Value);
+            Assert.Contains("loop=\"False\"", embed.Value);
+            Assert.Contains("menu=\"False\"", embed.Value);
+            Assert.Contains("bgColor=\"#000\"", embed.Value);
+            Assert.Contains("quality=\"Q\"", embed.Value);
+            Assert.Contains("scale=\"S\"", embed.Value);
+            Assert.Contains("wmode=\"WM\"", embed.Value);
+            Assert.Contains("base=\"http://foo.bar.com/\"", embed.Value);
         }
 
         [Fact]
         public void FlashWithUnexposedOptions()
         {
             string html = Video.Flash(GetContext(), _pathUtility, "http://foo.bar.com/foo.swf", options: new { X = "Y", Z = 123 }).ToString().Replace("\r\n", "");
-            Assert.True(html.Contains("<param name=\"X\" value=\"Y\" />"));
-            Assert.True(html.Contains("<param name=\"Z\" value=\"123\" />"));
+            Assert.Contains("<param name=\"X\" value=\"Y\" />", html);
+            Assert.Contains("<param name=\"Z\" value=\"123\" />", html);
             // note - can't guarantee order of optional params:
             Assert.True(
                 html.Contains("<embed src=\"http://foo.bar.com/foo.swf\" type=\"application/x-shockwave-flash\" X=\"Y\" Z=\"123\" />") ||
@@ -102,12 +100,10 @@ namespace Microsoft.Web.Helpers.Test
         public void MediaPlayerDefaults()
         {
             string html = Video.MediaPlayer(GetContext(), _pathUtility, "http://foo.bar.com/foo.wmv").ToString().Replace("\r\n", "");
-            Assert.True(html.StartsWith(
-                "<object classid=\"clsid:6BF52A52-394A-11D3-B153-00C04F79FAA6\" >"
-                            ));
-            Assert.True(html.Contains("<param name=\"URL\" value=\"http://foo.bar.com/foo.wmv\" />"));
-            Assert.True(html.Contains("<embed src=\"http://foo.bar.com/foo.wmv\" type=\"application/x-mplayer2\" />"));
-            Assert.True(html.EndsWith("</object>"));
+            Assert.StartsWith("<object classid=\"clsid:6BF52A52-394A-11D3-B153-00C04F79FAA6\" >", html);
+            Assert.Contains("<param name=\"URL\" value=\"http://foo.bar.com/foo.wmv\" />", html);
+            Assert.Contains("<embed src=\"http://foo.bar.com/foo.wmv\" type=\"application/x-mplayer2\" />", html);
+            Assert.EndsWith("</object>", html);
         }
 
         [Fact]
@@ -128,38 +124,36 @@ namespace Microsoft.Web.Helpers.Test
             string html = Video.MediaPlayer(GetContext(), _pathUtility, "http://foo.bar.com/foo.wmv", width: "100px", height: "100px",
                                             autoStart: false, playCount: 2, uiMode: "UIMODE", stretchToFit: true, enableContextMenu: false, mute: true,
                                             volume: 1, baseUrl: "http://foo.bar.com/", htmlAttributes: new { id = "mp" }, embedName: "emp").ToString().Replace("\r\n", "");
-            Assert.True(html.StartsWith(
-                "<object classid=\"clsid:6BF52A52-394A-11D3-B153-00C04F79FAA6\" height=\"100px\" id=\"mp\" width=\"100px\" >"
-                            ));
-            Assert.True(html.Contains("<param name=\"URL\" value=\"http://foo.bar.com/foo.wmv\" />"));
-            Assert.True(html.Contains("<param name=\"autoStart\" value=\"False\" />"));
-            Assert.True(html.Contains("<param name=\"playCount\" value=\"2\" />"));
-            Assert.True(html.Contains("<param name=\"uiMode\" value=\"UIMODE\" />"));
-            Assert.True(html.Contains("<param name=\"stretchToFit\" value=\"True\" />"));
-            Assert.True(html.Contains("<param name=\"enableContextMenu\" value=\"False\" />"));
-            Assert.True(html.Contains("<param name=\"mute\" value=\"True\" />"));
-            Assert.True(html.Contains("<param name=\"volume\" value=\"1\" />"));
-            Assert.True(html.Contains("<param name=\"baseURL\" value=\"http://foo.bar.com/\" />"));
+            Assert.StartsWith("<object classid=\"clsid:6BF52A52-394A-11D3-B153-00C04F79FAA6\" height=\"100px\" id=\"mp\" width=\"100px\" >", html);
+            Assert.Contains("<param name=\"URL\" value=\"http://foo.bar.com/foo.wmv\" />", html);
+            Assert.Contains("<param name=\"autoStart\" value=\"False\" />", html);
+            Assert.Contains("<param name=\"playCount\" value=\"2\" />", html);
+            Assert.Contains("<param name=\"uiMode\" value=\"UIMODE\" />", html);
+            Assert.Contains("<param name=\"stretchToFit\" value=\"True\" />", html);
+            Assert.Contains("<param name=\"enableContextMenu\" value=\"False\" />", html);
+            Assert.Contains("<param name=\"mute\" value=\"True\" />", html);
+            Assert.Contains("<param name=\"volume\" value=\"1\" />", html);
+            Assert.Contains("<param name=\"baseURL\" value=\"http://foo.bar.com/\" />", html);
 
             var embed = new Regex("<embed.*/>").Match(html);
             Assert.True(embed.Success);
-            Assert.True(embed.Value.StartsWith("<embed src=\"http://foo.bar.com/foo.wmv\" width=\"100px\" height=\"100px\" name=\"emp\" type=\"application/x-mplayer2\" "));
-            Assert.True(embed.Value.Contains("autoStart=\"False\""));
-            Assert.True(embed.Value.Contains("playCount=\"2\""));
-            Assert.True(embed.Value.Contains("uiMode=\"UIMODE\""));
-            Assert.True(embed.Value.Contains("stretchToFit=\"True\""));
-            Assert.True(embed.Value.Contains("enableContextMenu=\"False\""));
-            Assert.True(embed.Value.Contains("mute=\"True\""));
-            Assert.True(embed.Value.Contains("volume=\"1\""));
-            Assert.True(embed.Value.Contains("baseURL=\"http://foo.bar.com/\""));
+            Assert.StartsWith("<embed src=\"http://foo.bar.com/foo.wmv\" width=\"100px\" height=\"100px\" name=\"emp\" type=\"application/x-mplayer2\" ", embed.Value);
+            Assert.Contains("autoStart=\"False\"", embed.Value);
+            Assert.Contains("playCount=\"2\"", embed.Value);
+            Assert.Contains("uiMode=\"UIMODE\"", embed.Value);
+            Assert.Contains("stretchToFit=\"True\"", embed.Value);
+            Assert.Contains("enableContextMenu=\"False\"", embed.Value);
+            Assert.Contains("mute=\"True\"", embed.Value);
+            Assert.Contains("volume=\"1\"", embed.Value);
+            Assert.Contains("baseURL=\"http://foo.bar.com/\"", embed.Value);
         }
 
         [Fact]
         public void MediaPlayerWithUnexposedOptions()
         {
             string html = Video.MediaPlayer(GetContext(), _pathUtility, "http://foo.bar.com/foo.wmv", options: new { X = "Y", Z = 123 }).ToString().Replace("\r\n", "");
-            Assert.True(html.Contains("<param name=\"X\" value=\"Y\" />"));
-            Assert.True(html.Contains("<param name=\"Z\" value=\"123\" />"));
+            Assert.Contains("<param name=\"X\" value=\"Y\" />", html);
+            Assert.Contains("<param name=\"Z\" value=\"123\" />", html);
             Assert.True(
                 html.Contains("<embed src=\"http://foo.bar.com/foo.wmv\" type=\"application/x-mplayer2\" X=\"Y\" Z=\"123\" />") ||
                 html.Contains("<embed src=\"http://foo.bar.com/foo.wmv\" type=\"application/x-mplayer2\" Z=\"123\" X=\"Y\" />")
@@ -180,16 +174,14 @@ namespace Microsoft.Web.Helpers.Test
         public void SilverlightDefaults()
         {
             string html = Video.Silverlight(GetContext(), _pathUtility, "http://foo.bar.com/foo.xap", "100px", "100px").ToString().Replace("\r\n", "");
-            Assert.True(html.StartsWith(
-                "<object data=\"data:application/x-silverlight-2,\" height=\"100px\" type=\"application/x-silverlight-2\" " +
-                "width=\"100px\" >"
-                            ));
-            Assert.True(html.Contains("<param name=\"source\" value=\"http://foo.bar.com/foo.xap\" />"));
-            Assert.True(html.Contains(
-                "<a href=\"http://go.microsoft.com/fwlink/?LinkID=149156\" style=\"text-decoration:none\">" +
+            Assert.StartsWith("<object data=\"data:application/x-silverlight-2,\" height=\"100px\" type=\"application/x-silverlight-2\" " +
+                "width=\"100px\" >",
+                html);
+            Assert.Contains("<param name=\"source\" value=\"http://foo.bar.com/foo.xap\" />", html);
+            Assert.Contains("<a href=\"http://go.microsoft.com/fwlink/?LinkID=149156\" style=\"text-decoration:none\">" +
                 "<img src=\"http://go.microsoft.com/fwlink?LinkId=108181\" alt=\"Get Microsoft Silverlight\" " +
-                "style=\"border-style:none\"/></a>"));
-            Assert.True(html.EndsWith("</object>"));
+                "style=\"border-style:none\"/></a>", html);
+            Assert.EndsWith("</object>", html);
         }
 
         [Fact]
@@ -234,14 +226,13 @@ namespace Microsoft.Web.Helpers.Test
             string html = Video.Silverlight(GetContext(), _pathUtility, "http://foo.bar.com/foo.xap", width: "85%", height: "85%",
                                             backgroundColor: "red", initParameters: "X=Y", minimumVersion: "1.0.0.0", autoUpgrade: false,
                                             htmlAttributes: new { id = "sl" }).ToString().Replace("\r\n", "");
-            Assert.True(html.StartsWith(
-                "<object data=\"data:application/x-silverlight-2,\" height=\"85%\" id=\"sl\" " +
-                "type=\"application/x-silverlight-2\" width=\"85%\" >"
-                            ));
-            Assert.True(html.Contains("<param name=\"background\" value=\"red\" />"));
-            Assert.True(html.Contains("<param name=\"initparams\" value=\"X=Y\" />"));
-            Assert.True(html.Contains("<param name=\"minruntimeversion\" value=\"1.0.0.0\" />"));
-            Assert.True(html.Contains("<param name=\"autoUpgrade\" value=\"False\" />"));
+            Assert.StartsWith("<object data=\"data:application/x-silverlight-2,\" height=\"85%\" id=\"sl\" " +
+                "type=\"application/x-silverlight-2\" width=\"85%\" >",
+                html);
+            Assert.Contains("<param name=\"background\" value=\"red\" />", html);
+            Assert.Contains("<param name=\"initparams\" value=\"X=Y\" />", html);
+            Assert.Contains("<param name=\"minruntimeversion\" value=\"1.0.0.0\" />", html);
+            Assert.Contains("<param name=\"autoUpgrade\" value=\"False\" />", html);
 
             var embed = new Regex("<embed.*/>").Match(html);
             Assert.False(embed.Success);
@@ -252,8 +243,8 @@ namespace Microsoft.Web.Helpers.Test
         {
             string html = Video.Silverlight(GetContext(), _pathUtility, "http://foo.bar.com/foo.xap", width: "50px", height: "50px",
                                             options: new { X = "Y", Z = 123 }).ToString().Replace("\r\n", "");
-            Assert.True(html.Contains("<param name=\"X\" value=\"Y\" />"));
-            Assert.True(html.Contains("<param name=\"Z\" value=\"123\" />"));
+            Assert.Contains("<param name=\"X\" value=\"Y\" />", html);
+            Assert.Contains("<param name=\"Z\" value=\"123\" />", html);
         }
 
         [Fact]
@@ -269,8 +260,8 @@ namespace Microsoft.Web.Helpers.Test
             HttpContextBase context = GetContext(serverMock.Object);
 
             string html = Video.Flash(context, pathUtility.Object, "foo.bar").ToString();
-            Assert.True(html.StartsWith("<object"));
-            Assert.True(html.Contains(HttpUtility.HtmlAttributeEncode(HttpUtility.UrlPathEncode(path))));
+            Assert.StartsWith("<object", html);
+            Assert.Contains(HttpUtility.HtmlAttributeEncode(HttpUtility.UrlPathEncode(path)), html);
         }
 
         [Fact]

--- a/test/Microsoft.Web.Helpers.Test/packages.config
+++ b/test/Microsoft.Web.Helpers.Test/packages.config
@@ -2,7 +2,9 @@
 <packages>
   <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
+  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />

--- a/test/Microsoft.Web.Mvc.Test/Microsoft.Web.Mvc.Test.csproj
+++ b/test/Microsoft.Web.Mvc.Test/Microsoft.Web.Mvc.Test.csproj
@@ -159,6 +159,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/Microsoft.Web.Mvc.Test/ModelBinding/Test/MutableObjectModelBinderTest.cs
+++ b/test/Microsoft.Web.Mvc.Test/ModelBinding/Test/MutableObjectModelBinderTest.cs
@@ -591,10 +591,10 @@ namespace Microsoft.Web.Mvc.ModelBinding.Test
 
             // Assert
             Assert.False(bindingContext.ModelState.IsValid);
-            Assert.Equal(1, bindingContext.ModelState["foo.NameNoAttribute"].Errors.Count);
+            ModelError error = Assert.Single(bindingContext.ModelState["foo.NameNoAttribute"].Errors);
             Assert.Equal("This is a different exception." + Environment.NewLine
                        + "Parameter name: value",
-                         bindingContext.ModelState["foo.NameNoAttribute"].Errors[0].Exception.Message);
+                         error.Exception.Message);
         }
 
         [Fact]
@@ -622,8 +622,8 @@ namespace Microsoft.Web.Mvc.ModelBinding.Test
 
             // Assert
             Assert.False(bindingContext.ModelState.IsValid);
-            Assert.Equal(1, bindingContext.ModelState["foo.Name"].Errors.Count);
-            Assert.Equal("This message comes from the [Required] attribute.", bindingContext.ModelState["foo.Name"].Errors[0].ErrorMessage);
+            ModelError error = Assert.Single(bindingContext.ModelState["foo.Name"].Errors);
+            Assert.Equal("This message comes from the [Required] attribute.", error.ErrorMessage);
         }
 
         private static ModelMetadata GetMetadataForCanUpdateProperty(string propertyName)

--- a/test/Microsoft.Web.Mvc.Test/packages.config
+++ b/test/Microsoft.Web.Mvc.Test/packages.config
@@ -3,7 +3,9 @@
   <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />

--- a/test/Microsoft.Web.WebPages.OAuth.Test/Microsoft.Web.WebPages.OAuth.Test.csproj
+++ b/test/Microsoft.Web.WebPages.OAuth.Test/Microsoft.Web.WebPages.OAuth.Test.csproj
@@ -89,6 +89,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/Microsoft.Web.WebPages.OAuth.Test/packages.config
+++ b/test/Microsoft.Web.WebPages.OAuth.Test/packages.config
@@ -8,7 +8,9 @@
   <package id="DotNetOpenAuth.OpenId.Core" version="4.0.3.12153" targetFramework="net452" />
   <package id="DotNetOpenAuth.OpenId.RelyingParty" version="4.0.3.12153" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
+  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />

--- a/test/System.Net.Http.Formatting.NetCore.Test/System.Net.Http.Formatting.NetCore.Test.csproj
+++ b/test/System.Net.Http.Formatting.NetCore.Test/System.Net.Http.Formatting.NetCore.Test.csproj
@@ -313,6 +313,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.8\tools\Microsoft.Bcl.Build.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/test/System.Net.Http.Formatting.NetCore.Test/packages.config
+++ b/test/System.Net.Http.Formatting.NetCore.Test/packages.config
@@ -6,7 +6,9 @@
   <package id="Microsoft.Net.Http" version="2.2.13" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />

--- a/test/System.Net.Http.Formatting.NetStandard.Test/System.Net.Http.Formatting.NetStandard.Test.csproj
+++ b/test/System.Net.Http.Formatting.NetStandard.Test/System.Net.Http.Formatting.NetStandard.Test.csproj
@@ -306,6 +306,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/System.Net.Http.Formatting.NetStandard.Test/packages.config
+++ b/test/System.Net.Http.Formatting.NetStandard.Test/packages.config
@@ -3,7 +3,9 @@
   <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />

--- a/test/System.Net.Http.Formatting.Test/Formatting/BsonMediaTypeFormatterTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/BsonMediaTypeFormatterTests.cs
@@ -101,8 +101,6 @@ namespace System.Net.Http.Formatting
             }
         }
 
-        [Theory]
-        [TestDataSet(typeof(HttpTestData), "ReadAndWriteCorrectCharacterEncoding")]
         public override Task ReadFromStreamAsync_UsesCorrectCharacterEncoding(string content, string encoding, bool isDefaultEncoding)
         {
             // Arrange
@@ -123,11 +121,10 @@ namespace System.Net.Http.Formatting
             return ReadContentUsingCorrectCharacterEncodingHelperAsync(formatter, content, sourceData, mediaType);
         }
 
-        [Theory]
-        [TestDataSet(typeof(HttpTestData), "ReadAndWriteCorrectCharacterEncoding")]
         public override Task WriteToStreamAsync_UsesCorrectCharacterEncoding(string content, string encoding, bool isDefaultEncoding)
         {
             // Arrange
+            GC.KeepAlive(isDefaultEncoding); // Mark parameter as used. See xUnit1026, [Theory] method doesn't use all parameters.
             BsonMediaTypeFormatter formatter = new BsonMediaTypeFormatter();
 
             string mediaType = string.Format("application/bson; charset={0}", encoding);
@@ -197,6 +194,7 @@ namespace System.Net.Http.Formatting
         public void CanReadType_ReturnsExpectedValues(Type variationType, object testData)
         {
             // Arrange
+            GC.KeepAlive(testData); // Mark parameter as used. See xUnit1026, [Theory] method doesn't use all parameters.
             BsonMediaTypeFormatter formatter = new BsonMediaTypeFormatter();
 
             // Act & Assert
@@ -208,6 +206,7 @@ namespace System.Net.Http.Formatting
         public void CanWriteType_ReturnsExpectedValues(Type variationType, object testData)
         {
             // Arrange
+            GC.KeepAlive(testData); // Mark parameter as used. See xUnit1026, [Theory] method doesn't use all parameters.
             BsonMediaTypeFormatter formatter = new BsonMediaTypeFormatter();
 
             // Act & Assert
@@ -381,7 +380,7 @@ namespace System.Net.Http.Formatting
             if (readJObject != null)
             {
                 // Serialized a Dictionary<string, object> to handle simple runtime type; round trips as a JObject
-                Assert.Equal(1, readJObject.Count);
+                Assert.Single(readJObject);
                 JToken readJToken = readJObject["Value"];
                 Assert.NotNull(readJToken);
                 Assert.Equal(testData, readJToken.ToObject(testData.GetType()));
@@ -413,11 +412,10 @@ namespace System.Net.Http.Formatting
         public async Task ReadFromStreamAsync_RoundTripsWriteToStreamAsync_DBNullAsNull_Dictionary(Type variationType, object testData)
         {
             // Guard
-            Assert.IsType<Dictionary<string, object>>(testData);
+            IDictionary<string, object> expectedDictionary = Assert.IsType<Dictionary<string, object>>(testData);
 
             // Arrange
             TestBsonMediaTypeFormatter formatter = new TestBsonMediaTypeFormatter();
-            IDictionary<string, object> expectedDictionary = (IDictionary<string, object>)testData;
 
             // Arrange & Act & Assert
             object readObj = await ReadFromStreamAsync_RoundTripsWriteToStreamAsync_Helper(formatter, variationType, testData);

--- a/test/System.Net.Http.Formatting.Test/Formatting/BufferedMediaTypeFormatterTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/BufferedMediaTypeFormatterTests.cs
@@ -92,7 +92,7 @@ namespace System.Net.Http.Formatting
         [Fact]
         public async Task BufferedWrite()
         {
-            // Arrange. Specifically use the base class with async signatures. 
+            // Arrange. Specifically use the base class with async signatures.
             MediaTypeFormatter formatter = new MockBufferedMediaTypeFormatter();
             MemoryStream output = new MemoryStream();
 
@@ -108,7 +108,7 @@ namespace System.Net.Http.Formatting
         [Fact]
         public async Task BufferedRead()
         {
-            // Arrange. Specifically use the base class with async signatures. 
+            // Arrange. Specifically use the base class with async signatures.
             MediaTypeFormatter formatter = new MockBufferedMediaTypeFormatter();
             byte[] expectedBytes = ExpectedSupportedEncodings.ElementAt(0).GetBytes(TestData);
             MemoryStream input = new MemoryStream(expectedBytes);
@@ -120,8 +120,6 @@ namespace System.Net.Http.Formatting
             Assert.Equal(TestData, result);
         }
 
-        [Theory]
-        [TestDataSet(typeof(HttpTestData), "ReadAndWriteCorrectCharacterEncoding")]
         public override Task ReadFromStreamAsync_UsesCorrectCharacterEncoding(string content, string encoding, bool isDefaultEncoding)
         {
             // Arrange
@@ -132,8 +130,6 @@ namespace System.Net.Http.Formatting
             return ReadFromStreamAsync_UsesCorrectCharacterEncodingHelper(formatter, content, content, mediaType, encoding, isDefaultEncoding);
         }
 
-        [Theory]
-        [TestDataSet(typeof(HttpTestData), "ReadAndWriteCorrectCharacterEncoding")]
         public override Task WriteToStreamAsync_UsesCorrectCharacterEncoding(string content, string encoding, bool isDefaultEncoding)
         {
             // Arrange

--- a/test/System.Net.Http.Formatting.Test/Formatting/DataContractJsonMediaTypeFormatterTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/DataContractJsonMediaTypeFormatterTests.cs
@@ -212,8 +212,6 @@ namespace System.Net.Http.Formatting
                     memoryStream, content, transportContext: null));
         }
 
-        [Theory]
-        [TestDataSet(typeof(HttpTestData), "ReadAndWriteCorrectCharacterEncoding")]
         public override Task ReadFromStreamAsync_UsesCorrectCharacterEncoding(string content, string encoding, bool isDefaultEncoding)
         {
             if (!isDefaultEncoding)
@@ -232,8 +230,6 @@ namespace System.Net.Http.Formatting
                 formatter, content, formattedContent, mediaType, encoding, isDefaultEncoding);
         }
 
-        [Theory]
-        [TestDataSet(typeof(HttpTestData), "ReadAndWriteCorrectCharacterEncoding")]
         public override Task WriteToStreamAsync_UsesCorrectCharacterEncoding(string content, string encoding, bool isDefaultEncoding)
         {
             // DataContractJsonSerializer does not honor the value of byteOrderMark in the UnicodeEncoding ctor.

--- a/test/System.Net.Http.Formatting.Test/Formatting/FormDataCollectionTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/FormDataCollectionTests.cs
@@ -69,10 +69,10 @@ namespace System.Net.Http.Formatting
         [Fact]
         public void CreateFromPairs()
         {
-            Dictionary<string, string> pairs = new Dictionary<string, string> 
-            { 
-                { "x",  "1"}, 
-                { "y" , "2"} 
+            Dictionary<string, string> pairs = new Dictionary<string, string>
+            {
+                { "x",  "1"},
+                { "y" , "2"}
             };
 
             var form = new FormDataCollection(pairs);
@@ -154,7 +154,7 @@ namespace System.Net.Http.Formatting
         {
             FormDataCollection fd = new FormDataCollection(queryString);
 
-            Assert.Equal(1, fd.Count());
+            Assert.Single(fd);
             Assert.Equal(expected, fd.Get("x"));
         }
     }

--- a/test/System.Net.Http.Formatting.Test/Formatting/FormUrlEncodedMediaTypeFormatterTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/FormUrlEncodedMediaTypeFormatterTests.cs
@@ -169,6 +169,7 @@ namespace System.Net.Http.Formatting
         [TestDataSet(typeof(CommonUnitTestDataSets), "RepresentativeValueAndRefTypeTestDataCollection")]
         public void CanReadTypeReturnsFalse(Type variationType, object testData)
         {
+            GC.KeepAlive(testData); // Mark parameter as used. See xUnit1026, [Theory] method doesn't use all parameters.
             TestFormUrlEncodedMediaTypeFormatter formatter = new TestFormUrlEncodedMediaTypeFormatter();
 
             Assert.False(formatter.CanReadType(variationType));
@@ -189,6 +190,7 @@ namespace System.Net.Http.Formatting
         [TestDataSet(typeof(CommonUnitTestDataSets), "RepresentativeValueAndRefTypeTestDataCollection")]
         public void CanWriteTypeReturnsFalse(Type variationType, object testData)
         {
+            GC.KeepAlive(testData); // Mark parameter as used. See xUnit1026, [Theory] method doesn't use all parameters.
             TestFormUrlEncodedMediaTypeFormatter formatter = new TestFormUrlEncodedMediaTypeFormatter();
 
             Assert.False(formatter.CanWriteType(variationType), "formatter should have returned false.");

--- a/test/System.Net.Http.Formatting.Test/Formatting/JsonMediaTypeFormatterTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/JsonMediaTypeFormatterTests.cs
@@ -394,11 +394,10 @@ namespace System.Net.Http.Formatting
         public async Task ReadFromStreamAsync_RoundTripsWriteToStreamAsync_DBNullAsNull_Dictionary(Type variationType, object testData)
         {
             // Guard
-            Assert.IsType<Dictionary<string, object>>(testData);
+            IDictionary<string, object> expectedDictionary = Assert.IsType<Dictionary<string, object>>(testData);
 
             // Arrange
             TestJsonMediaTypeFormatter formatter = new TestJsonMediaTypeFormatter();
-            IDictionary<string, object> expectedDictionary = (IDictionary<string, object>)testData;
 
             // Arrange & Act & Assert
             object readObj = await ReadFromStreamAsync_RoundTripsWriteToStreamAsync_Helper(formatter, variationType, testData);
@@ -565,8 +564,6 @@ namespace System.Net.Http.Formatting
             Assert.Equal(beforeMessage, afterMessage);
         }
 
-        [Theory]
-        [TestDataSet(typeof(HttpTestData), "ReadAndWriteCorrectCharacterEncoding")]
         public override Task ReadFromStreamAsync_UsesCorrectCharacterEncoding(string content, string encoding, bool isDefaultEncoding)
         {
             // Arrange
@@ -579,8 +576,6 @@ namespace System.Net.Http.Formatting
                 formatter, content, formattedContent, mediaType, encoding, isDefaultEncoding);
         }
 
-        [Theory]
-        [TestDataSet(typeof(HttpTestData), "ReadAndWriteCorrectCharacterEncoding")]
         public override Task WriteToStreamAsync_UsesCorrectCharacterEncoding(string content, string encoding, bool isDefaultEncoding)
         {
             // Arrange

--- a/test/System.Net.Http.Formatting.Test/Formatting/JsonNetSerializationTest.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/JsonNetSerializationTest.cs
@@ -192,7 +192,7 @@ namespace System.Net.Http.Formatting
             formatter.SerializerSettings.TypeNameHandling = TypeNameHandling.Objects;
             string json = await SerializeAsync(new Derived(), typeof(Base), formatter);
             object deserializedObject = await DeserializeAsync(json, typeof(Base), formatter);
-            Assert.IsType(typeof(Derived), deserializedObject);
+            Assert.IsType<Derived>(deserializedObject);
         }
 
         [Fact]
@@ -200,7 +200,7 @@ namespace System.Net.Http.Formatting
         {
             string json = "{\"$type\":\"" + typeof(DangerousType).AssemblyQualifiedName + "\"}";
             object deserializedObject = await DeserializeAsync(json, typeof(object));
-            Assert.IsNotType(typeof(DangerousType), deserializedObject);
+            Assert.IsNotType<DangerousType>(deserializedObject);
         }
 
         [Fact]

--- a/test/System.Net.Http.Formatting.Test/Formatting/MediaTypeFormatterCollectionTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/MediaTypeFormatterCollectionTests.cs
@@ -38,7 +38,7 @@ namespace System.Net.Http.Formatting
         public void Constructor1_AcceptsEmptyList()
         {
             MediaTypeFormatterCollection collection = new MediaTypeFormatterCollection(new MediaTypeFormatter[0]);
-            Assert.Equal(0, collection.Count);
+            Assert.Empty(collection);
         }
 
         [Theory]
@@ -191,7 +191,7 @@ namespace System.Net.Http.Formatting
             MediaTypeFormatterCollection collection = new MediaTypeFormatterCollection(new MediaTypeFormatter[0]);
             Assert.Null(collection.FormUrlEncodedFormatter);
         }
-        
+
         [Fact]
         public void Remove_SetsXmlFormatter()
         {
@@ -275,6 +275,7 @@ namespace System.Net.Http.Formatting
         public void FindReader_ReturnsFormatterOnMatch(Type variationType, object testData, string mediaType)
         {
             // Arrange
+            GC.KeepAlive(testData); // Mark parameter as used. See xUnit1026, [Theory] method doesn't use all parameters.
             MockMediaTypeFormatter formatter = new MockMediaTypeFormatter() { CallBase = true };
             foreach (string legalMediaType in HttpTestData.LegalMediaTypeStrings)
             {
@@ -335,6 +336,7 @@ namespace System.Net.Http.Formatting
         public void FindWriter_ReturnsFormatterOnMatch(Type variationType, object testData, string mediaType)
         {
             // Arrange
+            GC.KeepAlive(testData); // Mark parameter as used. See xUnit1026, [Theory] method doesn't use all parameters.
             MockMediaTypeFormatter formatter = new MockMediaTypeFormatter() { CallBase = true };
             foreach (string legalMediaType in HttpTestData.LegalMediaTypeStrings)
             {

--- a/test/System.Net.Http.Formatting.Test/Formatting/MediaTypeFormatterExtensionsTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/MediaTypeFormatterExtensionsTests.cs
@@ -42,15 +42,14 @@ namespace System.Net.Http.Formatting
         public void AddRequestHeaderMappingAddsSuccessfully()
         {
             MediaTypeFormatter formatter = new MockMediaTypeFormatter();
-            Assert.Equal(0, formatter.MediaTypeMappings.Count);
+            Assert.Empty(formatter.MediaTypeMappings);
             formatter.AddRequestHeaderMapping("name", "value", StringComparison.CurrentCulture, true, new MediaTypeHeaderValue("application/xml"));
             IEnumerable<RequestHeaderMapping> mappings = formatter.MediaTypeMappings.OfType<RequestHeaderMapping>();
-            Assert.Equal(1, mappings.Count());
-            RequestHeaderMapping mapping = mappings.ElementAt(0);
+            RequestHeaderMapping mapping = Assert.Single(mappings);
             Assert.Equal("name", mapping.HeaderName);
             Assert.Equal("value", mapping.HeaderValue);
             Assert.Equal(StringComparison.CurrentCulture, mapping.HeaderValueComparison);
-            Assert.Equal(true, mapping.IsValueSubstring);
+            Assert.True(mapping.IsValueSubstring);
             Assert.Equal(new MediaTypeHeaderValue("application/xml"), mapping.MediaType);
         }
 
@@ -65,15 +64,14 @@ namespace System.Net.Http.Formatting
         public void AddRequestHeaderMapping1AddsSuccessfully()
         {
             MediaTypeFormatter formatter = new MockMediaTypeFormatter();
-            Assert.Equal(0, formatter.MediaTypeMappings.Count);
+            Assert.Empty(formatter.MediaTypeMappings);
             formatter.AddRequestHeaderMapping("name", "value", StringComparison.CurrentCulture, true, "application/xml");
             IEnumerable<RequestHeaderMapping> mappings = formatter.MediaTypeMappings.OfType<RequestHeaderMapping>();
-            Assert.Equal(1, mappings.Count());
-            RequestHeaderMapping mapping = mappings.ElementAt(0);
+            RequestHeaderMapping mapping = Assert.Single(mappings);
             Assert.Equal("name", mapping.HeaderName);
             Assert.Equal("value", mapping.HeaderValue);
             Assert.Equal(StringComparison.CurrentCulture, mapping.HeaderValueComparison);
-            Assert.Equal(true, mapping.IsValueSubstring);
+            Assert.True(mapping.IsValueSubstring);
             Assert.Equal(new MediaTypeHeaderValue("application/xml"), mapping.MediaType);
         }
     }

--- a/test/System.Net.Http.Formatting.Test/Formatting/MediaTypeFormatterTestBase.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/MediaTypeFormatterTestBase.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Http.Formatting.DataSets;
 using System.Net.Http.Headers;
 using System.Reflection;
 using System.Runtime.Serialization;
@@ -138,6 +139,7 @@ namespace System.Net.Http.Formatting
         public async Task ReadFromStreamAsync_WhenContentLengthIsZero_ReturnsDefaultTypeValue<T>(T value)
         {
             // Arrange
+            GC.KeepAlive(value); // Mark parameter as used. See xUnit1026, [Theory] method doesn't use all parameters.
             TFormatter formatter = CreateFormatter();
             HttpContent content = new StringContent("");
 
@@ -320,9 +322,16 @@ namespace System.Net.Http.Formatting
             formatter.Verify();
         }
 
+        // Remove this suppression once we pick up an xunit.analyzers package containing the xnuit/xunit#1466 fix.
+#pragma warning disable xUnit1013 // Public method should be marked as test
+        [Theory]
+        [TestDataSet(typeof(HttpTestData), "ReadAndWriteCorrectCharacterEncoding")]
         public abstract Task ReadFromStreamAsync_UsesCorrectCharacterEncoding(string content, string encoding, bool isDefaultEncoding);
 
+        [Theory]
+        [TestDataSet(typeof(HttpTestData), "ReadAndWriteCorrectCharacterEncoding")]
         public abstract Task WriteToStreamAsync_UsesCorrectCharacterEncoding(string content, string encoding, bool isDefaultEncoding);
+#pragma warning restore xUnit1013 // Public method should be marked as test
 
         protected virtual TFormatter CreateFormatter()
         {
@@ -359,7 +368,7 @@ namespace System.Net.Http.Formatting
             return readObj;
         }
 
-        public async Task ReadFromStreamAsync_UsesCorrectCharacterEncodingHelper(MediaTypeFormatter formatter, string content, string formattedContent, string mediaType, string encoding, bool isDefaultEncoding)
+        protected async Task ReadFromStreamAsync_UsesCorrectCharacterEncodingHelper(MediaTypeFormatter formatter, string content, string formattedContent, string mediaType, string encoding, bool isDefaultEncoding)
         {
             // Arrange
             Encoding enc = null;
@@ -391,7 +400,7 @@ namespace System.Net.Http.Formatting
             Assert.Equal(content, result);
         }
 
-        public async Task WriteToStreamAsync_UsesCorrectCharacterEncodingHelper(MediaTypeFormatter formatter, string content, string formattedContent, string mediaType, string encoding, bool isDefaultEncoding)
+        protected async Task WriteToStreamAsync_UsesCorrectCharacterEncodingHelper(MediaTypeFormatter formatter, string content, string formattedContent, string mediaType, string encoding, bool isDefaultEncoding)
         {
             // Arrange
             Encoding enc = null;
@@ -445,7 +454,7 @@ namespace System.Net.Http.Formatting
             return enc;
         }
 
-        public static Task ReadContentUsingCorrectCharacterEncodingHelperAsync(MediaTypeFormatter formatter, string content, string formattedContent, string mediaType, string encoding, bool isDefaultEncoding)
+        protected static Task ReadContentUsingCorrectCharacterEncodingHelperAsync(MediaTypeFormatter formatter, string content, string formattedContent, string mediaType, string encoding, bool isDefaultEncoding)
         {
             // Arrange
             Encoding enc = CreateOrGetSupportedEncoding(formatter, encoding, isDefaultEncoding);
@@ -455,7 +464,7 @@ namespace System.Net.Http.Formatting
             return ReadContentUsingCorrectCharacterEncodingHelperAsync(formatter, content, sourceData, mediaType);
         }
 
-        public static async Task ReadContentUsingCorrectCharacterEncodingHelperAsync(MediaTypeFormatter formatter, string content, byte[] sourceData, string mediaType)
+        protected static async Task ReadContentUsingCorrectCharacterEncodingHelperAsync(MediaTypeFormatter formatter, string content, byte[] sourceData, string mediaType)
         {
             // Arrange
             MemoryStream memStream = new MemoryStream(sourceData);
@@ -475,7 +484,7 @@ namespace System.Net.Http.Formatting
             Assert.Equal(content, result);
         }
 
-        public static Task WriteContentUsingCorrectCharacterEncodingHelperAsync(MediaTypeFormatter formatter, string content, string formattedContent, string mediaType, string encoding, bool isDefaultEncoding)
+        protected static Task WriteContentUsingCorrectCharacterEncodingHelperAsync(MediaTypeFormatter formatter, string content, string formattedContent, string mediaType, string encoding, bool isDefaultEncoding)
         {
             // Arrange
             Encoding enc = CreateOrGetSupportedEncoding(formatter, encoding, isDefaultEncoding);
@@ -491,7 +500,7 @@ namespace System.Net.Http.Formatting
         }
 
 
-        public static async Task WriteContentUsingCorrectCharacterEncodingHelperAsync(MediaTypeFormatter formatter, string content, byte[] expectedData, string mediaType)
+        protected static async Task WriteContentUsingCorrectCharacterEncodingHelperAsync(MediaTypeFormatter formatter, string content, byte[] expectedData, string mediaType)
         {
             // Arrange
             MemoryStream memStream = new MemoryStream();

--- a/test/System.Net.Http.Formatting.Test/Formatting/MediaTypeFormatterTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/MediaTypeFormatterTests.cs
@@ -48,12 +48,12 @@ namespace System.Net.Http.Formatting
             MockMediaTypeFormatter formatter = new MockMediaTypeFormatter();
             Collection<MediaTypeHeaderValue> supportedMediaTypes = formatter.SupportedMediaTypes;
             Assert.NotNull(supportedMediaTypes);
-            Assert.Equal(0, supportedMediaTypes.Count);
+            Assert.Empty(supportedMediaTypes);
 #if !NETFX_CORE // No MediaTypeMapping support in portable libraries
             Collection<MediaTypeMapping> mappings = formatter.MediaTypeMappings;
 
             Assert.NotNull(mappings);
-            Assert.Equal(0, mappings.Count);
+            Assert.Empty(mappings);
 #endif
         }
 

--- a/test/System.Net.Http.Formatting.Test/Formatting/Parsers/FormUrlEncodedParserTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/Parsers/FormUrlEncodedParserTests.cs
@@ -113,7 +113,7 @@ namespace System.Net.Http.Formatting.Parsers
             ParserState state = parser.ParseBuffer(data, data.Length, ref bytesConsumed, true);
             Assert.Equal(ParserState.Done, state);
             Assert.Equal(data.Length, bytesConsumed);
-            Assert.Equal(0, collection.Count());
+            Assert.Empty(collection);
         }
 
         [Theory]

--- a/test/System.Net.Http.Formatting.Test/Formatting/Parsers/InternetMessageFormatHeaderParserTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/Parsers/InternetMessageFormatHeaderParserTests.cs
@@ -29,7 +29,7 @@ namespace System.Net.Http.Formatting.Parsers
 
             Assert.ThrowsArgumentGreaterThanOrEqualTo(() => new InternetMessageFormatHeaderParser(headers.ElementAt(0), ParserData.MinHeaderSize - 1),
                 "maxHeaderSize", ParserData.MinHeaderSize.ToString(), ParserData.MinHeaderSize - 1);
-            
+
             Assert.ThrowsArgumentNull(() => { new InternetMessageFormatHeaderParser(null, ParserData.MinHeaderSize); }, "headers");
         }
 
@@ -57,7 +57,7 @@ namespace System.Net.Http.Formatting.Parsers
             Assert.Equal(ParserState.Done, state);
             Assert.Equal(data.Length, bytesConsumed);
 
-            Assert.Equal(0, headers.Count());
+            Assert.Empty(headers);
         }
 
         [Fact]
@@ -76,10 +76,10 @@ namespace System.Net.Http.Formatting.Parsers
                 Assert.Equal(ParserState.Done, state);
                 Assert.Equal(data.Length, totalBytesConsumed);
 
-                Assert.Equal(1, headers.Count());
+                Assert.Single(headers);
                 IEnumerable<string> parsedValues = headers.GetValues("N");
-                Assert.Equal(1, parsedValues.Count());
-                Assert.Equal(parsedValues.ElementAt(0), "V");
+                string parsedValue = Assert.Single(parsedValues);
+                Assert.Equal("V", parsedValue);
             }
         }
 
@@ -99,10 +99,10 @@ namespace System.Net.Http.Formatting.Parsers
                 Assert.Equal(ParserState.Done, state);
                 Assert.Equal(data.Length, totalBytesConsumed);
 
-                Assert.Equal(1, headers.Count());
+                Assert.Single(headers);
                 IEnumerable<string> parsedValues = headers.GetValues("N");
-                Assert.Equal(1, parsedValues.Count());
-                Assert.Equal("", parsedValues.ElementAt(0));
+                string parsedValue = Assert.Single(parsedValues);
+                Assert.Equal("", parsedValue);
             }
         }
 
@@ -122,7 +122,7 @@ namespace System.Net.Http.Formatting.Parsers
                 Assert.Equal(ParserState.Done, state);
                 Assert.Equal(data.Length, totalBytesConsumed);
 
-                Assert.Equal(1, headers.Count());
+                Assert.Single(headers);
                 IEnumerable<string> parsedValues = headers.GetValues("N");
                 Assert.Equal(2, parsedValues.Count());
                 Assert.Equal("V1", parsedValues.ElementAt(0));
@@ -149,16 +149,16 @@ namespace System.Net.Http.Formatting.Parsers
                 Assert.Equal(3, headers.Count());
 
                 IEnumerable<string> parsedValues = headers.GetValues("N1");
-                Assert.Equal(1, parsedValues.Count());
-                Assert.Equal("V1", parsedValues.ElementAt(0));
+                string parsedValue = Assert.Single(parsedValues);
+                Assert.Equal("V1", parsedValue);
 
                 parsedValues = headers.GetValues("N2");
-                Assert.Equal(1, parsedValues.Count());
-                Assert.Equal("V2", parsedValues.ElementAt(0));
+                parsedValue = Assert.Single(parsedValues);
+                Assert.Equal("V2", parsedValue);
 
                 parsedValues = headers.GetValues("N3");
-                Assert.Equal(1, parsedValues.Count());
-                Assert.Equal("V3", parsedValues.ElementAt(0));
+                parsedValue = Assert.Single(parsedValues);
+                Assert.Equal("V3", parsedValue);
             }
         }
 
@@ -229,9 +229,9 @@ namespace System.Net.Http.Formatting.Parsers
                 Assert.Equal(ParserState.Done, state);
                 Assert.Equal(data.Length, totalBytesConsumed);
 
-                Assert.Equal(1, headers.Count());
+                Assert.Single(headers);
                 IEnumerable<string> parsedValues = headers.GetValues("N");
-                Assert.Equal(1, parsedValues.Count());
+                string parsedValue = Assert.Single(parsedValues);
                 Assert.Equal("V1, V2, V3,      V4, \tV5", parsedValues.ElementAt(0));
             }
         }
@@ -449,7 +449,7 @@ namespace System.Net.Http.Formatting.Parsers
                 });
         }
 
-        // Set of samples from RFC 5322 with times adjusted to GMT following HTTP style for date time format. 
+        // Set of samples from RFC 5322 with times adjusted to GMT following HTTP style for date time format.
         static readonly string[] Rfc5322Sample1 = new string[] {
             @"From: John Doe <jdoe@machine.example>",
             @"To: Mary Smith <mary@example.net>",

--- a/test/System.Net.Http.Formatting.Test/Formatting/Parsers/MimeMultipartParserTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/Parsers/MimeMultipartParserTests.cs
@@ -391,9 +391,8 @@ namespace System.Net.Http.Formatting.Parsers
             }
         }
 
-        [Theory]
-        [TestDataSet(typeof(MimeMultipartParserTests), "TrueAndFalse", typeof(MimeMultipartParserTests), "TrueAndFalse")]
-        public void MaxMessageSizeIsExact(bool withExtraWhitespace, bool withExtraCRLF)
+        [Fact]
+        public void MaxMessageSizeIsExact()
         {
             string boundary = "--A";
             byte[] data = CreateBuffer(boundary, "cool");
@@ -409,7 +408,7 @@ namespace System.Net.Http.Formatting.Parsers
                 Assert.Equal(data.Length, totalBytesConsumed);
 
                 Assert.Equal(2, bodyParts.Count);
-                Assert.Equal(0, bodyParts[0].Length);
+                Assert.Empty(bodyParts[0]);
             }
         }
 
@@ -440,9 +439,9 @@ namespace System.Net.Http.Formatting.Parsers
                 Assert.Equal(4, bodyParts.Count);
                 Assert.Empty(bodyParts[0]);
 
-                Assert.True(bodyParts[1].EndsWith("A"));
-                Assert.True(bodyParts[2].EndsWith("B"));
-                Assert.True(bodyParts[3].EndsWith("C"));
+                Assert.EndsWith("A", bodyParts[1]);
+                Assert.EndsWith("B", bodyParts[2]);
+                Assert.EndsWith("C", bodyParts[3]);
             }
         }
 

--- a/test/System.Net.Http.Formatting.Test/Formatting/QueryStringMappingTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/QueryStringMappingTests.cs
@@ -107,6 +107,7 @@ namespace System.Net.Http.Formatting
             typeof(CommonUnitTestDataSets), "EmptyStrings")]
         public void Constructor1ThrowsWithEmptyMediaType(string queryStringParameterName, string queryStringParameterValue, string mediaType)
         {
+            GC.KeepAlive(mediaType); // Mark parameter as used. See xUnit1026, [Theory] method doesn't use all parameters.
             Assert.ThrowsArgumentNull(() => new QueryStringMapping(queryStringParameterName, queryStringParameterValue, (MediaTypeHeaderValue)null), "mediaType");
         }
 

--- a/test/System.Net.Http.Formatting.Test/Formatting/RequestHeaderMappingTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/RequestHeaderMappingTests.cs
@@ -29,7 +29,7 @@ namespace System.Net.Http.Formatting
             Assert.Equal(headerName, mapping.HeaderName);
             Assert.Equal(headerValue, mapping.HeaderValue);
             Assert.Equal(StringComparison.CurrentCulture, mapping.HeaderValueComparison);
-            Assert.Equal(true, mapping.IsValueSubstring);
+            Assert.True(mapping.IsValueSubstring);
             Assert.MediaType.AreEqual(mediaType, mapping.MediaType, "MediaType failed to set.");
         }
 
@@ -83,7 +83,7 @@ namespace System.Net.Http.Formatting
             Assert.Equal(headerName, mapping.HeaderName);
             Assert.Equal(headerValue, mapping.HeaderValue);
             Assert.Equal(StringComparison.CurrentCulture, mapping.HeaderValueComparison);
-            Assert.Equal(true, mapping.IsValueSubstring);
+            Assert.True(mapping.IsValueSubstring);
             Assert.MediaType.AreEqual(mediaType, mapping.MediaType, "MediaType failed to set.");
         }
 

--- a/test/System.Net.Http.Formatting.Test/Formatting/XmlMediaTypeFormatterTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/XmlMediaTypeFormatterTests.cs
@@ -501,8 +501,6 @@ namespace System.Net.Http.Formatting
             Assert.Equal(String.Empty, readObj);
         }
 
-        [Theory]
-        [TestDataSet(typeof(HttpTestData), "ReadAndWriteCorrectCharacterEncoding")]
         public override Task ReadFromStreamAsync_UsesCorrectCharacterEncoding(string content, string encoding, bool isDefaultEncoding)
         {
             if (!isDefaultEncoding)
@@ -571,8 +569,6 @@ namespace System.Net.Http.Formatting
                 "The object of type 'JsonSerializer' returned by GetDeserializer must be an instance of either XmlObjectSerializer or XmlSerializer.");
         }
 
-        [Theory]
-        [TestDataSet(typeof(HttpTestData), "ReadAndWriteCorrectCharacterEncoding")]
         public override Task WriteToStreamAsync_UsesCorrectCharacterEncoding(string content, string encoding, bool isDefaultEncoding)
         {
             if (!isDefaultEncoding)

--- a/test/System.Net.Http.Formatting.Test/Formatting/XmlSerializerMediaTypeFormatterTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/XmlSerializerMediaTypeFormatterTests.cs
@@ -248,8 +248,6 @@ namespace System.Net.Http.Formatting
             Assert.Equal(testData, readObj);
         }
 
-        [Theory]
-        [TestDataSet(typeof(HttpTestData), "ReadAndWriteCorrectCharacterEncoding")]
         public override Task ReadFromStreamAsync_UsesCorrectCharacterEncoding(string content, string encoding, bool isDefaultEncoding)
         {
             if (!isDefaultEncoding)
@@ -274,8 +272,6 @@ namespace System.Net.Http.Formatting
             return ReadFromStreamAsync_UsesCorrectCharacterEncodingHelper(formatter, content, formattedContent, mediaType, encoding, isDefaultEncoding);
         }
 
-        [Theory]
-        [TestDataSet(typeof(HttpTestData), "ReadAndWriteCorrectCharacterEncoding")]
         public override Task WriteToStreamAsync_UsesCorrectCharacterEncoding(string content, string encoding, bool isDefaultEncoding)
         {
             if (!isDefaultEncoding)

--- a/test/System.Net.Http.Formatting.Test/FormattingUtilitiesTests.cs
+++ b/test/System.Net.Http.Formatting.Test/FormattingUtilitiesTests.cs
@@ -152,7 +152,7 @@ namespace System.Net.Http
         {
             HttpContentHeaders headers = FormattingUtilities.CreateEmptyContentHeaders();
             Assert.NotNull(headers);
-            Assert.Equal(0, headers.Count());
+            Assert.Empty(headers);
         }
 
         [Theory]

--- a/test/System.Net.Http.Formatting.Test/Headers/CookieHeaderValueTest.cs
+++ b/test/System.Net.Http.Formatting.Test/Headers/CookieHeaderValueTest.cs
@@ -51,6 +51,20 @@ namespace System.Net.Http.Headers
             }
         }
 
+        public static TheoryDataSet<string> CookieHeaderDataSet_NoCookie
+        {
+            get
+            {
+                var dataSet = new TheoryDataSet<string>();
+                foreach (var item in CookieHeaderDataSet)
+                {
+                    dataSet.Add((string)item[1]);
+                }
+
+                return dataSet;
+            }
+        }
+
         public static TheoryDataSet<string> InvalidCookieHeaderDataSet
         {
             get
@@ -68,9 +82,9 @@ namespace System.Net.Http.Headers
         public void CookieHeaderValue_Ctor1_InitializesCorrectly()
         {
             CookieHeaderValue header = new CookieHeaderValue("cookie", "value");
-            Assert.Equal(1, header.Cookies.Count);
-            Assert.Equal("cookie", header.Cookies[0].Name);
-            Assert.Equal("value", header.Cookies[0].Values.AllKeys[0]);
+            CookieState cookie = Assert.Single(header.Cookies);
+            Assert.Equal("cookie", cookie.Name);
+            Assert.Equal("value", cookie.Values.AllKeys[0]);
         }
 
         [Fact]
@@ -79,10 +93,10 @@ namespace System.Net.Http.Headers
             NameValueCollection nvc = new NameValueCollection();
             nvc.Add("name", "value");
             CookieHeaderValue header = new CookieHeaderValue("cookie", nvc);
-            Assert.Equal(1, header.Cookies.Count);
-            Assert.Equal("cookie", header.Cookies[0].Name);
-            Assert.Equal("name", header.Cookies[0].Values.AllKeys[0]);
-            Assert.Equal("value", header.Cookies[0].Values["name"]);
+            CookieState cookie = Assert.Single(header.Cookies);
+            Assert.Equal("cookie", cookie.Name);
+            Assert.Equal("name", cookie.Values.AllKeys[0]);
+            Assert.Equal("value", cookie.Values["name"]);
         }
 
         [Fact]
@@ -127,8 +141,8 @@ namespace System.Net.Http.Headers
         {
             CookieHeaderValue header = new CookieHeaderValue("cookie", "value");
 
+            Assert.Single(header.Cookies);
             CookieState state = header["cookie"];
-            Assert.Equal(1, header.Cookies.Count);
             Assert.Equal("value", state.Value);
         }
 
@@ -143,8 +157,8 @@ namespace System.Net.Http.Headers
         }
 
         [Theory]
-        [PropertyData("CookieHeaderDataSet")]
-        public void CookieHeaderValue_TryParse_AcceptsValidValues(CookieHeaderValue cookie, string expectedValue)
+        [PropertyData("CookieHeaderDataSet_NoCookie")]
+        public void CookieHeaderValue_TryParse_AcceptsValidValues(string expectedValue)
         {
             CookieHeaderValue header;
             bool result = CookieHeaderValue.TryParse(expectedValue, out header);

--- a/test/System.Net.Http.Formatting.Test/Headers/CookieStateTest.cs
+++ b/test/System.Net.Http.Formatting.Test/Headers/CookieStateTest.cs
@@ -88,7 +88,7 @@ namespace System.Net.Http.Headers
 
             // Assert
             Assert.Equal("name", cookie.Name);
-            Assert.Equal(1, cookie.Values.Count);
+            Assert.Single(cookie.Values);
             Assert.Equal("n1", cookie.Values.AllKeys[0]);
             Assert.Equal("v1", cookie.Values["n1"]);
             Assert.Equal("n1", cookie.Value);
@@ -163,7 +163,7 @@ namespace System.Net.Http.Headers
 
             // Assert
             Assert.Equal("name", actualValue.Name);
-            Assert.Equal(1, actualValue.Values.Count);
+            Assert.Single(actualValue.Values);
             Assert.Equal("n1", actualValue.Values.AllKeys[0]);
             Assert.Equal("v1", actualValue.Values["n1"]);
         }

--- a/test/System.Net.Http.Formatting.Test/HttpContentExtensionsTest.cs
+++ b/test/System.Net.Http.Formatting.Test/HttpContentExtensionsTest.cs
@@ -215,8 +215,8 @@ namespace System.Net.Http
                 .Returns<Type, Stream, HttpContent, IFormatterLogger>(async (type, stream, content, logger) =>
                     {
                         MultipartMemoryStreamProvider provider = await content.ReadAsMultipartAsync();
-                        Assert.Equal(1, provider.Contents.Count);
-                        return await provider.Contents[0].ReadAsStringAsync();
+                        HttpContent providerContent = Assert.Single(provider.Contents);
+                        return await providerContent.ReadAsStringAsync();
                     });
             MediaTypeFormatter formatter = _formatterMock.Object;
             formatter.SupportedMediaTypes.Add(new MediaTypeHeaderValue("multipart/mixed"));

--- a/test/System.Net.Http.Formatting.Test/HttpContentFormDataExtensionsTest.cs
+++ b/test/System.Net.Http.Formatting.Test/HttpContentFormDataExtensionsTest.cs
@@ -5,7 +5,6 @@ using System.Collections.Specialized;
 using System.Net.Http.Formatting;
 using System.Net.Http.Headers;
 using System.Text;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.TestCommon;
@@ -167,12 +166,8 @@ namespace System.Net.Http
             NameValueCollection data = await content.ReadAsFormDataAsync();
 
             // Assert
-            Assert.Equal(1, data.Count);
-#if NETFX_CORE
-            Assert.Equal(irregularFormData, data.First().Key);
-#else
-            Assert.Equal(irregularFormData, data.AllKeys[0]);
-#endif
+            Assert.Single(data);
+            Assert.NotNull(data[irregularFormData]);
         }
 
         [Fact]

--- a/test/System.Net.Http.Formatting.Test/HttpRequestHeadersExtensionsTest.cs
+++ b/test/System.Net.Http.Formatting.Test/HttpRequestHeadersExtensionsTest.cs
@@ -17,70 +17,70 @@ namespace System.Net.Http
                 // IEnumerable<string> inputCookies, string matchName, IEnumerable<string> expectedOuput
                 return new TheoryDataSet<string[], string, string[]>
                 {
-                    { 
-                        new string[] {}, 
-                        "empty", 
-                        new string[] {} 
+                    {
+                        new string[] {},
+                        "empty",
+                        new string[] {}
                     },
-                    { 
+                    {
                         new string[]
                         {
                             "RMID=2dab5fc9747d4f8edaf410ff",
                             "adxcs=-",
                             "adxcl=l*2ba62=4fc449bf:1",
                             "adxcs=si=0:1",
-                        }, 
-                        "nomatch", 
-                        new string[] {} 
+                        },
+                        "nomatch",
+                        new string[] {}
                     },
-                    { 
+                    {
                         new string[]
                         {
                             "RMID=2dab5fc9747d4f8edaf410ff",
                             "adxcs=-",
                             "adxcl=l*2ba62=4fc449bf:1",
                             "ADXCS=si=0:1",
-                        }, 
-                        "adxcs", 
-                        new string[] 
+                        },
+                        "adxcs",
+                        new string[]
                         {
                             "adxcs=-",
                             "ADXCS=si=0%3a1"
-                        } 
+                        }
                     },
-                    { 
+                    {
                         new string[]
                         {
                             "MC1=GUID=e87574286c55d547b5a0b19fb27d57a4&HASH=2874&LV=20124&V=3&LU=1334766376863; MS0=7bbaad2a8316483c89bbd2ca4e96fcea; A=I&I=AxUFAAAAAACSCAAAHFNnP3xE7Uth5BCZZSiqZQ!!",
                             "MC0=1334766377159; MC1=GUID=e87574286c55d547b5a0b19fb27d57a4&HASH=2874&LV=20124&V=3&LU=1334766376863; MS0=7bbaad2a8316483c89bbd2ca4e96fcea; A=I&I=AxUFAAAAAACSCAAAHFNnP3xE7Uth5BCZZSiqZQ!!; MUID=20EC57A324256BF3039D54E520256B7D&TUID=1",
-                        }, 
-                        "A", 
+                        },
+                        "A",
                         new string[]
                         {
                             "MC1=GUID=e87574286c55d547b5a0b19fb27d57a4&HASH=2874&LV=20124&V=3&LU=1334766376863; MS0=7bbaad2a8316483c89bbd2ca4e96fcea; A=I&I=AxUFAAAAAACSCAAAHFNnP3xE7Uth5BCZZSiqZQ!!",
                             "MC0=1334766377159; MC1=GUID=e87574286c55d547b5a0b19fb27d57a4&HASH=2874&LV=20124&V=3&LU=1334766376863; MS0=7bbaad2a8316483c89bbd2ca4e96fcea; A=I&I=AxUFAAAAAACSCAAAHFNnP3xE7Uth5BCZZSiqZQ!!; MUID=20EC57A324256BF3039D54E520256B7D&TUID=1",
-                        } 
+                        }
                     },
-                    { 
+                    {
                         new string[]
                         {
                             "MC1=GUID=e87574286c55d547b5a0b19fb27d57a4&HASH=2874&LV=20124&V=3&LU=1334766376863; MS0=7bbaad2a8316483c89bbd2ca4e96fcea; A=I&I=AxUFAAAAAACSCAAAHFNnP3xE7Uth5BCZZSiqZQ!!",
                             "MC0=1334766377159; MC1=GUID=e87574286c55d547b5a0b19fb27d57a4&HASH=2874&LV=20124&V=3&LU=1334766376863; MS0=7bbaad2a8316483c89bbd2ca4e96fcea; A=I&I=AxUFAAAAAACSCAAAHFNnP3xE7Uth5BCZZSiqZQ!!; MUID=20EC57A324256BF3039D54E520256B7D&TUID=1",
-                        }, 
-                        "MC0", 
+                        },
+                        "MC0",
                         new string[]
                         {
                             "MC0=1334766377159; MC1=GUID=e87574286c55d547b5a0b19fb27d57a4&HASH=2874&LV=20124&V=3&LU=1334766376863; MS0=7bbaad2a8316483c89bbd2ca4e96fcea; A=I&I=AxUFAAAAAACSCAAAHFNnP3xE7Uth5BCZZSiqZQ!!; MUID=20EC57A324256BF3039D54E520256B7D&TUID=1",
-                        } 
+                        }
                     },
-                    { 
+                    {
                         new string[]
                         {
                             "MC1=GUID=e87574286c55d547b5a0b19fb27d57a4&HASH=2874&LV=20124&V=3&LU=1334766376863; MS0=7bbaad2a8316483c89bbd2ca4e96fcea; A=I&I=AxUFAAAAAACSCAAAHFNnP3xE7Uth5BCZZSiqZQ!!",
                             "MC0=1334766377159; MC1=GUID=e87574286c55d547b5a0b19fb27d57a4&HASH=2874&LV=20124&V=3&LU=1334766376863; MS0=7bbaad2a8316483c89bbd2ca4e96fcea; A=I&I=AxUFAAAAAACSCAAAHFNnP3xE7Uth5BCZZSiqZQ!!; MUID=20EC57A324256BF3039D54E520256B7D&TUID=1",
-                        }, 
-                        "MC", 
-                        new string[] { } 
+                        },
+                        "MC",
+                        new string[] { }
                     },
                 };
             }
@@ -102,7 +102,7 @@ namespace System.Net.Http
             IEnumerable<CookieHeaderValue> cookies = headers.GetCookies();
 
             // Assert
-            Assert.Equal(0, cookies.Count());
+            Assert.Empty(cookies);
         }
 
         [Theory]
@@ -117,8 +117,8 @@ namespace System.Net.Http
             IEnumerable<CookieHeaderValue> cookies = headers.GetCookies();
 
             // Assert
-            Assert.Equal(1, cookies.Count());
-            string actualCookie = cookies.ElementAt(0).ToString();
+            CookieHeaderValue cookie = Assert.Single(cookies);
+            string actualCookie = cookie.ToString();
             Assert.Equal(expectedCookie, actualCookie);
         }
 

--- a/test/System.Net.Http.Formatting.Test/HttpResponseHeadersExtensionsTest.cs
+++ b/test/System.Net.Http.Formatting.Test/HttpResponseHeadersExtensionsTest.cs
@@ -49,8 +49,8 @@ namespace System.Net.Http
             IEnumerable<string> actualCookies;
             bool addedCorrectly = headers.TryGetValues("Set-Cookie", out actualCookies);
             Assert.True(addedCorrectly);
-            Assert.Equal(1, actualCookies.Count());
-            Assert.Equal(expectedCookie, actualCookies.ElementAt(0));
+            string actualCookie = Assert.Single(actualCookies);
+            Assert.Equal(expectedCookie, actualCookie);
         }
 
         private static HttpResponseHeaders CreateHttpResponseHeaders()

--- a/test/System.Net.Http.Formatting.Test/Internal/HttpValueCollectionTest.cs
+++ b/test/System.Net.Http.Formatting.Test/Internal/HttpValueCollectionTest.cs
@@ -143,7 +143,7 @@ namespace System.Net.Http.Internal
             var nvc = CreateInstance();
 
             Assert.IsType<HttpValueCollection>(nvc);
-            Assert.Equal(0, nvc.Count);
+            Assert.Empty(nvc);
         }
 
         // This set of tests requires running on a separate appdomain so we don't

--- a/test/System.Net.Http.Formatting.Test/MultipartFormDataRemoteStreamProviderTests.cs
+++ b/test/System.Net.Http.Formatting.Test/MultipartFormDataRemoteStreamProviderTests.cs
@@ -63,12 +63,12 @@ namespace System.Net.Http
                 Assert.IsType<MemoryStream>(stream0);
                 Assert.Single(provider.RemoteStreams, stream1);
 
-                Assert.Equal(1, provider.FileData.Count);
+                MultipartRemoteFileData fileData = Assert.Single(provider.FileData);
                 string expectedUrl = provider.UrlBase + "Filename";
-                Assert.Equal(expectedUrl, provider.FileData[0].Location);
+                Assert.Equal(expectedUrl, fileData.Location);
 
                 Assert.Same(content.ElementAt(1).Headers.ContentDisposition,
-                    provider.FileData[0].Headers.ContentDisposition);
+                    fileData.Headers.ContentDisposition);
             }
             finally
             {

--- a/test/System.Net.Http.Formatting.Test/MultipartFormDataStreamProviderTests.cs
+++ b/test/System.Net.Http.Formatting.Test/MultipartFormDataStreamProviderTests.cs
@@ -70,11 +70,11 @@ namespace System.Net.Http
                 Assert.IsType<MemoryStream>(stream0);
                 Assert.IsType<FileStream>(stream1);
 
-                Assert.Equal(1, provider.FileData.Count);
+                MultipartFileData fileData = Assert.Single(provider.FileData);
                 string partialFileName = String.Format("{0}BodyPart_", tempPath);
-                Assert.Contains(partialFileName, provider.FileData[0].LocalFileName);
+                Assert.Contains(partialFileName, fileData.LocalFileName);
 
-                Assert.Same(content.ElementAt(1).Headers.ContentDisposition, provider.FileData[0].Headers.ContentDisposition);
+                Assert.Same(content.ElementAt(1).Headers.ContentDisposition, fileData.Headers.ContentDisposition);
             }
             finally
             {

--- a/test/System.Net.Http.Formatting.Test/System.Net.Http.Formatting.Test.csproj
+++ b/test/System.Net.Http.Formatting.Test/System.Net.Http.Formatting.Test.csproj
@@ -185,6 +185,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/System.Net.Http.Formatting.Test/packages.config
+++ b/test/System.Net.Http.Formatting.Test/packages.config
@@ -3,7 +3,9 @@
   <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />

--- a/test/System.Web.Cors.Test/CorsEngineTest.cs
+++ b/test/System.Web.Cors.Test/CorsEngineTest.cs
@@ -395,7 +395,7 @@ namespace System.Web.Cors.Test
             CorsResult result = corsEngine.EvaluatePolicy(requestContext, policy);
 
             Assert.True(requestContext.IsPreflight);
-            Assert.Equal(1, result.AllowedMethods.Count());
+            Assert.Single(result.AllowedMethods);
             Assert.Contains("PUT", result.AllowedMethods);
         }
 

--- a/test/System.Web.Cors.Test/System.Web.Cors.Test.csproj
+++ b/test/System.Web.Cors.Test/System.Web.Cors.Test.csproj
@@ -67,6 +67,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/System.Web.Cors.Test/packages.config
+++ b/test/System.Web.Cors.Test/packages.config
@@ -2,7 +2,9 @@
 <packages>
   <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
+  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />


### PR DESCRIPTION
- part of #65
- do not use `xunit.core` package in Microsoft.TestCommon
- improve `TestData` behavior when tests sharing dataset properties run in parallel

Manual changes:
- use `Assert.IsAssignableFrom<T>(...)`, `Assert.IsType<T>(...)` and `Assert.Single(...)` return values
- work around xUnit1013, Public method should be marked as test
  - move duplicated `[Theory]` and `[TestDataSet(...)]` attributes down to `abstract` methods
  - add suppression due to xnuit/xunit#1466
- work around xUnit1026, `[Theory]` method doesn't use all parameters
  - add new data sets or `GC.KeepAlive(...)`
- reset `OAuthWebSecurity.OAuthDataProvider` after use in two tests