### PR TITLE
Add xUnit analyzers and take fixer suggestions (2 of 5): System.Web.Helpers.Test to System.Web.Http.SignalR.Test

### DIFF
--- a/test/System.Web.Helpers.Test/ChartTest.cs
+++ b/test/System.Web.Helpers.Test/ChartTest.cs
@@ -26,8 +26,8 @@ namespace System.Web.Helpers.Test
             var chart = new Chart(GetContext(), GetVirtualPathProvider(), 100, 100);
             AssertBuiltChartAction(chart, c =>
             {
-                Assert.Equal(1, c.ChartAreas.Count);
-                Assert.Equal("Default", c.ChartAreas[0].Name);
+                ChartArea chartArea = Assert.Single(c.ChartAreas);
+                Assert.Equal("Default", chartArea.Name);
             });
         }
 
@@ -38,10 +38,10 @@ namespace System.Web.Helpers.Test
                 .SetXAxis("AxisX", 1, 100);
             AssertBuiltChartAction(chart, c =>
             {
-                Assert.Equal(1, c.ChartAreas.Count);
-                Assert.Equal("AxisX", c.ChartAreas[0].AxisX.Title);
-                Assert.Equal(1, c.ChartAreas[0].AxisX.Minimum);
-                Assert.Equal(100, c.ChartAreas[0].AxisX.Maximum);
+                ChartArea chartArea = Assert.Single(c.ChartAreas);
+                Assert.Equal("AxisX", chartArea.AxisX.Title);
+                Assert.Equal(1, chartArea.AxisX.Minimum);
+                Assert.Equal(100, chartArea.AxisX.Maximum);
             });
         }
 
@@ -52,10 +52,10 @@ namespace System.Web.Helpers.Test
                 .SetYAxis("AxisY", 1, 100);
             AssertBuiltChartAction(chart, c =>
             {
-                Assert.Equal(1, c.ChartAreas.Count);
-                Assert.Equal("AxisY", c.ChartAreas[0].AxisY.Title);
-                Assert.Equal(1, c.ChartAreas[0].AxisY.Minimum);
-                Assert.Equal(100, c.ChartAreas[0].AxisY.Maximum);
+                ChartArea chartArea = Assert.Single(c.ChartAreas);
+                Assert.Equal("AxisY", chartArea.AxisY.Title);
+                Assert.Equal(1, chartArea.AxisY.Minimum);
+                Assert.Equal(100, chartArea.AxisY.Maximum);
             });
         }
 
@@ -71,7 +71,7 @@ namespace System.Web.Helpers.Test
         public void ConstructorLoadsTheme()
         {
             //Vanilla theme
-            /* 
+            /*
              * <Chart Palette="SemiTransparent" BorderColor="#000" BorderWidth="2" BorderlineDashStyle="Solid">
                 <ChartAreas>
                     <ChartArea _Template_="All" Name="Default">
@@ -90,11 +90,11 @@ namespace System.Web.Helpers.Test
             var chart = new Chart(GetContext(), GetVirtualPathProvider(), 100, 100, theme: ChartTheme.Vanilla);
             AssertBuiltChartAction(chart, c =>
             {
-                Assert.Equal(c.Palette, ChartColorPalette.SemiTransparent);
+                Assert.Equal(ChartColorPalette.SemiTransparent, c.Palette);
                 Assert.Equal(c.BorderColor, Color.FromArgb(0, Color.Black));
-                Assert.Equal(1, c.ChartAreas.Count);
-                Assert.False(c.ChartAreas[0].AxisX.MajorGrid.Enabled);
-                Assert.False(c.ChartAreas[0].AxisY.MinorGrid.Enabled);
+                ChartArea chartArea = Assert.Single(c.ChartAreas);
+                Assert.False(chartArea.AxisX.MajorGrid.Enabled);
+                Assert.False(chartArea.AxisY.MinorGrid.Enabled);
             });
         }
 
@@ -102,7 +102,7 @@ namespace System.Web.Helpers.Test
         public void ConstructorLoadsThemeAndTemplate()
         {
             //Vanilla theme
-            /* 
+            /*
              * <Chart Palette="SemiTransparent" BorderColor="#000" BorderWidth="2" BorderlineDashStyle="Solid">
                 <ChartAreas>
                     <ChartArea _Template_="All" Name="Default">
@@ -122,14 +122,14 @@ namespace System.Web.Helpers.Test
             var chart = new Chart(GetContext(), GetVirtualPathProvider(), 100, 100, theme: ChartTheme.Vanilla, themePath: template);
             AssertBuiltChartAction(chart, c =>
             {
-                Assert.Equal(c.Palette, ChartColorPalette.SemiTransparent);
+                Assert.Equal(ChartColorPalette.SemiTransparent, c.Palette);
                 Assert.Equal(c.BorderColor, Color.FromArgb(0, Color.Black));
-                Assert.Equal(c.BorderlineDashStyle, ChartDashStyle.DashDot);
-                Assert.Equal(1, c.ChartAreas.Count);
-                Assert.Equal(c.Legends.Count, 1);
-                Assert.Equal(c.Legends[0].BackColor, Color.Red);
-                Assert.False(c.ChartAreas[0].AxisX.MajorGrid.Enabled);
-                Assert.False(c.ChartAreas[0].AxisY.MinorGrid.Enabled);
+                Assert.Equal(ChartDashStyle.DashDot, c.BorderlineDashStyle);
+                Legend legend = Assert.Single(c.Legends);
+                Assert.Equal(legend.BackColor, Color.Red);
+                ChartArea chartArea = Assert.Single(c.ChartAreas);
+                Assert.False(chartArea.AxisX.MajorGrid.Enabled);
+                Assert.False(chartArea.AxisY.MinorGrid.Enabled);
             });
         }
 
@@ -155,14 +155,14 @@ namespace System.Web.Helpers.Test
             // Assert
             AssertBuiltChartAction(chart, c =>
             {
-                Assert.Equal(c.Palette, ChartColorPalette.SemiTransparent);
+                Assert.Equal(ChartColorPalette.SemiTransparent, c.Palette);
                 Assert.Equal(c.BorderColor, Color.FromArgb(0, Color.Black));
-                Assert.Equal(c.BorderlineDashStyle, ChartDashStyle.DashDot);
-                Assert.Equal(1, c.ChartAreas.Count);
-                Assert.Equal(c.Legends.Count, 1);
-                Assert.Equal(c.Legends[0].BackColor, Color.Red);
-                Assert.False(c.ChartAreas[0].AxisX.MajorGrid.Enabled);
-                Assert.False(c.ChartAreas[0].AxisY.MinorGrid.Enabled);
+                Assert.Equal(ChartDashStyle.DashDot, c.BorderlineDashStyle);
+                Legend legend = Assert.Single(c.Legends);
+                Assert.Equal(legend.BackColor, Color.Red);
+                ChartArea chartArea = Assert.Single(c.ChartAreas);
+                Assert.False(chartArea.AxisX.MajorGrid.Enabled);
+                Assert.False(chartArea.AxisY.MinorGrid.Enabled);
             });
 
             Assert.Equal(1, provider1.FileExistsCalls);
@@ -221,7 +221,7 @@ namespace System.Web.Helpers.Test
             {
                 Assert.Equal(2, c.Series.Count);
                 Assert.Equal(2, c.Series[0].Points.Count);
-                Assert.Equal(1, c.Series[1].Points.Count);
+                Assert.Single(c.Series[1].Points);
             });
         }
 
@@ -281,8 +281,8 @@ namespace System.Web.Helpers.Test
             // todo - anything else to verify here?
             AssertBuiltChartAction(chart, c =>
             {
-                Assert.Equal(1, c.Series.Count);
-                Assert.Equal(3, c.Series[0].Points.Count);
+                var series = Assert.Single(c.Series);
+                Assert.Equal(3, series.Points.Count);
             });
         }
 
@@ -300,8 +300,8 @@ namespace System.Web.Helpers.Test
             // todo - anything else to verify here?
             AssertBuiltChartAction(chart, c =>
             {
-                Assert.Equal(1, c.Series.Count);
-                Assert.Equal(3, c.Series[0].Points.Count);
+                var series = Assert.Single(c.Series);
+                Assert.Equal(3, series.Points.Count);
             });
         }
 
@@ -353,10 +353,10 @@ namespace System.Web.Helpers.Test
             var chart = new Chart(GetContext(), GetVirtualPathProvider(), 100, 100).AddLegend();
             AssertBuiltChartAction(chart, c =>
             {
-                Assert.Equal(1, c.Legends.Count);
+                Legend legend = Assert.Single(c.Legends);
                 // NOTE: Chart.Legends.Add will create default name
-                Assert.Equal("Legend1", c.Legends[0].Name);
-                Assert.Equal(1, c.Legends[0].BorderWidth);
+                Assert.Equal("Legend1", legend.Name);
+                Assert.Equal(1, legend.BorderWidth);
             });
         }
 
@@ -474,7 +474,7 @@ namespace System.Web.Helpers.Test
             chart.SaveXml(GetContext(), "SaveXmlWritesToFile.xml");
             Assert.True(File.Exists("SaveXmlWritesToFile.xml"));
             string result = File.ReadAllText("SaveXmlWritesToFile.xml");
-            Assert.True(result.Contains("BorderWidth=\"2\""));
+            Assert.Contains("BorderWidth=\"2\"", result);
         }
 
         [Fact]
@@ -531,8 +531,8 @@ namespace System.Web.Helpers.Test
                 .AddSeries(chartType: "Bar");
             AssertBuiltChartAction(chart, c =>
             {
-                Assert.Equal(1, c.Series.Count);
-                Assert.Equal(SeriesChartType.Bar, c.Series[0].ChartType);
+                var series = Assert.Single(c.Series);
+                Assert.Equal(SeriesChartType.Bar, series.ChartType);
             });
         }
 
@@ -556,11 +556,11 @@ namespace System.Web.Helpers.Test
             var chart = new Chart(GetContext(), GetVirtualPathProvider(), 100, 100).AddTitle();
             AssertBuiltChartAction(chart, c =>
             {
-                Assert.Equal(1, c.Titles.Count);
+                var title = Assert.Single(c.Titles);
                 // NOTE: Chart.Titles.Add will create default name
-                Assert.Equal("Title1", c.Titles[0].Name);
-                Assert.Equal(String.Empty, c.Titles[0].Text);
-                Assert.Equal(1, c.Titles[0].BorderWidth);
+                Assert.Equal("Title1", title.Name);
+                Assert.Equal(String.Empty, title.Text);
+                Assert.Equal(1, title.BorderWidth);
             });
         }
 

--- a/test/System.Web.Helpers.Test/DynamicHelperTest.cs
+++ b/test/System.Web.Helpers.Test/DynamicHelperTest.cs
@@ -21,7 +21,7 @@ namespace System.Web.Helpers.Test
             bool result = DynamicHelper.TryGetMemberValue(dynamic, mockMemberBinder, out value);
 
             // Assert
-            Assert.Equal(value, "Bar");
+            Assert.Equal("Bar", value);
         }
 
         private class MockMemberBinder : GetMemberBinder

--- a/test/System.Web.Helpers.Test/ObjectInfoTest.cs
+++ b/test/System.Web.Helpers.Test/ObjectInfoTest.cs
@@ -37,8 +37,8 @@ namespace System.Web.Helpers.Test
             visitor.Print(null);
 
             // Assert
-            Assert.Equal(1, visitor.Values.Count);
-            Assert.Equal("null", visitor.Values[0]);
+            string value = Assert.Single(visitor.Values);
+            Assert.Equal("null", value);
         }
 
         [Fact]
@@ -51,8 +51,8 @@ namespace System.Web.Helpers.Test
             visitor.Print(String.Empty);
 
             // Assert
-            Assert.Equal(1, visitor.Values.Count);
-            Assert.Equal(String.Empty, visitor.Values[0]);
+            string value = Assert.Single(visitor.Values);
+            Assert.Equal(String.Empty, value);
         }
 
         [Fact]
@@ -65,8 +65,8 @@ namespace System.Web.Helpers.Test
             visitor.Print(404);
 
             // Assert
-            Assert.Equal(1, visitor.Values.Count);
-            Assert.Equal("404", visitor.Values[0]);
+            string value = Assert.Single(visitor.Values);
+            Assert.Equal("404", value);
         }
 
         [Fact]
@@ -99,7 +99,7 @@ namespace System.Web.Helpers.Test
             // Assert
             foreach (var num in values)
             {
-                Assert.True(visitor.Values.Contains(num.ToString()));
+                Assert.Contains(num.ToString(), visitor.Values);
             }
         }
 
@@ -116,8 +116,8 @@ namespace System.Web.Helpers.Test
             // Assert
             for (int i = 0; i < values.Count; i++)
             {
-                Assert.True(visitor.Values.Contains(values[i].ToString()));
-                Assert.True(visitor.Indexes.Contains(i));
+                Assert.Contains(values[i].ToString(), visitor.Values);
+                Assert.Contains(i, visitor.Indexes);
             }
         }
 
@@ -134,8 +134,8 @@ namespace System.Web.Helpers.Test
             // Assert
             for (int i = 0; i < values.Length; i++)
             {
-                Assert.True(visitor.Values.Contains(values[i].ToString()));
-                Assert.True(visitor.Indexes.Contains(i));
+                Assert.Contains(values[i].ToString(), visitor.Values);
+                Assert.Contains(i, visitor.Indexes);
             }
         }
 
@@ -148,7 +148,7 @@ namespace System.Web.Helpers.Test
             values["a"] = "1";
             values["b"] = null;
 
-            // Act            
+            // Act
             visitor.Print(values);
 
             // Assert
@@ -165,7 +165,7 @@ namespace System.Web.Helpers.Test
                 MockObjectVisitor visitor = CreateObjectVisitor();
                 var dt = new DateTime(2001, 11, 20, 10, 30, 1);
 
-                // Act            
+                // Act
                 visitor.Print(dt);
 
                 // Assert
@@ -189,19 +189,19 @@ namespace System.Web.Helpers.Test
 
             using (new CultureReplacer("en-US"))
             {
-                // Act            
+                // Act
                 visitor.Print(person);
 
                 // Assert
                 Assert.Equal(9, visitor.Members.Count);
-                Assert.True(visitor.Members.Contains("double Age = 23.3"));
-                Assert.True(visitor.Members.Contains("string Name = David"));
-                Assert.True(visitor.Members.Contains("DateTime Dob = 11/19/1986 12:00:00 AM"));
-                Assert.True(visitor.Members.Contains("short Type = 1"));
-                Assert.True(visitor.Members.Contains("float Float = 0"));
-                Assert.True(visitor.Members.Contains("byte Byte = 0"));
-                Assert.True(visitor.Members.Contains("decimal Decimal = 0"));
-                Assert.True(visitor.Members.Contains("bool Bool = False"));
+                Assert.Contains("double Age = 23.3", visitor.Members);
+                Assert.Contains("string Name = David", visitor.Members);
+                Assert.Contains("DateTime Dob = 11/19/1986 12:00:00 AM", visitor.Members);
+                Assert.Contains("short Type = 1", visitor.Members);
+                Assert.Contains("float Float = 0", visitor.Members);
+                Assert.Contains("byte Byte = 0", visitor.Members);
+                Assert.Contains("decimal Decimal = 0", visitor.Members);
+                Assert.Contains("bool Bool = False", visitor.Members);
             }
         }
 
@@ -223,10 +223,10 @@ namespace System.Web.Helpers.Test
             // Act
             visitor.Print(node);
 
-            // Assert            
-            Assert.True(visitor.Members.Contains("string Name = David"));
-            Assert.True(visitor.Members.Contains(String.Format("double Age = {0}", 23.3)));
-            Assert.True(visitor.Members.Contains("PersonNode Next = Visited"));
+            // Assert
+            Assert.Contains("string Name = David", visitor.Members);
+            Assert.Contains(String.Format("double Age = {0}", 23.3), visitor.Members);
+            Assert.Contains("PersonNode Next = Visited", visitor.Members);
         }
 
         [Fact]
@@ -240,7 +240,7 @@ namespace System.Web.Helpers.Test
             // Act
             visitor.Print(values);
 
-            // Assert            
+            // Assert
             Assert.Equal("Visited", visitor.Values[0]);
             Assert.Equal("Visited " + values.GetHashCode(), visitor.Visited[0]);
         }
@@ -256,7 +256,7 @@ namespace System.Web.Helpers.Test
             // Act
             visitor.Print(values);
 
-            // Assert            
+            // Assert
             Assert.Equal("Visited", visitor.Values[0]);
             Assert.Equal("Visited " + values.GetHashCode(), visitor.Visited[0]);
         }
@@ -275,9 +275,9 @@ namespace System.Web.Helpers.Test
             // Act
             visitor.Print(values);
 
-            // Assert            
-            Assert.True(visitor.Values.Contains("Visited"));
-            Assert.True(visitor.Visited.Contains("Visited " + nameValues.GetHashCode()));
+            // Assert
+            Assert.Contains("Visited", visitor.Values);
+            Assert.Contains("Visited " + nameValues.GetHashCode(), visitor.Visited);
         }
 
         [Fact]
@@ -291,7 +291,7 @@ namespace System.Web.Helpers.Test
             visitor.Print(cls);
 
             // Assert
-            Assert.Equal(0, visitor.Members.Count);
+            Assert.Empty(visitor.Members);
         }
 
         [Fact]
@@ -309,14 +309,14 @@ namespace System.Web.Helpers.Test
             {
                 if (i < 1000)
                 {
-                    Assert.True(visitor.Values.Contains(i.ToString()));
+                    Assert.Contains(i.ToString(), visitor.Values);
                 }
                 else
                 {
-                    Assert.False(visitor.Values.Contains(i.ToString()));
+                    Assert.DoesNotContain(i.ToString(), visitor.Values);
                 }
             }
-            Assert.True(visitor.Values.Contains("Limit Exceeded"));
+            Assert.Contains("Limit Exceeded", visitor.Values);
         }
 
         [Fact]
@@ -330,8 +330,8 @@ namespace System.Web.Helpers.Test
             visitor.Print(value);
 
             // Assert
-            Assert.True(visitor.Members.Contains("string Name = John"));
-            Assert.True(visitor.Members.Contains("int X = 1"));
+            Assert.Contains("string Name = John", visitor.Members);
+            Assert.Contains("int X = 1", visitor.Members);
         }
 
         [Fact]
@@ -346,9 +346,9 @@ namespace System.Web.Helpers.Test
             // Actt
             visitor.Print(value);
 
-            // Assert            
-            Assert.True(visitor.Members.Contains("string Foo = John"));
-            Assert.True(visitor.Members.Contains("int Bar = 1"));
+            // Assert
+            Assert.Contains("string Foo = John", visitor.Members);
+            Assert.Contains("int Bar = 1", visitor.Members);
         }
 
         [Fact]
@@ -364,10 +364,10 @@ namespace System.Web.Helpers.Test
             // Act
             visitor.Print(d);
 
-            // Assert                                   
-            Assert.True(visitor.Members.Contains("DynamicDictionary Cycle = Visited"));
-            Assert.True(visitor.Members.Contains("string Name = Foo"));
-            Assert.True(visitor.Members.Contains("Value = null"));
+            // Assert
+            Assert.Contains("DynamicDictionary Cycle = Visited", visitor.Members);
+            Assert.Contains("string Name = Foo", visitor.Members);
+            Assert.Contains("Value = null", visitor.Members);
         }
 
         [Fact]
@@ -383,7 +383,7 @@ namespace System.Web.Helpers.Test
             // Act
             visitor.Print(d);
 
-            // Assert                                   
+            // Assert
             Assert.False(visitor.Members.Any());
         }
 
@@ -425,7 +425,7 @@ namespace System.Web.Helpers.Test
             // Act
             visitor.Print(value);
 
-            // Assert            
+            // Assert
             Assert.Equal("int MyProperty = Property accessor 'MyProperty' on object 'System.Web.Helpers.Test.ObjectInfoTest+ClassWithPropertyThatThrowsException' threw the following exception:'Property that shows an exception'", visitor.Members[0]);
         }
 
@@ -457,7 +457,7 @@ namespace System.Web.Helpers.Test
             HtmlElement element = new HtmlElement("span");
             printer.PushElement(element);
 
-            // Act            
+            // Act
             printer.VisitConvertedValue('x', "x");
 
             // Assert
@@ -475,7 +475,7 @@ namespace System.Web.Helpers.Test
             HtmlElement element = new HtmlElement("span");
             printer.PushElement(element);
 
-            // Act            
+            // Act
             printer.VisitConvertedValue('\t', "\t");
 
             // Assert

--- a/test/System.Web.Helpers.Test/PreComputedGridDataSourceTest.cs
+++ b/test/System.Web.Helpers.Test/PreComputedGridDataSourceTest.cs
@@ -27,13 +27,13 @@ namespace System.Web.Helpers.Test
             var grid = new WebGrid(GetContext());
             var dataSource = new PreComputedGridDataSource(grid: grid, values: Enumerable.Range(0, 10).Cast<dynamic>(), totalRows: 10);
 
-            // Act 
+            // Act
             var rows = dataSource.GetRows(new SortInfo { SortColumn = String.Empty }, 0);
 
             // Assert
-            Assert.Equal(rows.Count, 10);
-            Assert.Equal(rows.First().Value, 0);
-            Assert.Equal(rows.Last().Value, 9);
+            Assert.Equal(10, rows.Count);
+            Assert.Equal(0, rows.First().Value);
+            Assert.Equal(9, rows.Last().Value);
         }
 
         private HttpContextBase GetContext()

--- a/test/System.Web.Helpers.Test/ServerInfoTest.cs
+++ b/test/System.Web.Helpers.Test/ServerInfoTest.cs
@@ -111,7 +111,7 @@ namespace System.Web.Helpers.Test
 
                 // Assert
                 Assert.True(configValue.ContainsKey("Legacy Code Access Security"));
-                Assert.Equal(configValue["Legacy Code Access Security"], "Legacy Code Access Security has been detected on your system. Microsoft WebPage features require the ASP.NET 4 Code Access Security model. For information about how to resolve this, contact your server administrator.");
+                Assert.Equal("Legacy Code Access Security has been detected on your system. Microsoft WebPage features require the ASP.NET 4 Code Access Security model. For information about how to resolve this, contact your server administrator.", configValue["Legacy Code Access Security"]);
             };
 
             AppDomainUtils.RunInSeparateAppDomain(GetAppDomainSetup(legacyCasEnabled: true), action);

--- a/test/System.Web.Helpers.Test/System.Web.Helpers.Test.csproj
+++ b/test/System.Web.Helpers.Test/System.Web.Helpers.Test.csproj
@@ -93,6 +93,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/System.Web.Helpers.Test/WebGridDataSourceTest.cs
+++ b/test/System.Web.Helpers.Test/WebGridDataSourceTest.cs
@@ -196,7 +196,7 @@ namespace System.Web.Helpers.Test
             var rows = dataSource.GetRows(new SortInfo(), 0);
 
             // Assert
-            Assert.Equal(rows.Count, 2);
+            Assert.Equal(2, rows.Count);
             Assert.Equal(rows.ElementAt(0).Value.LastName, "B2");
             Assert.Equal(rows.ElementAt(1).Value.LastName, "A2");
         }
@@ -212,7 +212,7 @@ namespace System.Web.Helpers.Test
             var rows = dataSource.GetRows(new SortInfo { SortColumn = "LastName", SortDirection = SortDirection.Descending }, 0);
 
             // Assert
-            Assert.Equal(rows.Count, 2);
+            Assert.Equal(2, rows.Count);
             Assert.Equal(rows.ElementAt(0).Value.LastName, "E2");
             Assert.Equal(rows.ElementAt(1).Value.LastName, "D2");
         }
@@ -228,7 +228,7 @@ namespace System.Web.Helpers.Test
             var rows = dataSource.GetRows(new SortInfo(), 1);
 
             // Assert
-            Assert.Equal(rows.Count, 2);
+            Assert.Equal(2, rows.Count);
             Assert.Equal(rows.ElementAt(0).Value.LastName, "C2");
             Assert.Equal(rows.ElementAt(1).Value.LastName, "E2");
         }
@@ -244,7 +244,7 @@ namespace System.Web.Helpers.Test
             var rows = dataSource.GetRows(new SortInfo(), 0);
 
             // Assert
-            Assert.Equal(rows.Count, 2);
+            Assert.Equal(2, rows.Count);
             Assert.Equal(rows.ElementAt(0).Value, String.Empty);
             Assert.Null(rows.ElementAt(1).Value);
         }

--- a/test/System.Web.Helpers.Test/WebGridTest.cs
+++ b/test/System.Web.Helpers.Test/WebGridTest.cs
@@ -22,11 +22,11 @@ namespace System.Web.Helpers.Test
             var grid = new WebGrid(GetContext(), ajaxUpdateContainerId: "grid")
                 .Bind(new[] { new { First = "First", Second = "Second" } });
             string html = grid.Table().ToString();
-            Assert.True(html.Contains("<script"));
+            Assert.Contains("<script", html);
             html = grid.Table().ToString();
-            Assert.False(html.Contains("<script"));
+            Assert.DoesNotContain("<script", html);
             html = grid.Pager().ToString();
-            Assert.False(html.Contains("<script"));
+            Assert.DoesNotContain("<script", html);
         }
 
         [Fact]
@@ -35,16 +35,16 @@ namespace System.Web.Helpers.Test
             var grid = new WebGrid(GetContext(), ajaxUpdateCallback: "myCallback")
                 .Bind(new[] { new { First = "First", Second = "Second" } });
             string html = grid.Table().ToString();
-            Assert.False(html.Contains("<script"));
-            Assert.False(html.Contains("myCallback"));
+            Assert.DoesNotContain("<script", html);
+            Assert.DoesNotContain("myCallback", html);
         }
 
         [Fact]
         public void ColumnNameDefaultsExcludesIndexedProperties()
         {
             var grid = new WebGrid(GetContext()).Bind(new[] { "First", "Second" });
-            Assert.Equal(1, grid.ColumnNames.Count());
-            Assert.True(grid.ColumnNames.Contains("Length"));
+            Assert.Single(grid.ColumnNames);
+            Assert.Contains("Length", grid.ColumnNames);
         }
 
         [Fact]
@@ -52,8 +52,8 @@ namespace System.Web.Helpers.Test
         {
             var grid = new WebGrid(GetContext()).Bind(Dynamics(new { First = "First", Second = "Second" }));
             Assert.Equal(2, grid.ColumnNames.Count());
-            Assert.True(grid.ColumnNames.Contains("First"));
-            Assert.True(grid.ColumnNames.Contains("Second"));
+            Assert.Contains("First", grid.ColumnNames);
+            Assert.Contains("Second", grid.ColumnNames);
         }
 
         [Fact]
@@ -61,8 +61,8 @@ namespace System.Web.Helpers.Test
         {
             var grid = new WebGrid(GetContext()).Bind(new[] { new { First = "First", Second = "Second" } });
             Assert.Equal(2, grid.ColumnNames.Count());
-            Assert.True(grid.ColumnNames.Contains("First"));
-            Assert.True(grid.ColumnNames.Contains("Second"));
+            Assert.Contains("First", grid.ColumnNames);
+            Assert.Contains("Second", grid.ColumnNames);
         }
 
         [Fact]
@@ -84,15 +84,15 @@ namespace System.Web.Helpers.Test
                 }
             });
             Assert.Equal(7, grid.ColumnNames.Count());
-            Assert.True(grid.ColumnNames.Contains("DateTime"));
-            Assert.True(grid.ColumnNames.Contains("DateTimeOffset"));
-            Assert.True(grid.ColumnNames.Contains("Decimal"));
-            Assert.True(grid.ColumnNames.Contains("Guid"));
-            Assert.True(grid.ColumnNames.Contains("Int32"));
-            Assert.True(grid.ColumnNames.Contains("NullableInt32"));
-            Assert.True(grid.ColumnNames.Contains("TimeSpan"));
-            Assert.False(grid.ColumnNames.Contains("Object"));
-            Assert.False(grid.ColumnNames.Contains("Projection"));
+            Assert.Contains("DateTime", grid.ColumnNames);
+            Assert.Contains("DateTimeOffset", grid.ColumnNames);
+            Assert.Contains("Decimal", grid.ColumnNames);
+            Assert.Contains("Guid", grid.ColumnNames);
+            Assert.Contains("Int32", grid.ColumnNames);
+            Assert.Contains("NullableInt32", grid.ColumnNames);
+            Assert.Contains("TimeSpan", grid.ColumnNames);
+            Assert.DoesNotContain("Object", grid.ColumnNames);
+            Assert.DoesNotContain("Projection", grid.ColumnNames);
         }
 
         [Fact]
@@ -780,7 +780,7 @@ namespace System.Web.Helpers.Test
                     new { P1 = 4, P2 = '5', P3 = "6" }
                 });
             string html = grid.Pager().ToString();
-            Assert.True(html.Contains("<script"));
+            Assert.Contains("<script", html);
         }
 
         [Fact]
@@ -793,8 +793,8 @@ namespace System.Web.Helpers.Test
                     new { P1 = 4, P2 = '5', P3 = "6" }
                 });
             string html = grid.Pager().ToString();
-            Assert.True(html.Contains("<script"));
-            Assert.True(html.Contains("data-swhgcallback=\"myCallback\""));
+            Assert.Contains("<script", html);
+            Assert.Contains("data-swhgcallback=\"myCallback\"", html);
         }
 
         [Fact]
@@ -1952,8 +1952,8 @@ namespace System.Web.Helpers.Test
                 new { First = "First", Second = "Second" }
             });
             string html = grid.Table().ToString();
-            Assert.True(html.Contains("<script"));
-            Assert.True(html.Contains("swhgajax=\"true\""));
+            Assert.Contains("<script", html);
+            Assert.Contains("swhgajax=\"true\"", html);
         }
 
         [Fact]
@@ -1964,8 +1964,8 @@ namespace System.Web.Helpers.Test
                 new { First = "First", Second = "Second" }
             });
             string html = grid.Table().ToString();
-            Assert.True(html.Contains("<script"));
-            Assert.True(html.Contains("myCallback"));
+            Assert.Contains("<script", html);
+            Assert.Contains("myCallback", html);
         }
 
         [Fact]
@@ -1976,8 +1976,8 @@ namespace System.Web.Helpers.Test
                 new { First = "First", Second = "Second" }
             });
             string html = grid.Table().ToString();
-            Assert.True(html.Contains(@"&#39;grid&#39;"));
-            Assert.True(html.Contains(@"&#39;myCallback&#39;"));
+            Assert.Contains(@"&#39;grid&#39;", html);
+            Assert.Contains(@"&#39;myCallback&#39;", html);
         }
 
         [Fact]
@@ -2101,10 +2101,10 @@ namespace System.Web.Helpers.Test
 
             // Assert
             Assert.NotNull(html);
-            Assert.Equal(grid.Rows[0]["Salary"], 20);
-            Assert.Equal(grid.Rows[1]["Salary"], 15);
-            Assert.Equal(grid.Rows[2]["Salary"], 10);
-            Assert.Equal(grid.Rows[3]["Salary"], 5);
+            Assert.Equal(20, grid.Rows[0]["Salary"]);
+            Assert.Equal(15, grid.Rows[1]["Salary"]);
+            Assert.Equal(10, grid.Rows[2]["Salary"]);
+            Assert.Equal(5, grid.Rows[3]["Salary"]);
         }
 
         [Fact]
@@ -2142,9 +2142,9 @@ namespace System.Web.Helpers.Test
             var html = grid.Table();
 
             // Assert
-            Assert.Equal(grid.Rows[0]["Salary"], 5);
-            Assert.Equal(grid.Rows[1]["Salary"], 10);
-            Assert.Equal(grid.Rows[2]["Salary"], 15);
+            Assert.Equal(5, grid.Rows[0]["Salary"]);
+            Assert.Equal(10, grid.Rows[1]["Salary"]);
+            Assert.Equal(15, grid.Rows[2]["Salary"]);
 
             UnitTestHelper.AssertEqualsIgnoreWhitespace(
                 "<table><thead><tr>"
@@ -2172,9 +2172,9 @@ namespace System.Web.Helpers.Test
             var html = grid.Table();
 
             // Assert
-            Assert.Equal(grid.Rows[0]["Salary"], 5);
-            Assert.Equal(grid.Rows[1]["Salary"], 10);
-            Assert.Equal(grid.Rows[2]["Salary"], 15);
+            Assert.Equal(5, grid.Rows[0]["Salary"]);
+            Assert.Equal(10, grid.Rows[1]["Salary"]);
+            Assert.Equal(15, grid.Rows[2]["Salary"]);
 
             UnitTestHelper.AssertEqualsIgnoreWhitespace(
                 "<table><thead><tr>"

--- a/test/System.Web.Helpers.Test/WebImageTest.cs
+++ b/test/System.Web.Helpers.Test/WebImageTest.cs
@@ -385,7 +385,7 @@ namespace System.Web.Helpers.Test
             image.Resize(200, 100, preserveAspectRatio: true, preventEnlarge: true);
 
             // Assert
-            Assert.Equal(image.ImageFormat, "png");
+            Assert.Equal("png", image.ImageFormat);
             image.Save(GetContext(), saveAction, @"x:\1.png", null, false);
 
             using (Image modified = Image.FromStream(output))
@@ -980,7 +980,7 @@ namespace System.Web.Helpers.Test
             image.Save(GetContext(), saveAction, filePath: specifiedOutputFile, imageFormat: null, forceWellKnownExtension: true);
 
             // Assert
-            Assert.Equal(Path.GetExtension(actualOutputFile), ".png");
+            Assert.Equal(".png", Path.GetExtension(actualOutputFile));
         }
 
         [Fact]
@@ -997,7 +997,7 @@ namespace System.Web.Helpers.Test
             image.Save(GetContext(), saveAction, filePath: specifiedOutputFile, imageFormat: null, forceWellKnownExtension: true);
 
             // Assert
-            Assert.Equal(Path.GetExtension(actualOutputFile), ".png");
+            Assert.Equal(".png", Path.GetExtension(actualOutputFile));
         }
 
         [Fact]

--- a/test/System.Web.Helpers.Test/WebMailTest.cs
+++ b/test/System.Web.Helpers.Test/WebMailTest.cs
@@ -214,8 +214,8 @@ namespace System.Web.Helpers.Test
                 Assert.Equal(Encoding.UTF8, message.BodyEncoding);
                 Assert.Equal(Encoding.Unicode, message.HeadersEncoding);
 
-                Assert.True(message.Headers.AllKeys.Contains("header1"));
-                Assert.True(message.Attachments.Count == 1);
+                Assert.Contains("header1", message.Headers.AllKeys);
+                Assert.Single(message.Attachments);
             }
             finally
             {
@@ -254,7 +254,7 @@ namespace System.Web.Helpers.Test
             WebMail.AssignHeaderValues(message, headers);
 
             // Assert
-            Assert.Equal(1, message.Headers.Count);
+            Assert.Single(message.Headers);
             Assert.Equal("foo1", message.Headers.AllKeys[0]);
             Assert.Equal("bar1", message.Headers[0]);
         }
@@ -318,7 +318,7 @@ namespace System.Web.Helpers.Test
             Assert.Equal(MailPriority.Normal, message.Priority);
 
             // Assert we transparently set header values
-            Assert.Equal(1, message.Headers.Count);
+            Assert.Single(message.Headers);
             Assert.Equal("Priority", message.Headers.Keys[0]);
             Assert.Equal("invalid-value", message.Headers["Priority"]);
         }
@@ -334,10 +334,10 @@ namespace System.Web.Helpers.Test
             WebMail.AssignHeaderValues(message, headers);
 
             // Assert
-            Assert.Equal(0, message.To.Count);
+            Assert.Empty(message.To);
 
             // Assert we transparently set header values
-            Assert.Equal(1, message.Headers.Count);
+            Assert.Single(message.Headers);
             Assert.Equal("To", message.Headers.Keys[0]);
             Assert.Equal("not-#-email@@", message.Headers["To"]);
         }
@@ -353,10 +353,10 @@ namespace System.Web.Helpers.Test
             WebMail.AssignHeaderValues(message, headers);
 
             // Assert
-            Assert.Equal(0, message.To.Count);
+            Assert.Empty(message.To);
 
             // Assert we transparently set header values
-            Assert.Equal(1, message.Headers.Count);
+            Assert.Single(message.Headers);
             Assert.Equal("Priority", message.Headers.Keys[0]);
             Assert.Equal("false", message.Headers["Priority"]);
         }

--- a/test/System.Web.Helpers.Test/packages.config
+++ b/test/System.Web.Helpers.Test/packages.config
@@ -2,7 +2,9 @@
 <packages>
   <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
+  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />

--- a/test/System.Web.Http.Cors.Test/AttributeBasedPolicyProviderFactoryTest.cs
+++ b/test/System.Web.Http.Cors.Test/AttributeBasedPolicyProviderFactoryTest.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Web.Cors;
 using System.Web.Http.Controllers;
-using System.Web.Http.Hosting;
 using System.Web.Http.Routing;
 using Microsoft.TestCommon;
 using Moq;
@@ -64,7 +63,7 @@ namespace System.Web.Http.Cors
             request.SetRouteData(route.GetRouteData("/", request));
 
             ICorsPolicyProvider provider = providerFactory.GetCorsPolicyProvider(request);
-                                      
+
             // Assert
             Assert.NotNull(controllerContext);
             Assert.Equal(config, controllerContext.Configuration);
@@ -86,7 +85,7 @@ namespace System.Web.Http.Cors
             HttpControllerContext controllerContext = null;
             var actionSelector = new Mock<IHttpActionSelector>();
             actionSelector.Setup(s => s.SelectAction(It.IsAny<HttpControllerContext>()))
-                          .Callback<HttpControllerContext>(context => 
+                          .Callback<HttpControllerContext>(context =>
                           {
                               Assert.False(((SampleController)context.Controller).Disposed);
                               controllerContext = context;
@@ -214,7 +213,7 @@ namespace System.Web.Http.Cors
             ICorsPolicyProvider policyProvider = providerFactory.GetCorsPolicyProvider(request);
 
             Assert.NotNull(policyProvider);
-            Assert.IsType(typeof(EnableCorsAttribute), policyProvider);
+            Assert.IsType<EnableCorsAttribute>(policyProvider);
         }
 
         [Fact]
@@ -232,7 +231,7 @@ namespace System.Web.Http.Cors
             ICorsPolicyProvider policyProvider = providerFactory.GetCorsPolicyProvider(request);
 
             Assert.NotNull(policyProvider);
-            Assert.IsType(typeof(DisableCorsAttribute), policyProvider);
+            Assert.IsType<DisableCorsAttribute>(policyProvider);
         }
 
         [Fact]
@@ -250,8 +249,8 @@ namespace System.Web.Http.Cors
 
             Assert.True(request.GetCorsRequestContext().IsPreflight);
             EnableCorsAttribute enableCorsAttribute = Assert.IsType<EnableCorsAttribute>(provider);
-            Assert.Equal(1, enableCorsAttribute.Origins.Count());
-            Assert.Equal("http://example.com", enableCorsAttribute.Origins.First());
+            string origin = Assert.Single(enableCorsAttribute.Origins);
+            Assert.Equal("http://example.com", origin);
         }
 
         [Fact]

--- a/test/System.Web.Http.Cors.Test/CorsHttpConfigurationExtensionsTest.cs
+++ b/test/System.Web.Http.Cors.Test/CorsHttpConfigurationExtensionsTest.cs
@@ -32,8 +32,8 @@ namespace System.Web.Http.Cors.Test
 
             config.Initializer(config);
 
-            Assert.Equal(1, config.MessageHandlers.Count);
-            Assert.IsType(typeof(CorsMessageHandler), config.MessageHandlers[0]);
+            var handler = Assert.Single(config.MessageHandlers);
+            Assert.IsType<CorsMessageHandler>(handler);
         }
 
         [Fact]
@@ -49,8 +49,8 @@ namespace System.Web.Http.Cors.Test
 
             config.Initializer(config);
 
-            Assert.Equal(1, config.MessageHandlers.Count);
-            Assert.IsType(typeof(CorsMessageHandler), config.MessageHandlers[0]);
+            var handler = Assert.Single(config.MessageHandlers);
+            Assert.IsType<CorsMessageHandler>(handler);
         }
 
         [Fact]
@@ -66,8 +66,8 @@ namespace System.Web.Http.Cors.Test
             config.Initializer(config);
             config.Initializer(config);
 
-            Assert.Equal(1, config.MessageHandlers.Count);
-            Assert.IsType(typeof(CorsMessageHandler), config.MessageHandlers[0]);
+            var handler = Assert.Single(config.MessageHandlers);
+            Assert.IsType<CorsMessageHandler>(handler);
         }
 
         [Fact]
@@ -96,7 +96,7 @@ namespace System.Web.Http.Cors.Test
             config.Initializer(config);
 
             ICorsPolicyProviderFactory providerFactory = config.GetCorsPolicyProviderFactory();
-            Assert.IsType(typeof(CorsPolicyProviderFactoryTracer), providerFactory);
+            Assert.IsType<CorsPolicyProviderFactoryTracer>(providerFactory);
         }
 
         [Fact]
@@ -116,7 +116,7 @@ namespace System.Web.Http.Cors.Test
             ICorsPolicyProviderFactory providerFactory = config.GetCorsPolicyProviderFactory();
 
             Assert.NotNull(providerFactory);
-            Assert.IsType(typeof(AttributeBasedPolicyProviderFactory), providerFactory);
+            Assert.IsType<AttributeBasedPolicyProviderFactory>(providerFactory);
         }
 
         [Fact]
@@ -145,7 +145,7 @@ namespace System.Web.Http.Cors.Test
         {
             HttpConfiguration config = new HttpConfiguration();
             ICorsEngine corsEngine = config.GetCorsEngine();
-            Assert.IsType(typeof(CorsEngine), corsEngine);
+            Assert.IsType<CorsEngine>(corsEngine);
         }
 
         [Fact]

--- a/test/System.Web.Http.Cors.Test/CorsHttpResponseMessageExtensionsTest.cs
+++ b/test/System.Web.Http.Cors.Test/CorsHttpResponseMessageExtensionsTest.cs
@@ -48,7 +48,7 @@ namespace System.Web.Cors.Test.WebAPI
             response.WriteCorsHeaders(corsResult);
             HttpResponseHeaders headers = response.Headers;
 
-            Assert.Equal(1, headers.Count());
+            Assert.Single(headers);
             string[] allowMethods = headers.GetValues("Access-Control-Allow-Methods").FirstOrDefault().Split(',');
             Assert.Contains("DELETE", allowMethods);
             Assert.Contains("PUT", allowMethods);
@@ -64,7 +64,7 @@ namespace System.Web.Cors.Test.WebAPI
             response.WriteCorsHeaders(corsResult);
             HttpResponseHeaders headers = response.Headers;
 
-            Assert.Equal(1, headers.Count());
+            Assert.Single(headers);
             string[] exposedHeaders = headers.GetValues("Access-Control-Expose-Headers").FirstOrDefault().Split(',');
             Assert.Contains("baz", exposedHeaders);
         }
@@ -80,7 +80,7 @@ namespace System.Web.Cors.Test.WebAPI
             response.WriteCorsHeaders(corsResult);
             HttpResponseHeaders headers = response.Headers;
 
-            Assert.Equal(1, headers.Count());
+            Assert.Single(headers);
             string[] allowHeaders = headers.GetValues("Access-Control-Allow-Headers").FirstOrDefault().Split(',');
             Assert.Contains("foo", allowHeaders);
             Assert.Contains("bar", allowHeaders);
@@ -98,7 +98,7 @@ namespace System.Web.Cors.Test.WebAPI
             response.WriteCorsHeaders(corsResult);
             HttpResponseHeaders headers = response.Headers;
 
-            Assert.Equal(1, headers.Count());
+            Assert.Single(headers);
             Assert.Equal("true", headers.GetValues("Access-Control-Allow-Credentials").FirstOrDefault());
         }
 
@@ -114,7 +114,7 @@ namespace System.Web.Cors.Test.WebAPI
             response.WriteCorsHeaders(corsResult);
             HttpResponseHeaders headers = response.Headers;
 
-            Assert.Equal(1, headers.Count());
+            Assert.Single(headers);
             Assert.Equal("*", headers.GetValues("Access-Control-Allow-Origin").FirstOrDefault());
         }
 
@@ -130,7 +130,7 @@ namespace System.Web.Cors.Test.WebAPI
             response.WriteCorsHeaders(corsResult);
             HttpResponseHeaders headers = response.Headers;
 
-            Assert.Equal(1, headers.Count());
+            Assert.Single(headers);
             Assert.Equal("10", headers.GetValues("Access-Control-Max-Age").FirstOrDefault());
         }
     }

--- a/test/System.Web.Http.Cors.Test/System.Web.Http.Cors.Test.csproj
+++ b/test/System.Web.Http.Cors.Test/System.Web.Http.Cors.Test.csproj
@@ -96,6 +96,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/System.Web.Http.Cors.Test/Tracing/CorsPolicyProviderFactoryTracerTest.cs
+++ b/test/System.Web.Http.Cors.Test/Tracing/CorsPolicyProviderFactoryTracerTest.cs
@@ -44,7 +44,7 @@ namespace System.Web.Http.Cors.Tracing
 
             ICorsPolicyProvider policyProvider = tracer.GetCorsPolicyProvider(new HttpRequestMessage());
 
-            Assert.IsType(typeof(CorsPolicyProviderTracer), policyProvider);
+            Assert.IsType<CorsPolicyProviderTracer>(policyProvider);
         }
 
         [Fact]

--- a/test/System.Web.Http.Cors.Test/packages.config
+++ b/test/System.Web.Http.Cors.Test/packages.config
@@ -3,7 +3,9 @@
   <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />

--- a/test/System.Web.Http.Integration.Test/ApiExplorer/ParameterSourceTest.cs
+++ b/test/System.Web.Http.Integration.Test/ApiExplorer/ParameterSourceTest.cs
@@ -69,8 +69,8 @@ namespace System.Web.Http.ApiExplorer
 
             ApiDescription description = explorer.ApiDescriptions.FirstOrDefault(desc => desc.ActionDescriptor.ActionName == "GetWithEnumParameter");
             Assert.NotNull(description);
-            Assert.Equal(1, description.ParameterDescriptions.Count);
-            Assert.Equal(ApiParameterSource.FromUri, description.ParameterDescriptions[0].Source);
+            ApiParameterDescription parameterDescription = Assert.Single(description.ParameterDescriptions);
+            Assert.Equal(ApiParameterSource.FromUri, parameterDescription.Source);
             Assert.Equal("EnumParameterOverloads?scope={scope}", description.RelativePath);
 
             description = explorer.ApiDescriptions.FirstOrDefault(desc => desc.ActionDescriptor.ActionName == "GetWithTwoEnumParameters");
@@ -82,8 +82,8 @@ namespace System.Web.Http.ApiExplorer
 
             description = explorer.ApiDescriptions.FirstOrDefault(desc => desc.ActionDescriptor.ActionName == "GetWithNullableEnumParameter");
             Assert.NotNull(description);
-            Assert.Equal(1, description.ParameterDescriptions.Count);
-            Assert.Equal(ApiParameterSource.FromUri, description.ParameterDescriptions[0].Source);
+            parameterDescription = Assert.Single(description.ParameterDescriptions);
+            Assert.Equal(ApiParameterSource.FromUri, parameterDescription.Source);
             Assert.Equal("EnumParameterOverloads?level={level}", description.RelativePath);
         }
 
@@ -153,7 +153,7 @@ namespace System.Web.Http.ApiExplorer
             public string Value { get; set; }
         }
 
-        // We only support complex types whose all of their individual 
+        // We only support complex types whose all of their individual
         // properties can be converted from string.
         public class NonDescribable
         {

--- a/test/System.Web.Http.Integration.Test/ApiExplorer/RoutesTest.cs
+++ b/test/System.Web.Http.Integration.Test/ApiExplorer/RoutesTest.cs
@@ -20,7 +20,7 @@ namespace System.Web.Http.ApiExplorer
             IApiExplorer explorer = config.Services.GetApiExplorer();
 
             Assert.NotNull(explorer);
-            Assert.Equal(0, explorer.ApiDescriptions.Count);
+            Assert.Empty(explorer.ApiDescriptions);
         }
 
         [Fact]
@@ -31,7 +31,7 @@ namespace System.Web.Http.ApiExplorer
             IApiExplorer explorer = config.Services.GetApiExplorer();
 
             Assert.NotNull(explorer);
-            Assert.Equal(0, explorer.ApiDescriptions.Count);
+            Assert.Empty(explorer.ApiDescriptions);
         }
 
         public static IEnumerable<object[]> VerifyDescription_OnDefaultRoute_PropertyData

--- a/test/System.Web.Http.Integration.Test/ContentNegotiation/CustomFormatterTests.cs
+++ b/test/System.Web.Http.Integration.Test/ContentNegotiation/CustomFormatterTests.cs
@@ -45,10 +45,10 @@ namespace System.Web.Http.ContentNegotiation
 
             IEnumerable<string> versionHdr = null;
             Assert.True(response.Content.Headers.TryGetValues("Version", out versionHdr));
-            Assert.Equal<string>("1.3.5.0", versionHdr.First());
+            Assert.Equal("1.3.5.0", versionHdr.First());
             Assert.NotNull(response.Content);
             Assert.NotNull(response.Content.Headers.ContentType);
-            Assert.Equal<string>("text/plainwithversioninfo", response.Content.Headers.ContentType.MediaType);
+            Assert.Equal("text/plainwithversioninfo", response.Content.Headers.ContentType.MediaType);
         }
 
         [Fact]
@@ -66,8 +66,8 @@ namespace System.Web.Http.ContentNegotiation
             response.EnsureSuccessStatusCode();
             Assert.NotNull(response.Content);
             Assert.NotNull(response.Content.Headers.ContentType);
-            Assert.Equal<string>("text/plain", response.Content.Headers.ContentType.MediaType);
-            Assert.Equal<string>("Hello World!", await response.Content.ReadAsStringAsync());
+            Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);
+            Assert.Equal("Hello World!", await response.Content.ReadAsStringAsync());
         }
 
         [Fact]
@@ -86,8 +86,8 @@ namespace System.Web.Http.ContentNegotiation
             response.EnsureSuccessStatusCode();
             Assert.NotNull(response.Content);
             Assert.NotNull(response.Content.Headers.ContentType);
-            Assert.Equal<string>("text/plain", response.Content.Headers.ContentType.MediaType);
-            Assert.Equal<int>(100, Convert.ToInt32(await response.Content.ReadAsStringAsync()));
+            Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);
+            Assert.Equal(100, Convert.ToInt32(await response.Content.ReadAsStringAsync()));
         }
 
         [Fact]
@@ -106,7 +106,7 @@ namespace System.Web.Http.ContentNegotiation
             response.EnsureSuccessStatusCode();
             Assert.NotNull(response.Content);
             Assert.NotNull(response.Content.Headers.ContentType);
-            Assert.Equal<string>("text/plain", response.Content.Headers.ContentType.MediaType);
+            Assert.Equal("text/plain", response.Content.Headers.ContentType.MediaType);
         }
 
         private void SetupHost()

--- a/test/System.Web.Http.Integration.Test/ContentNegotiation/HttpResponseReturnTests.cs
+++ b/test/System.Web.Http.Integration.Test/ContentNegotiation/HttpResponseReturnTests.cs
@@ -41,8 +41,8 @@ namespace System.Web.Http.ContentNegotiation
 
             Assert.NotNull(response.Content);
             Assert.NotNull(response.Content.Headers.ContentType);
-            Assert.Equal<string>("application/xml", response.Content.Headers.ContentType.MediaType);
-            Assert.Equal<string>(expectedResponseValue, await response.Content.ReadAsStringAsync());
+            Assert.Equal("application/xml", response.Content.Headers.ContentType.MediaType);
+            Assert.Equal(expectedResponseValue, await response.Content.ReadAsStringAsync());
         }
 
         [Theory]
@@ -59,8 +59,8 @@ namespace System.Web.Http.ContentNegotiation
 
             Assert.NotNull(response.Content);
             Assert.NotNull(response.Content.Headers.ContentType);
-            Assert.Equal<string>("application/xml", response.Content.Headers.ContentType.MediaType);
-            Assert.Equal<string>(expectedResponseValue, await response.Content.ReadAsStringAsync());
+            Assert.Equal("application/xml", response.Content.Headers.ContentType.MediaType);
+            Assert.Equal(expectedResponseValue, await response.Content.ReadAsStringAsync());
         }
 
         [Theory]
@@ -77,7 +77,7 @@ namespace System.Web.Http.ContentNegotiation
             Assert.Equal(new[] { "cookie1", "cookie2" }, list);
         }
 
-        public void SetupHost()
+        private void SetupHost()
         {
             baseAddress = "http://localhost/";
 

--- a/test/System.Web.Http.Integration.Test/Controllers/ActionAttributesTest.cs
+++ b/test/System.Web.Http.Integration.Test/Controllers/ActionAttributesTest.cs
@@ -27,7 +27,7 @@ namespace System.Web.Http
             controllerContext.ControllerDescriptor = new HttpControllerDescriptor(controllerContext.Configuration, "test", typeof(ActionAttributeTestController));
             HttpActionDescriptor descriptor = ApiControllerHelper.SelectAction(controllerContext);
 
-            Assert.Equal<string>(expectedActionName, descriptor.ActionName);
+            Assert.Equal(expectedActionName, descriptor.ActionName);
         }
 
         [Theory]
@@ -63,7 +63,7 @@ namespace System.Web.Http
         [InlineData("PUT", "ActionAttributeTest/AddUsers")] // id is required on this action, so url is invalid. 404
         [InlineData("WHATEVER", "ActionAttributeTest/AddUsers")] // id is required on this action, so url is invalid. 404
         [InlineData("GET", "ActionAttributeTest/Users")] // key param is required, bad url. 404
-        [InlineData("POST", "ActionAttributeTest/Users")] // key param is required, bad url. 404 
+        [InlineData("POST", "ActionAttributeTest/Users")] // key param is required, bad url. 404
         [InlineData("PATCHING", "ActionAttributeTest/Users")] // key param is required, bad url. 404
         [InlineData("NonAction", "ActionAttributeTest/NonAction")] // NonAction, 404
         [InlineData("GET", "ActionAttributeTest/NonAction")] // NonAction, 404
@@ -86,7 +86,7 @@ namespace System.Web.Http
 
             // Error message might be ApiControllerActionSelector_ActionNameNotFound or ApiControllerActionSelector_ActionNotFound
             string actualMessage = (string)((HttpError)content.Value)["MessageDetail"];
-            Assert.True(actualMessage.StartsWith("No action was found on the controller 'ActionAttributeTestController' that matches"));
+            Assert.StartsWith("No action was found on the controller 'ActionAttributeTestController' that matches", actualMessage);
         }
 
         [Theory]
@@ -115,7 +115,7 @@ namespace System.Web.Http
             controllerContext.ControllerDescriptor = new HttpControllerDescriptor(controllerContext.Configuration, "test", typeof(ActionAttributeTestController));
             HttpActionDescriptor descriptor = ApiControllerHelper.SelectAction(controllerContext);
 
-            Assert.Equal<string>(expectedActionName, descriptor.ActionName);
+            Assert.Equal(expectedActionName, descriptor.ActionName);
         }
 
         [Theory]

--- a/test/System.Web.Http.Integration.Test/Controllers/ApiControllerActionSelectorTest.cs
+++ b/test/System.Web.Http.Integration.Test/Controllers/ApiControllerActionSelectorTest.cs
@@ -237,7 +237,7 @@ namespace System.Web.Http
             context.ControllerDescriptor = new HttpControllerDescriptor(context.Configuration, "test", typeof(TestController));
             HttpActionDescriptor descriptor = ApiControllerHelper.SelectAction(context);
 
-            Assert.Equal<string>("PutUser", descriptor.ActionName);
+            Assert.Equal("PutUser", descriptor.ActionName);
 
             // When you have the HttpMethod attribute, the convention should not be applied.
             httpMethod = "PUT";
@@ -254,7 +254,7 @@ namespace System.Web.Http
             AssertAllowedHeaders(exception.Response, HttpMethod.Get, new HttpMethod("PATCH"), HttpMethod.Post, HttpMethod.Delete, HttpMethod.Head);
         }
 
-        // Verify response has all the methods in its Allow header. values are unsorted. 
+        // Verify response has all the methods in its Allow header. values are unsorted.
         private void AssertAllowedHeaders(HttpResponseMessage response, params HttpMethod[] allowedMethods)
         {
             foreach (var method in allowedMethods)

--- a/test/System.Web.Http.Integration.Test/ExceptionHandling/HttpResponseExceptionTest.cs
+++ b/test/System.Web.Http.Integration.Test/ExceptionHandling/HttpResponseExceptionTest.cs
@@ -48,7 +48,7 @@ namespace System.Web.Http.ExceptionHandling
                 {
                     Assert.NotNull(response.Content);
                     Assert.NotNull(response.Content.Headers.ContentType);
-                    Assert.Equal(response.Content.Headers.ContentType.MediaType, "application/json");
+                    Assert.Equal("application/json", response.Content.Headers.ContentType.MediaType);
 
                     if (throwAt == "DoNotThrow")
                     {

--- a/test/System.Web.Http.Integration.Test/ExceptionHandling/IncludeErrorDetailTest.cs
+++ b/test/System.Web.Http.Integration.Test/ExceptionHandling/IncludeErrorDetailTest.cs
@@ -97,7 +97,7 @@ namespace System.Web.Http
         {
             Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
             JObject json = JToken.Parse(await response.Content.ReadAsStringAsync()) as JObject;
-            Assert.Equal(1, json.Count);
+            Assert.Single(json);
             string errorMessage = ((JValue)json["Message"]).ToString();
             Assert.Equal("An error has occurred.", errorMessage);
         }

--- a/test/System.Web.Http.Integration.Test/ModelBinding/BodyBindingTests.cs
+++ b/test/System.Web.Http.Integration.Test/ModelBinding/BodyBindingTests.cs
@@ -138,7 +138,7 @@ namespace System.Web.Http.ModelBinding
 
             // Assert
             ModelBindOrder actualItem = await response.Content.ReadAsAsync<ModelBindOrder>();
-            Assert.Equal<ModelBindOrder>(expectedItem, actualItem, new ModelBindOrderEqualityComparer());
+            Assert.Equal(expectedItem, actualItem, new ModelBindOrderEqualityComparer());
         }
 
         [Theory]
@@ -168,7 +168,7 @@ namespace System.Web.Http.ModelBinding
 
             // Assert
             ModelBindOrder actualItem = await response.Content.ReadAsAsync<ModelBindOrder>();
-            Assert.Equal<ModelBindOrder>(expectedItem, actualItem, new ModelBindOrderEqualityComparer());
+            Assert.Equal(expectedItem, actualItem, new ModelBindOrderEqualityComparer());
         }
     }
 }

--- a/test/System.Web.Http.Integration.Test/ModelBinding/CustomBindingTests.cs
+++ b/test/System.Web.Http.Integration.Test/ModelBinding/CustomBindingTests.cs
@@ -29,7 +29,7 @@ namespace System.Web.Http.ModelBinding
 
             // Assert
             string responseString = await response.Content.ReadAsStringAsync();
-            Assert.Equal<string>("5", responseString);
+            Assert.Equal("5", responseString);
         }
 
     }

--- a/test/System.Web.Http.Integration.Test/ModelBinding/DefaultActionValueBinderTest.cs
+++ b/test/System.Web.Http.Integration.Test/ModelBinding/DefaultActionValueBinderTest.cs
@@ -63,7 +63,7 @@ namespace System.Web.Http.ModelBinding
 
             // Assert
             var result = context.ActionArguments;
-            Assert.Equal(1, result.Count);
+            Assert.Single(result);
             var item = Assert.IsType<ActionValueItem>(result["item"]);
             Assert.Equal(cust.FirstName, item.FirstName);
             Assert.Equal(cust.LastName, item.LastName);
@@ -170,8 +170,8 @@ namespace System.Web.Http.ModelBinding
 
             // Assert
             Assert.True(actionContext.ModelState.IsValid);
-            Assert.Equal(1, actionContext.ActionArguments.Count);
-            ActionValueItem deserializedActionValueItem = Assert.IsType<ActionValueItem>(actionContext.ActionArguments.First().Value);
+            KeyValuePair<string, object> actionArgument = Assert.Single(actionContext.ActionArguments);
+            ActionValueItem deserializedActionValueItem = Assert.IsType<ActionValueItem>(actionArgument.Value);
             Assert.Equal(5, deserializedActionValueItem.Id);
             Assert.Equal("queryFirstName", deserializedActionValueItem.FirstName);
             Assert.Equal("queryLastName", deserializedActionValueItem.LastName);
@@ -197,8 +197,8 @@ namespace System.Web.Http.ModelBinding
 
             // Assert
             Assert.True(actionContext.ModelState.IsValid);
-            Assert.Equal(1, actionContext.ActionArguments.Count);
-            ActionValueItem deserializedActionValueItem = Assert.IsType<ActionValueItem>(actionContext.ActionArguments.First().Value);
+            KeyValuePair<string, object> actionArgument = Assert.Single(actionContext.ActionArguments);
+            ActionValueItem deserializedActionValueItem = Assert.IsType<ActionValueItem>(actionArgument.Value);
             Assert.Equal(5, deserializedActionValueItem.Id);
             Assert.Equal("queryFirstName", deserializedActionValueItem.FirstName);
             Assert.Equal("queryLastName", deserializedActionValueItem.LastName);
@@ -224,8 +224,8 @@ namespace System.Web.Http.ModelBinding
 
             // Assert
             Assert.True(actionContext.ModelState.IsValid);
-            Assert.Equal(1, actionContext.ActionArguments.Count);
-            IEnumerable<ActionValueItem> items = Assert.IsAssignableFrom<IEnumerable<ActionValueItem>>(actionContext.ActionArguments.First().Value);
+            KeyValuePair<string, object> keyValuePair = Assert.Single(actionContext.ActionArguments);
+            IEnumerable<ActionValueItem> items = Assert.IsAssignableFrom<IEnumerable<ActionValueItem>>(keyValuePair.Value);
             ActionValueItem deserializedActionValueItem = items.First();
             Assert.Equal(5, deserializedActionValueItem.Id);
             Assert.Equal("queryFirstName", deserializedActionValueItem.FirstName);
@@ -252,9 +252,9 @@ namespace System.Web.Http.ModelBinding
 
             // Assert
             Assert.True(actionContext.ModelState.IsValid);
-            Assert.Equal(1, actionContext.ActionArguments.Count);
-            IEnumerable<ActionValueItem> items = Assert.IsAssignableFrom<IEnumerable<ActionValueItem>>(actionContext.ActionArguments.First().Value);
-            Assert.Equal(0, items.Count());     // expect unsuccessful bind but proves we don't loop infinitely
+            KeyValuePair<string, object> keyValuePair = Assert.Single(actionContext.ActionArguments);
+            IEnumerable<ActionValueItem> items = Assert.IsAssignableFrom<IEnumerable<ActionValueItem>>(keyValuePair.Value);
+            Assert.Empty(items);     // expect unsuccessful bind but proves we don't loop infinitely
         }
 
         [Fact]
@@ -276,8 +276,8 @@ namespace System.Web.Http.ModelBinding
             await provider.BindValuesAsync(actionContext, cancellationToken);
 
             // Assert
-            Assert.Equal(1, actionContext.ActionArguments.Count);
-            ActionValueItem deserializedActionValueItem = Assert.IsType<ActionValueItem>(actionContext.ActionArguments.First().Value);
+            KeyValuePair<string, object> keyValuePair = Assert.Single(actionContext.ActionArguments);
+            ActionValueItem deserializedActionValueItem = Assert.IsType<ActionValueItem>(keyValuePair.Value);
             Assert.Equal(5, deserializedActionValueItem.Id);
             Assert.Equal("queryFirstName", deserializedActionValueItem.FirstName);
             Assert.Equal("queryLastName", deserializedActionValueItem.LastName);
@@ -302,8 +302,8 @@ namespace System.Web.Http.ModelBinding
             await provider.BindValuesAsync(actionContext, cancellationToken);
 
             // Assert
-            Assert.Equal(1, actionContext.ActionArguments.Count);
-            ActionValueItem deserializedActionValueItem = Assert.IsType<ActionValueItem>(actionContext.ActionArguments.First().Value);
+            KeyValuePair<string, object> keyValuePair = Assert.Single(actionContext.ActionArguments);
+            ActionValueItem deserializedActionValueItem = Assert.IsType<ActionValueItem>(keyValuePair.Value);
             Assert.Equal(5, deserializedActionValueItem.Id);
             Assert.Equal("queryFirstName", deserializedActionValueItem.FirstName);
             Assert.Equal("queryLastName", deserializedActionValueItem.LastName);
@@ -473,8 +473,8 @@ namespace System.Web.Http.ModelBinding
             await provider.BindValuesAsync(controllerContext, cancellationToken);
 
             // Assert
-            Assert.Equal(1, controllerContext.ActionArguments.Count);
-            ActionValueItem deserializedActionValueItem = Assert.IsType<ActionValueItem>(controllerContext.ActionArguments.First().Value);
+            KeyValuePair<string, object> keyValuePair = Assert.Single(controllerContext.ActionArguments);
+            ActionValueItem deserializedActionValueItem = Assert.IsType<ActionValueItem>(keyValuePair.Value);
             Assert.Equal(6, deserializedActionValueItem.Id);
             Assert.Equal("routeFirstName", deserializedActionValueItem.FirstName);
             Assert.Equal("routeLastName", deserializedActionValueItem.LastName);
@@ -504,8 +504,8 @@ namespace System.Web.Http.ModelBinding
             await provider.BindValuesAsync(controllerContext, cancellationToken);
 
             // Assert
-            Assert.Equal(1, controllerContext.ActionArguments.Count);
-            ActionValueItem deserializedActionValueItem = Assert.IsType<ActionValueItem>(controllerContext.ActionArguments.First().Value);
+            KeyValuePair<string, object> keyValuePair = Assert.Single(controllerContext.ActionArguments);
+            ActionValueItem deserializedActionValueItem = Assert.IsType<ActionValueItem>(keyValuePair.Value);
             Assert.Equal(6, deserializedActionValueItem.Id);
             Assert.Equal("routeFirstName", deserializedActionValueItem.FirstName);
             Assert.Equal("routeLastName", deserializedActionValueItem.LastName);
@@ -532,8 +532,8 @@ namespace System.Web.Http.ModelBinding
             await provider.BindValuesAsync(actionContext, cancellationToken);
 
             // Assert
-            Assert.Equal(1, actionContext.ActionArguments.Count);
-            Assert.Equal(cancellationToken, actionContext.ActionArguments.First().Value);
+            KeyValuePair<string, object> keyValuePair = Assert.Single(actionContext.ActionArguments);
+            Assert.Equal(cancellationToken, keyValuePair.Value);
         }
         #endregion ControllerContext
 
@@ -558,8 +558,8 @@ namespace System.Web.Http.ModelBinding
             await provider.BindValuesAsync(context, cancellationToken);
 
             // Assert
-            Assert.Equal(1, context.ActionArguments.Count);
-            ActionValueItem deserializedActionValueItem = Assert.IsAssignableFrom<ActionValueItem>(context.ActionArguments.First().Value);
+            KeyValuePair<string, object> keyValuePair = Assert.Single(context.ActionArguments);
+            ActionValueItem deserializedActionValueItem = Assert.IsAssignableFrom<ActionValueItem>(keyValuePair.Value);
             Assert.Equal(7, deserializedActionValueItem.Id);
             Assert.Equal("testFirstName", deserializedActionValueItem.FirstName);
             Assert.Equal("testLastName", deserializedActionValueItem.LastName);
@@ -606,8 +606,8 @@ namespace System.Web.Http.ModelBinding
             await provider.BindValuesAsync(context, cancellationToken);
 
             // Assert
-            Assert.Equal(1, context.ActionArguments.Count);
-            ActionValueItem deserializedActionValueItem = Assert.IsAssignableFrom<ActionValueItem>(context.ActionArguments.First().Value);
+            KeyValuePair<string, object> keyValuePair = Assert.Single(context.ActionArguments);
+            ActionValueItem deserializedActionValueItem = Assert.IsAssignableFrom<ActionValueItem>(keyValuePair.Value);
             Assert.Equal(7, deserializedActionValueItem.Id);
             Assert.Equal("testFirstName", deserializedActionValueItem.FirstName);
             Assert.Equal("testLastName", deserializedActionValueItem.LastName);
@@ -656,8 +656,8 @@ namespace System.Web.Http.ModelBinding
             await provider.BindValuesAsync(context, cancellationToken);
 
             // Assert
-            Assert.Equal(1, context.ActionArguments.Count);
-            ActionValueItem deserializedActionValueItem = Assert.IsAssignableFrom<ActionValueItem>(context.ActionArguments.First().Value);
+            KeyValuePair<string, object> keyValuePair = Assert.Single(context.ActionArguments);
+            ActionValueItem deserializedActionValueItem = Assert.IsAssignableFrom<ActionValueItem>(keyValuePair.Value);
             Assert.Equal(item.Id, deserializedActionValueItem.Id);
             Assert.Equal(item.FirstName, deserializedActionValueItem.FirstName);
             Assert.Equal(item.LastName, deserializedActionValueItem.LastName);
@@ -692,8 +692,8 @@ namespace System.Web.Http.ModelBinding
             await provider.BindValuesAsync(context, cancellationToken);
 
             // Assert
-            Assert.Equal(1, context.ActionArguments.Count);
-            ActionValueItem deserializedActionValueItem = Assert.IsAssignableFrom<ActionValueItem>(context.ActionArguments.First().Value);
+            KeyValuePair<string, object> keyValuePair = Assert.Single(context.ActionArguments);
+            ActionValueItem deserializedActionValueItem = Assert.IsAssignableFrom<ActionValueItem>(keyValuePair.Value);
             Assert.Equal(7, deserializedActionValueItem.Id);
             Assert.Equal("testFirstName", deserializedActionValueItem.FirstName);
             Assert.Equal("testLastName", deserializedActionValueItem.LastName);
@@ -738,8 +738,8 @@ namespace System.Web.Http.ModelBinding
             await provider.BindValuesAsync(context, CancellationToken.None);
 
             // Assert
-            Assert.Equal(1, context.ActionArguments.Count);
-            object deserializedActionValueItem = context.ActionArguments.First().Value;
+            KeyValuePair<string, object> keyValuePair = Assert.Single(context.ActionArguments);
+            object deserializedActionValueItem = keyValuePair.Value;
             Assert.Null(deserializedActionValueItem);
         }
 
@@ -795,8 +795,8 @@ namespace System.Web.Http.ModelBinding
             await provider.BindValuesAsync(context, cancellationToken);
 
             // Assert
-            Assert.Equal(1, context.ActionArguments.Count);
-            ActionValueItem deserializedActionValueItem = Assert.IsAssignableFrom<ActionValueItem>(context.ActionArguments.First().Value);
+            KeyValuePair<string, object> keyValuePair = Assert.Single(context.ActionArguments);
+            ActionValueItem deserializedActionValueItem = Assert.IsAssignableFrom<ActionValueItem>(keyValuePair.Value);
             Assert.Equal(7, deserializedActionValueItem.Id);
             Assert.Equal("testFirstName", deserializedActionValueItem.FirstName);
             Assert.Equal("testLastName", deserializedActionValueItem.LastName);
@@ -820,8 +820,8 @@ namespace System.Web.Http.ModelBinding
             await provider.BindValuesAsync(context, cancellationToken);
 
             // Assert
-            Assert.Equal(1, context.ActionArguments.Count);
-            ActionValueItem deserializedActionValueItem = Assert.IsAssignableFrom<ActionValueItem>(context.ActionArguments.First().Value);
+            KeyValuePair<string, object> keyValuePair = Assert.Single(context.ActionArguments);
+            ActionValueItem deserializedActionValueItem = Assert.IsAssignableFrom<ActionValueItem>(keyValuePair.Value);
             Assert.Equal(7, deserializedActionValueItem.Id);
             Assert.Equal("testFirstName", deserializedActionValueItem.FirstName);
             Assert.Equal("testLastName", deserializedActionValueItem.LastName);
@@ -848,8 +848,8 @@ namespace System.Web.Http.ModelBinding
             await provider.BindValuesAsync(context, cancellationToken);
 
             // Assert
-            Assert.Equal(1, context.ActionArguments.Count);
-            IEnumerable<ActionValueItem> items = Assert.IsAssignableFrom<IEnumerable<ActionValueItem>>(context.ActionArguments.First().Value);
+            KeyValuePair<string, object> keyValuePair = Assert.Single(context.ActionArguments);
+            IEnumerable<ActionValueItem> items = Assert.IsAssignableFrom<IEnumerable<ActionValueItem>>(keyValuePair.Value);
             ActionValueItem deserializedActionValueItem = items.First();
             Assert.Equal(7, deserializedActionValueItem.Id);
             Assert.Equal("testFirstName", deserializedActionValueItem.FirstName);
@@ -879,8 +879,8 @@ namespace System.Web.Http.ModelBinding
             await provider.BindValuesAsync(context, cancellationToken);
 
             // Assert
-            Assert.Equal(1, context.ActionArguments.Count);
-            JToken deserializedJsonValue = Assert.IsAssignableFrom<JToken>(context.ActionArguments.First().Value);
+            KeyValuePair<string, object> keyValuePair = Assert.Single(context.ActionArguments);
+            JToken deserializedJsonValue = Assert.IsAssignableFrom<JToken>(keyValuePair.Value);
             string deserializedJsonAsString = deserializedJsonValue.ToString(Formatting.None);
             Assert.Equal(json, deserializedJsonAsString);
         }
@@ -983,8 +983,8 @@ namespace System.Web.Http.ModelBinding
             await provider.BindValuesAsync(context, CancellationToken.None);
 
             // Assert
-            Assert.Equal(1, context.ActionArguments.Count);
-            ActionValueItem result = Assert.IsAssignableFrom<ActionValueItem>(context.ActionArguments.First().Value);
+            KeyValuePair<string, object> keyValuePair = Assert.Single(context.ActionArguments);
+            ActionValueItem result = Assert.IsAssignableFrom<ActionValueItem>(keyValuePair.Value);
             Assert.Equal(7, result.Id);
             Assert.Equal("testFirstName", result.FirstName);
             Assert.Equal("testLastName", result.LastName);

--- a/test/System.Web.Http.Integration.Test/ModelBinding/ModelBindingController.cs
+++ b/test/System.Web.Http.Integration.Test/ModelBinding/ModelBindingController.cs
@@ -65,7 +65,6 @@ namespace System.Web.Http.ModelBinding
 
         public Task<int> GetIntAsync(int value, CancellationToken token)
         {
-            Assert.NotNull(token);
             TaskCompletionSource<int> tcs = new TaskCompletionSource<int>();
             tcs.TrySetResult(value);
             return tcs.Task;
@@ -236,8 +235,8 @@ namespace System.Web.Http.ModelBinding
         {
             Assert.True(x != null, "Expected ModelBindOrder cannot be null.");
             Assert.True(y != null, "Actual ModelBindOrder was null.");
-            Assert.Equal<string>(x.ItemName, y.ItemName);
-            Assert.Equal<int>(x.Quantity, y.Quantity);
+            Assert.Equal(x.ItemName, y.ItemName);
+            Assert.Equal(x.Quantity, y.Quantity);
 
             if (x.Customer != null)
             {

--- a/test/System.Web.Http.Integration.Test/ModelBinding/QueryStringBindingTests.cs
+++ b/test/System.Web.Http.Integration.Test/ModelBinding/QueryStringBindingTests.cs
@@ -40,7 +40,7 @@ namespace System.Web.Http.ModelBinding
 
             // Assert
             string responseString = await response.Content.ReadAsStringAsync();
-            Assert.Equal<string>(expectedResponse, responseString);
+            Assert.Equal(expectedResponse, responseString);
         }
 
         [Theory]
@@ -65,7 +65,7 @@ namespace System.Web.Http.ModelBinding
 
             // Assert
             string responseString = await response.Content.ReadAsStringAsync();
-            Assert.Equal<string>(expectedResponse, responseString);
+            Assert.Equal(expectedResponse, responseString);
         }
 
         [Theory]
@@ -91,7 +91,7 @@ namespace System.Web.Http.ModelBinding
 
             // Assert
             ModelBindOrder actualItem = await response.Content.ReadAsAsync<ModelBindOrder>();
-            Assert.Equal<ModelBindOrder>(expectedItem, actualItem, new ModelBindOrderEqualityComparer());
+            Assert.Equal(expectedItem, actualItem, new ModelBindOrderEqualityComparer());
         }
 
         [Theory]
@@ -116,7 +116,7 @@ namespace System.Web.Http.ModelBinding
 
             // Assert
             ModelBindOrder actualItem = await response.Content.ReadAsAsync<ModelBindOrder>();
-            Assert.Equal<ModelBindOrder>(expectedItem, actualItem, new ModelBindOrderEqualityComparer());
+            Assert.Equal(expectedItem, actualItem, new ModelBindOrderEqualityComparer());
         }
 
         [Theory]

--- a/test/System.Web.Http.Integration.Test/ModelBinding/RouteBindingTests.cs
+++ b/test/System.Web.Http.Integration.Test/ModelBinding/RouteBindingTests.cs
@@ -27,7 +27,7 @@ namespace System.Web.Http.ModelBinding
 
             // Assert
             string responseString = await response.Content.ReadAsStringAsync();
-            Assert.Equal<string>("\"ModelBinding:GetStringFromRoute\"", responseString);
+            Assert.Equal("\"ModelBinding:GetStringFromRoute\"", responseString);
         }
     }
 }

--- a/test/System.Web.Http.Integration.Test/System.Web.Http.Integration.Test.csproj
+++ b/test/System.Web.Http.Integration.Test/System.Web.Http.Integration.Test.csproj
@@ -150,6 +150,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/System.Web.Http.Integration.Test/packages.config
+++ b/test/System.Web.Http.Integration.Test/packages.config
@@ -3,7 +3,9 @@
   <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />

--- a/test/System.Web.Http.Owin.Test/ExceptionHandling/DefaultExceptionHandlerTests.cs
+++ b/test/System.Web.Http.Owin.Test/ExceptionHandling/DefaultExceptionHandlerTests.cs
@@ -58,8 +58,7 @@ namespace System.Web.Http.Owin.ExceptionHandling
 
                 // Assert
                 IHttpActionResult result = context.Result;
-                Assert.IsType(typeof(ResponseMessageResult), result);
-                ResponseMessageResult typedResult = (ResponseMessageResult)result;
+                ResponseMessageResult typedResult = Assert.IsType<ResponseMessageResult>(result);
                 using (HttpResponseMessage response = typedResult.Response)
                 {
                     Assert.NotNull(response);
@@ -78,14 +77,12 @@ namespace System.Web.Http.Owin.ExceptionHandling
         private static void AssertErrorResponse(HttpResponseMessage expected, HttpResponseMessage actual)
         {
             Assert.NotNull(expected); // Guard
-            Assert.IsType(typeof(ObjectContent<HttpError>), expected.Content); // Guard
-            ObjectContent<HttpError> expectedContent = (ObjectContent<HttpError>)expected.Content;
+            ObjectContent<HttpError> expectedContent = Assert.IsType<ObjectContent<HttpError>>(expected.Content); // Guard
             Assert.NotNull(expectedContent.Formatter); // Guard
 
             Assert.NotNull(actual);
             Assert.Equal(expected.StatusCode, actual.StatusCode);
-            Assert.IsType(typeof(ObjectContent<HttpError>), actual.Content);
-            ObjectContent<HttpError> actualContent = (ObjectContent<HttpError>)actual.Content;
+            ObjectContent<HttpError> actualContent = Assert.IsType<ObjectContent<HttpError>>(actual.Content);
             Assert.NotNull(actualContent.Formatter);
             Assert.Same(expectedContent.Formatter.GetType(), actualContent.Formatter.GetType());
             Assert.Equal(expectedContent.Value, actualContent.Value);

--- a/test/System.Web.Http.Owin.Test/HostAuthenticationAttributeTest.cs
+++ b/test/System.Web.Http.Owin.Test/HostAuthenticationAttributeTest.cs
@@ -135,8 +135,7 @@ namespace System.Web.Http.Owin
             IAuthenticationFilter innerFilter = product.InnerFilter;
 
             // Assert
-            Assert.IsType<HostAuthenticationFilter>(innerFilter);
-            HostAuthenticationFilter typedInnerFilter = (HostAuthenticationFilter)innerFilter;
+            HostAuthenticationFilter typedInnerFilter = Assert.IsType<HostAuthenticationFilter>(innerFilter);
             Assert.Same(expectedAuthenticationType, typedInnerFilter.AuthenticationType);
         }
 

--- a/test/System.Web.Http.Owin.Test/HostAuthenticationFilterTest.cs
+++ b/test/System.Web.Http.Owin.Test/HostAuthenticationFilterTest.cs
@@ -93,8 +93,7 @@ namespace System.Web.Http.Owin
             // Assert
             Assert.Null(context.ErrorResult);
             IPrincipal principal = context.Principal;
-            Assert.IsType<ClaimsPrincipal>(principal);
-            ClaimsPrincipal claimsPrincipal = (ClaimsPrincipal)principal;
+            ClaimsPrincipal claimsPrincipal = Assert.IsType<ClaimsPrincipal>(principal);
             IIdentity identity = claimsPrincipal.Identity;
             Assert.Same(expectedIdentity, identity);
         }
@@ -291,8 +290,8 @@ namespace System.Web.Http.Owin
             Assert.NotNull(challenge);
             string[] authenticationTypes = challenge.AuthenticationTypes;
             Assert.NotNull(authenticationTypes);
-            Assert.Equal(1, authenticationTypes.Length);
-            Assert.Same(expectedAuthenticationType, authenticationTypes[0]);
+            string authenticationType = Assert.Single(authenticationTypes);
+            Assert.Same(expectedAuthenticationType, authenticationType);
             AuthenticationProperties extra = challenge.Properties;
             Assert.Same(originalExtra, extra);
         }
@@ -321,8 +320,8 @@ namespace System.Web.Http.Owin
             Assert.NotNull(challenge);
             string[] authenticationTypes = challenge.AuthenticationTypes;
             Assert.NotNull(authenticationTypes);
-            Assert.Equal(1, authenticationTypes.Length);
-            Assert.Same(expectedAuthenticationType, authenticationTypes[0]);
+            string authenticationType = Assert.Single(authenticationTypes);
+            Assert.Same(expectedAuthenticationType, authenticationType);
             AuthenticationProperties extra = challenge.Properties;
             Assert.NotNull(extra);
         }

--- a/test/System.Web.Http.Owin.Test/HttpMessageHandlerAdapterTest.cs
+++ b/test/System.Web.Http.Owin.Test/HttpMessageHandlerAdapterTest.cs
@@ -630,8 +630,7 @@ namespace System.Web.Http.Owin
 
                     // Assert
                     HttpRequestContext requestContext = request.GetRequestContext();
-                    Assert.IsType<OwinHttpRequestContext>(requestContext);
-                    OwinHttpRequestContext typedContext = (OwinHttpRequestContext)requestContext;
+                    OwinHttpRequestContext typedContext = Assert.IsType<OwinHttpRequestContext>(requestContext);
                     Assert.Same(expectedContext, typedContext.Context);
                     Assert.Same(request, typedContext.Request);
                 }
@@ -1171,7 +1170,7 @@ namespace System.Web.Http.Owin
                     var exception = await Assert.ThrowsAsync<Exception>(() => product.Invoke(context));
                     Assert.Same(expectedException, exception);
                     Assert.NotNull(exception.StackTrace);
-                    Assert.True(exception.StackTrace.StartsWith(expectedStackTrace));
+                    Assert.StartsWith(expectedStackTrace, exception.StackTrace);
                 }
             }
         }

--- a/test/System.Web.Http.Owin.Test/NonOwnedStreamTests.cs
+++ b/test/System.Web.Http.Owin.Test/NonOwnedStreamTests.cs
@@ -109,7 +109,7 @@ namespace System.Web.Http.Owin
                 bool canRead = product.CanRead;
 
                 // Assert
-                Assert.Equal(false, canRead);
+                Assert.False(canRead);
             }
         }
 

--- a/test/System.Web.Http.Owin.Test/OwinHostIntegrationTest.cs
+++ b/test/System.Web.Http.Owin.Test/OwinHostIntegrationTest.cs
@@ -75,7 +75,9 @@ namespace System.Web.Http.Owin
             return CreateBaseUrl(port) + "/" + localPath;
         }
 
+#pragma warning disable xUnit1013 // Public method should be marked as test
         public void Configuration(IAppBuilder appBuilder)
+#pragma warning restore xUnit1013 // Public method should be marked as test
         {
             var config = new HttpConfiguration();
             config.Routes.MapHttpRoute("Default", "{controller}");

--- a/test/System.Web.Http.Owin.Test/OwinHttpRequestContextTests.cs
+++ b/test/System.Web.Http.Owin.Test/OwinHttpRequestContextTests.cs
@@ -175,7 +175,7 @@ namespace System.Web.Http.Owin
                 bool includeErrorDetail = context.IncludeErrorDetail;
 
                 // Assert
-                Assert.Equal(false, includeErrorDetail);
+                Assert.False(includeErrorDetail);
             }
         }
 
@@ -194,7 +194,7 @@ namespace System.Web.Http.Owin
                 bool includeErrorDetail = context.IncludeErrorDetail;
 
                 // Assert
-                Assert.Equal(true, includeErrorDetail);
+                Assert.True(includeErrorDetail);
             }
         }
 
@@ -310,7 +310,7 @@ namespace System.Web.Http.Owin
                 bool isLocal = context.IsLocal;
 
                 // Assert
-                Assert.Equal(false, isLocal);
+                Assert.False(isLocal);
             }
         }
 

--- a/test/System.Web.Http.Owin.Test/PassiveAuthenticationMessageHandlerTest.cs
+++ b/test/System.Web.Http.Owin.Test/PassiveAuthenticationMessageHandlerTest.cs
@@ -156,8 +156,7 @@ namespace System.Web.Http.Owin
             Assert.NotNull(challenge);
             string[] authenticationTypes = challenge.AuthenticationTypes;
             Assert.NotNull(authenticationTypes);
-            Assert.Equal(1, authenticationTypes.Length);
-            string authenticationType = authenticationTypes[0];
+            string authenticationType = Assert.Single(authenticationTypes);
             Assert.Null(authenticationType);
         }
 
@@ -185,8 +184,7 @@ namespace System.Web.Http.Owin
             Assert.NotNull(challenge);
             string[] authenticationTypes = challenge.AuthenticationTypes;
             Assert.NotNull(authenticationTypes);
-            Assert.Equal(1, authenticationTypes.Length);
-            string authenticationType = authenticationTypes[0];
+            string authenticationType = Assert.Single(authenticationTypes);
             Assert.Null(authenticationType);
             AuthenticationProperties actualExtraWrapper = challenge.Properties;
             Assert.NotNull(actualExtraWrapper);
@@ -217,8 +215,7 @@ namespace System.Web.Http.Owin
             Assert.NotNull(challenge);
             string[] authenticationTypes = challenge.AuthenticationTypes;
             Assert.NotNull(authenticationTypes);
-            Assert.Equal(1, authenticationTypes.Length);
-            string authenticationType = authenticationTypes[0];
+            string authenticationType = Assert.Single(authenticationTypes);
             Assert.Null(authenticationType);
             AuthenticationProperties actualExtraWrapper = challenge.Properties;
             Assert.NotNull(actualExtraWrapper);

--- a/test/System.Web.Http.Owin.Test/System.Web.Http.Owin.Test.csproj
+++ b/test/System.Web.Http.Owin.Test/System.Web.Http.Owin.Test.csproj
@@ -106,6 +106,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/System.Web.Http.Owin.Test/packages.config
+++ b/test/System.Web.Http.Owin.Test/packages.config
@@ -7,7 +7,9 @@
   <package id="Moq" version="4.7.142" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
+  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />

--- a/test/System.Web.Http.SelfHost.Test/DeeplyNestedTypeTests.cs
+++ b/test/System.Web.Http.SelfHost.Test/DeeplyNestedTypeTests.cs
@@ -25,7 +25,7 @@ namespace System.Web.Http.SelfHost
             this.SetupHost();
         }
 
-        public void SetupHost()
+        private void SetupHost()
         {
             baseAddress = String.Format("http://localhost/");
 

--- a/test/System.Web.Http.SelfHost.Test/HttpSelfHostConfigurationTest.cs
+++ b/test/System.Web.Http.SelfHost.Test/HttpSelfHostConfigurationTest.cs
@@ -21,7 +21,7 @@ namespace System.Web.Http.SelfHost
                 return new TheoryDataSet<string, HttpBindingSecurityMode, HttpClientCredentialType>()
                 {
                     {"http://localhost", HttpBindingSecurityMode.TransportCredentialOnly, HttpClientCredentialType.Basic},
-                    {"https://localhost", HttpBindingSecurityMode.Transport, HttpClientCredentialType.Basic}, 
+                    {"https://localhost", HttpBindingSecurityMode.Transport, HttpClientCredentialType.Basic},
                 };
             }
         }
@@ -33,7 +33,7 @@ namespace System.Web.Http.SelfHost
                 return new TheoryDataSet<string, HttpBindingSecurityMode, HttpClientCredentialType>()
                 {
                     {"http://localhost", HttpBindingSecurityMode.TransportCredentialOnly, HttpClientCredentialType.Certificate},
-                    {"https://localhost", HttpBindingSecurityMode.Transport, HttpClientCredentialType.Certificate}, 
+                    {"https://localhost", HttpBindingSecurityMode.Transport, HttpClientCredentialType.Certificate},
                 };
             }
         }
@@ -49,7 +49,7 @@ namespace System.Web.Http.SelfHost
                     {"http://localhost", HttpBindingSecurityMode.TransportCredentialOnly, HttpClientCredentialType.Basic},
                     {"https://localhost", HttpBindingSecurityMode.Transport, HttpClientCredentialType.Basic},
                     {"http://localhost", HttpBindingSecurityMode.TransportCredentialOnly, HttpClientCredentialType.Digest},
-                    {"https://localhost", HttpBindingSecurityMode.Transport, HttpClientCredentialType.Digest}, 
+                    {"https://localhost", HttpBindingSecurityMode.Transport, HttpClientCredentialType.Digest},
                     {"http://localhost", HttpBindingSecurityMode.TransportCredentialOnly, HttpClientCredentialType.Ntlm},
                     {"https://localhost", HttpBindingSecurityMode.Transport, HttpClientCredentialType.Ntlm},
                     {"http://localhost", HttpBindingSecurityMode.TransportCredentialOnly, HttpClientCredentialType.Windows},
@@ -69,7 +69,7 @@ namespace System.Web.Http.SelfHost
                     {"http://localhost", HttpBindingSecurityMode.TransportCredentialOnly, HttpClientCredentialType.Certificate},
                     {"https://localhost", HttpBindingSecurityMode.Transport, HttpClientCredentialType.Certificate},
                     {"http://localhost", HttpBindingSecurityMode.TransportCredentialOnly, HttpClientCredentialType.Digest},
-                    {"https://localhost", HttpBindingSecurityMode.Transport, HttpClientCredentialType.Digest}, 
+                    {"https://localhost", HttpBindingSecurityMode.Transport, HttpClientCredentialType.Digest},
                     {"http://localhost", HttpBindingSecurityMode.TransportCredentialOnly, HttpClientCredentialType.Ntlm},
                     {"https://localhost", HttpBindingSecurityMode.Transport, HttpClientCredentialType.Ntlm},
                     {"http://localhost", HttpBindingSecurityMode.TransportCredentialOnly, HttpClientCredentialType.Windows},
@@ -377,6 +377,7 @@ namespace System.Web.Http.SelfHost
         public void HttpSelfHostConfiguration_WrongClientCredentialType_WithUsernamePasswordValidator_Throws(string address, HttpBindingSecurityMode mode, HttpClientCredentialType clientCredentialType)
         {
             // Arrange
+            GC.KeepAlive(mode); // Mark parameter as used. See xUnit1026, [Theory] method doesn't use all parameters.
             HttpBinding binding = new HttpBinding();
             HttpSelfHostConfiguration config = new HttpSelfHostConfiguration(address)
             {
@@ -397,6 +398,7 @@ namespace System.Web.Http.SelfHost
         public void HttpSelfHostConfiguration_CorrectClientCredentialType_WithUsernamePasswordValidator_Works(string address, HttpBindingSecurityMode mode, HttpClientCredentialType clientCredentialType)
         {
             // Arrange
+            GC.KeepAlive(mode); // Mark parameter as used. See xUnit1026, [Theory] method doesn't use all parameters.
             HttpBinding binding = new HttpBinding();
             HttpSelfHostConfiguration config = new HttpSelfHostConfiguration(address)
             {
@@ -414,6 +416,7 @@ namespace System.Web.Http.SelfHost
         public void HttpSelfHostConfiguration_WrongClientCredentialType_WithX509CertificateValidator_Throws(string address, HttpBindingSecurityMode mode, HttpClientCredentialType clientCredentialType)
         {
             // Arrange
+            GC.KeepAlive(mode); // Mark parameter as used. See xUnit1026, [Theory] method doesn't use all parameters.
             HttpBinding binding = new HttpBinding();
             HttpSelfHostConfiguration config = new HttpSelfHostConfiguration(address)
             {
@@ -434,6 +437,7 @@ namespace System.Web.Http.SelfHost
         public void HttpSelfHostConfiguration_CorrectClientCredentialType_WithX509CertificateValidator_Works(string address, HttpBindingSecurityMode mode, HttpClientCredentialType clientCredentialType)
         {
             // Arrange
+            GC.KeepAlive(mode); // Mark parameter as used. See xUnit1026, [Theory] method doesn't use all parameters.
             HttpBinding binding = new HttpBinding();
             HttpSelfHostConfiguration config = new HttpSelfHostConfiguration(address)
             {

--- a/test/System.Web.Http.SelfHost.Test/MaxHttpCollectionKeyTests.cs
+++ b/test/System.Web.Http.SelfHost.Test/MaxHttpCollectionKeyTests.cs
@@ -27,7 +27,7 @@ namespace System.Web.Http.SelfHost
             this.SetupHost();
         }
 
-        public void SetupHost()
+        private void SetupHost()
         {
             baseAddress = String.Format("http://localhost/");
 
@@ -144,7 +144,7 @@ namespace System.Web.Http.SelfHost
             Assert.NotNull(response.Content);
             Assert.NotNull(response.Content.Headers.ContentType);
             Assert.Equal("application/xml", response.Content.Headers.ContentType.MediaType);
-            Assert.True((await response.Content.ReadAsStringAsync()).Contains(expectedResponseValue));
+            Assert.Contains(expectedResponseValue, await response.Content.ReadAsStringAsync());
         }
 
         private static string GenerateHttpCollectionKeyInput(int num)

--- a/test/System.Web.Http.SelfHost.Test/SelfHostHttpRequestContextTests.cs
+++ b/test/System.Web.Http.SelfHost.Test/SelfHostHttpRequestContextTests.cs
@@ -200,7 +200,7 @@ namespace System.Web.Http.SelfHost
                 bool includeErrorDetail = context.IncludeErrorDetail;
 
                 // Assert
-                Assert.Equal(false, includeErrorDetail);
+                Assert.False(includeErrorDetail);
             }
         }
 
@@ -220,7 +220,7 @@ namespace System.Web.Http.SelfHost
                 bool includeErrorDetail = context.IncludeErrorDetail;
 
                 // Assert
-                Assert.Equal(true, includeErrorDetail);
+                Assert.True(includeErrorDetail);
             }
         }
 
@@ -333,7 +333,7 @@ namespace System.Web.Http.SelfHost
                 bool isLocal = context.IsLocal;
 
                 // Assert
-                Assert.Equal(false, isLocal);
+                Assert.False(isLocal);
             }
         }
 

--- a/test/System.Web.Http.SelfHost.Test/System.Web.Http.SelfHost.Test.csproj
+++ b/test/System.Web.Http.SelfHost.Test/System.Web.Http.SelfHost.Test.csproj
@@ -101,6 +101,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/System.Web.Http.SelfHost.Test/packages.config
+++ b/test/System.Web.Http.SelfHost.Test/packages.config
@@ -3,7 +3,9 @@
   <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />

--- a/test/System.Web.Http.SignalR.Test/System.Web.Http.SignalR.Test.csproj
+++ b/test/System.Web.Http.SignalR.Test/System.Web.Http.SignalR.Test.csproj
@@ -81,6 +81,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/System.Web.Http.SignalR.Test/packages.config
+++ b/test/System.Web.Http.SignalR.Test/packages.config
@@ -4,7 +4,9 @@
   <package id="Microsoft.AspNet.SignalR.Core" version="1.0.0" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />


### PR DESCRIPTION
- part of #65

Few manual changes:
- use `Assert.IsAssignableFrom<T>(...)`, `Assert.IsType<T>(...)` and `Assert.Single(...)` return values
- suppress xUnit1013, Public method should be marked as test
  - mark a few methods as `private` for the same reason
- work around xUnit1026, `[Theory]` method doesn't use all parameters
  - add `GC.KeepAlive(...)`