### PR TITLE
Add xUnit analyzers and take xUnit fixer suggestions (3 of 5): System.Web.Http.Test

### DIFF
--- a/test/Common/CollectionExtensionsTest.cs
+++ b/test/Common/CollectionExtensionsTest.cs
@@ -14,10 +14,10 @@ namespace System.Collections.Generic
         {
             string[] empty = new string[0];
 
-            string[] emptyAppended = empty.AppendAndReallocate("AppendedEmpty");
+            string[] oneAppended = empty.AppendAndReallocate("AppendedEmpty");
 
-            Assert.Equal(1, emptyAppended.Length);
-            Assert.Equal("AppendedEmpty", emptyAppended[0]);
+            string one = Assert.Single(oneAppended);
+            Assert.Equal("AppendedEmpty", one);
         }
 
         [Fact]
@@ -131,6 +131,7 @@ namespace System.Collections.Generic
             Assert.NotSame(array, arrayAsList);
         }
 
+        [Fact]
         public void AsList_ListWrapperCollection_ReturnsSameInstance()
         {
             List<object> list = new List<object> { new object(), new object() };

--- a/test/Common/Routing/RouteFactoryAttributeTests.cs
+++ b/test/Common/Routing/RouteFactoryAttributeTests.cs
@@ -500,8 +500,8 @@ namespace System.Web.Mvc.Routing
             // Assert
             Assert.NotNull(usage);
             Assert.Equal(AttributeTargets.Class | AttributeTargets.Method, usage.ValidOn);
-            Assert.Equal(false, usage.Inherited);
-            Assert.Equal(true, usage.AllowMultiple);
+            Assert.False(usage.Inherited);
+            Assert.True(usage.AllowMultiple);
         }
 
         private static IDirectRouteBuilder CreateBuilder(Func<RouteEntry> build)

--- a/test/Common/UriQueryUtilityTest.cs
+++ b/test/Common/UriQueryUtilityTest.cs
@@ -52,7 +52,7 @@ namespace System.Net.Http
                 Assert.NotNull(result);
 
                 // Because this is a NameValueCollection, the same name appears only once
-                Assert.Equal(1, result.Count);
+                Assert.Single(result);
 
                 // Values should be a comma separated list of empty strings
                 string[] values = result[""].Split(new char[] { ',' });
@@ -84,7 +84,7 @@ namespace System.Net.Http
                 Assert.NotNull(result);
 
                 // Because this is a NameValueCollection, the same name appears only once
-                Assert.Equal(1, result.Count);
+                Assert.Single(result);
 
                 // Values should be a comma separated list of resultValue
                 string[] values = result[resultName].Split(new char[] { ',' });

--- a/test/System.Web.Http.Test/Batch/BatchHttpRequestMessageExtensionsTest.cs
+++ b/test/System.Web.Http.Test/Batch/BatchHttpRequestMessageExtensionsTest.cs
@@ -48,8 +48,7 @@ namespace System.Web.Http.Batch
 
                 // Assert
                 HttpRequestContext context = subRequest.GetRequestContext();
-                Assert.IsType<BatchHttpRequestContext>(context);
-                BatchHttpRequestContext typedContext = (BatchHttpRequestContext)context;
+                BatchHttpRequestContext typedContext = Assert.IsType<BatchHttpRequestContext>(context);
                 Assert.Same(expectedOriginalContext, typedContext.BatchContext);
             }
         }

--- a/test/System.Web.Http.Test/Batch/HttpBatchHandlerTest.cs
+++ b/test/System.Web.Http.Test/Batch/HttpBatchHandlerTest.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -82,12 +81,11 @@ namespace System.Web.Http
                     IExceptionLogger exceptionLogger = product.ExceptionLogger;
 
                     // Assert
-                    Assert.IsType<CompositeExceptionLogger>(exceptionLogger);
-                    CompositeExceptionLogger compositeLogger = (CompositeExceptionLogger)exceptionLogger;
+                    CompositeExceptionLogger compositeLogger = Assert.IsType<CompositeExceptionLogger>(exceptionLogger);
                     IEnumerable<IExceptionLogger> loggers = compositeLogger.Loggers;
                     Assert.NotNull(loggers);
-                    Assert.Equal(1, loggers.Count());
-                    Assert.Same(expectedExceptionLogger, loggers.Single());
+                    IExceptionLogger logger = Assert.Single(loggers);
+                    Assert.Same(expectedExceptionLogger, logger);
                 }
             }
         }
@@ -108,8 +106,7 @@ namespace System.Web.Http
                     IExceptionHandler exceptionHandler = product.ExceptionHandler;
 
                     // Assert
-                    Assert.IsType<LastChanceExceptionHandler>(exceptionHandler);
-                    LastChanceExceptionHandler lastChanceHandler = (LastChanceExceptionHandler)exceptionHandler;
+                    LastChanceExceptionHandler lastChanceHandler = Assert.IsType<LastChanceExceptionHandler>(exceptionHandler);
                     Assert.Same(expectedExceptionHandler, lastChanceHandler.InnerHandler);
                 }
             }
@@ -257,7 +254,7 @@ namespace System.Web.Http
                 // Assert
                 Assert.Same(expectedException, exception);
                 Assert.NotNull(exception.StackTrace);
-                Assert.True(exception.StackTrace.StartsWith(expectedStackTrace));
+                Assert.StartsWith(expectedStackTrace, exception.StackTrace);
             }
         }
 

--- a/test/System.Web.Http.Test/Controllers/ApiControllerTest.cs
+++ b/test/System.Web.Http.Test/Controllers/ApiControllerTest.cs
@@ -863,8 +863,7 @@ namespace System.Web.Http
             using (HttpRequestMessage expectedRequest = CreateRequest())
             {
                 ApiController controller = CreateFakeController();
-                Assert.IsType<RequestBackedHttpRequestContext>(controller.RequestContext); // Guard
-                RequestBackedHttpRequestContext context = (RequestBackedHttpRequestContext)controller.RequestContext;
+                RequestBackedHttpRequestContext context = Assert.IsType<RequestBackedHttpRequestContext>(controller.RequestContext); // Guard
 
                 // Act
                 controller.Request = expectedRequest;

--- a/test/System.Web.Http.Test/Controllers/ExceptionFilterResultTests.cs
+++ b/test/System.Web.Http.Test/Controllers/ExceptionFilterResultTests.cs
@@ -310,7 +310,7 @@ namespace System.Web.Http.Controllers
                 Assert.NotNull(expectedStackTrace);
                 Assert.NotNull(exception);
                 Assert.NotNull(exception.StackTrace);
-                Assert.True(exception.StackTrace.StartsWith(expectedStackTrace));
+                Assert.StartsWith(expectedStackTrace, exception.StackTrace);
             }
         }
 

--- a/test/System.Web.Http.Test/Controllers/FilterGroupingTests.cs
+++ b/test/System.Web.Http.Test/Controllers/FilterGroupingTests.cs
@@ -22,10 +22,10 @@ namespace System.Web.Http.Controllers
 
             // Act
             IActionFilter[] actionFilters = product.ActionFilters;
-            
+
             // Assert
             Assert.NotNull(actionFilters);
-            Assert.Equal(0, actionFilters.Length);
+            Assert.Empty(actionFilters);
         }
 
         [Fact]
@@ -120,8 +120,8 @@ namespace System.Web.Http.Controllers
 
             // Assert
             Assert.NotNull(actionFilters);
-            Assert.Equal(1, actionFilters.Length);
-            Assert.Same(expectedActionFilter, actionFilters[0]);
+            IActionFilter singleFilter = Assert.Single(actionFilters);
+            Assert.Same(expectedActionFilter, singleFilter);
         }
 
         [Fact]
@@ -169,8 +169,8 @@ namespace System.Web.Http.Controllers
 
             // Assert
             Assert.NotNull(authorizationFilters);
-            Assert.Equal(1, authorizationFilters.Length);
-            Assert.Same(expectedActionFilter, authorizationFilters[0]);
+            IAuthorizationFilter authorizationFilter = Assert.Single(authorizationFilters);
+            Assert.Same(expectedActionFilter, authorizationFilter);
         }
 
         [Fact]
@@ -193,8 +193,8 @@ namespace System.Web.Http.Controllers
 
             // Assert
             Assert.NotNull(authenticationFilters);
-            Assert.Equal(1, authenticationFilters.Length);
-            Assert.Same(expectedActionFilter, authenticationFilters[0]);
+            IAuthenticationFilter authenticationFilter = Assert.Single(authenticationFilters);
+            Assert.Same(expectedActionFilter, authenticationFilter);
         }
 
         [Fact]
@@ -216,8 +216,8 @@ namespace System.Web.Http.Controllers
 
             // Assert
             Assert.NotNull(exceptionFilters);
-            Assert.Equal(1, exceptionFilters.Length);
-            Assert.Same(expectedActionFilter, exceptionFilters[0]);
+            IExceptionFilter exceptionFilter = Assert.Single(exceptionFilters);
+            Assert.Same(expectedActionFilter, exceptionFilter);
         }
 
         [Fact]
@@ -237,10 +237,10 @@ namespace System.Web.Http.Controllers
 
             // Assert
             Assert.NotNull(actionFilters);
-            Assert.Equal(1, actionFilters.Length);
-            Assert.Same(expectedInstance, actionFilters[0]);
+            IActionFilter actionFilter = Assert.Single(actionFilters);
+            Assert.Same(expectedInstance, actionFilter);
             Assert.NotNull(exceptionFilters);
-            Assert.Equal(0, exceptionFilters.Length);
+            Assert.Empty(exceptionFilters);
         }
 
         private static IActionFilter CreateDummyActionFilter()

--- a/test/System.Web.Http.Test/Controllers/HttpControllerDescriptorTest.cs
+++ b/test/System.Web.Http.Test/Controllers/HttpControllerDescriptorTest.cs
@@ -123,7 +123,7 @@ namespace System.Web.Http
         [Fact]
         public void Initialize_In_InheritenceHierarchy()
         {
-            // Verifies that initialization is run in order with , and that they all mutate on the same descriptor object 
+            // Verifies that initialization is run in order with , and that they all mutate on the same descriptor object
             HttpConfiguration config = new HttpConfiguration();
 
             // Act.
@@ -139,7 +139,7 @@ namespace System.Web.Http
         [Fact]
         public void Initialize_In_InheritenceHierarchy_Branching()
         {
-            // Verifies that initialization is run in order with, and that they all mutate on the same descriptor object 
+            // Verifies that initialization is run in order with, and that they all mutate on the same descriptor object
             HttpConfiguration config = new HttpConfiguration();
 
             // Act.
@@ -181,7 +181,7 @@ namespace System.Web.Http
 
             var attributes = desc.GetCustomAttributes<MyConfigBaseAttribute>();
 
-            Assert.Equal(1, attributes.Count);
+            Assert.Single(attributes);
         }
 
         [Fact]
@@ -192,7 +192,7 @@ namespace System.Web.Http
 
             var attributes = desc.GetCustomAttributes<MyConfigBaseAttribute>(inherit: true);
 
-            Assert.Equal(1, attributes.Count);
+            Assert.Single(attributes);
         }
 
         [Fact]
@@ -214,7 +214,7 @@ namespace System.Web.Http
 
             var attributes = desc.GetCustomAttributes<MyConfigDerived1Attribute>(inherit: false);
 
-            Assert.Equal(1, attributes.Count);
+            Assert.Single(attributes);
         }
 
         class NoopControllerConfigAttribute : Attribute, IControllerConfiguration
@@ -307,7 +307,7 @@ namespace System.Web.Http
         [Fact]
         public void Initialize_Append_A_Formatter()
         {
-            // Verifies that controller inherit the formatter list from the global config, and can mutate it. 
+            // Verifies that controller inherit the formatter list from the global config, and can mutate it.
             HttpConfiguration config = new HttpConfiguration();
 
             MediaTypeFormatter globalFormatter = new Mock<MediaTypeFormatter>().Object;
@@ -328,8 +328,8 @@ namespace System.Web.Http
         {
             public void Initialize(HttpControllerSettings settings, HttpControllerDescriptor controllerDescriptor)
             {
-                // Appends to existing list. Formatter list has copy-on-write semantics. 
-                Assert.Equal(1, settings.Formatters.Count); // the one we already set 
+                // Appends to existing list. Formatter list has copy-on-write semantics.
+                Assert.Single(settings.Formatters); // the one we already set
                 settings.Formatters.Add(MyControllerWithCustomFormatter.CustomFormatter);
             }
         }

--- a/test/System.Web.Http.Test/Controllers/HttpParameterDescriptorTest.cs
+++ b/test/System.Web.Http.Test/Controllers/HttpParameterDescriptorTest.cs
@@ -61,7 +61,7 @@ namespace System.Web.Http
             HttpParameterDescriptor parameterDescriptor = new Mock<HttpParameterDescriptor> { CallBase = true }.Object;
             IEnumerable<object> attributes = parameterDescriptor.GetCustomAttributes<object>();
 
-            Assert.Equal(0, attributes.Count());
+            Assert.Empty(attributes);
         }
 
         [Fact]
@@ -70,7 +70,7 @@ namespace System.Web.Http
             HttpParameterDescriptor parameterDescriptor = new Mock<HttpParameterDescriptor> { CallBase = true }.Object;
             IEnumerable<FromBodyAttribute> attributes = parameterDescriptor.GetCustomAttributes<FromBodyAttribute>();
 
-            Assert.Equal(0, attributes.Count());
+            Assert.Empty(attributes);
         }
     }
 }

--- a/test/System.Web.Http.Test/Controllers/ReflectedHttpActionDescriptorTest.cs
+++ b/test/System.Web.Http.Test/Controllers/ReflectedHttpActionDescriptorTest.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
@@ -118,8 +117,8 @@ namespace System.Web.Http
             IEnumerable<IFilter> filters = actionDescriptor.GetFilters();
 
             Assert.NotNull(filters);
-            Assert.Equal(1, filters.Count());
-            Assert.Equal(typeof(AuthorizeAttribute), filters.First().GetType());
+            IFilter filter = Assert.Single(filters);
+            Assert.IsType<AuthorizeAttribute>(filter);
         }
 
         [Fact]
@@ -153,10 +152,10 @@ namespace System.Web.Http
             IEnumerable<HttpGetAttribute> httpGet = actionDescriptor.GetCustomAttributes<HttpGetAttribute>();
 
             Assert.NotNull(filters);
-            Assert.Equal(1, filters.Count());
-            Assert.Equal(typeof(AuthorizeAttribute), filters.First().GetType());
+            IFilter filter = Assert.Single(filters);
+            Assert.IsType<AuthorizeAttribute>(filter);
             Assert.NotNull(httpGet);
-            Assert.Equal(1, httpGet.Count());
+            Assert.Single(httpGet);
         }
 
         [Fact]
@@ -168,8 +167,8 @@ namespace System.Web.Http
             Collection<HttpParameterDescriptor> parameterDescriptors = actionDescriptor.GetParameters();
 
             Assert.Equal(2, parameterDescriptors.Count);
-            Assert.NotNull(parameterDescriptors.Where(p => p.ParameterName == "firstName").FirstOrDefault());
-            Assert.NotNull(parameterDescriptors.Where(p => p.ParameterName == "lastName").FirstOrDefault());
+            Assert.Contains(parameterDescriptors, p => p.ParameterName == "firstName");
+            Assert.Contains(parameterDescriptors, p => p.ParameterName == "lastName");
         }
 
         [Fact]

--- a/test/System.Web.Http.Test/Controllers/ReflectedHttpParameterDescriptorTest.cs
+++ b/test/System.Web.Http.Test/Controllers/ReflectedHttpParameterDescriptorTest.cs
@@ -88,8 +88,8 @@ namespace System.Web.Http
             ReflectedHttpParameterDescriptor parameterDescriptor = new ReflectedHttpParameterDescriptor(actionDescriptor, parameterInfo);
             object[] attributes = parameterDescriptor.GetCustomAttributes<object>().ToArray();
 
-            Assert.Equal(1, attributes.Length);
-            Assert.Equal(typeof(FromBodyAttribute), attributes[0].GetType());
+            object attribute = Assert.Single(attributes);
+            Assert.IsType<FromBodyAttribute>(attribute);
         }
 
         [Fact]
@@ -102,7 +102,7 @@ namespace System.Web.Http
             ReflectedHttpParameterDescriptor parameterDescriptor = new ReflectedHttpParameterDescriptor(actionDescriptor, parameterInfo);
             IEnumerable<FromBodyAttribute> attributes = parameterDescriptor.GetCustomAttributes<FromBodyAttribute>();
 
-            Assert.Equal(1, attributes.Count());
+            Assert.Single(attributes);
         }
     }
 }

--- a/test/System.Web.Http.Test/Controllers/RequestBackedHttpRequestContextTests.cs
+++ b/test/System.Web.Http.Test/Controllers/RequestBackedHttpRequestContextTests.cs
@@ -236,7 +236,7 @@ namespace System.Web.Http.Controllers
             bool includeErrorDetail = context.IncludeErrorDetail;
 
             // Assert
-            Assert.Equal(false, includeErrorDetail);
+            Assert.False(includeErrorDetail);
         }
 
         [Theory]
@@ -305,7 +305,7 @@ namespace System.Web.Http.Controllers
             bool isLocal = context.IsLocal;
 
             // Assert
-            Assert.Equal(false, isLocal);
+            Assert.False(isLocal);
         }
 
         [Theory]

--- a/test/System.Web.Http.Test/Description/ApiParameterDescriptionTest.cs
+++ b/test/System.Web.Http.Test/Description/ApiParameterDescriptionTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Web.Http.Controllers;
 using Microsoft.TestCommon;
@@ -25,8 +24,8 @@ namespace System.Web.Http.Description
             IEnumerable<PropertyInfo> bindableProperties = parameter.GetBindableProperties();
 
             // Assert
-            Assert.Equal(1, bindableProperties.Count());
-            Assert.Equal("ValidProperty", bindableProperties.Single().Name);
+            PropertyInfo bindableProperty = Assert.Single(bindableProperties);
+            Assert.Equal("ValidProperty", bindableProperty.Name);
         }
     }
 

--- a/test/System.Web.Http.Test/Dispatcher/DefaultHttpControllerSelectorTest.cs
+++ b/test/System.Web.Http.Test/Dispatcher/DefaultHttpControllerSelectorTest.cs
@@ -125,7 +125,7 @@ namespace System.Web.Http.Dispatcher
             HttpControllerDescriptor descriptor = selector.SelectController(request);
 
             // Assert
-            Assert.IsType(typeof(HttpControllerDescriptor), descriptor);
+            Assert.IsType<HttpControllerDescriptor>(descriptor);
             Assert.Equal(controllerType, descriptor.ControllerType);
         }
 

--- a/test/System.Web.Http.Test/Dispatcher/HttpControllerDispatcherTest.cs
+++ b/test/System.Web.Http.Test/Dispatcher/HttpControllerDispatcherTest.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Runtime.ExceptionServices;
@@ -81,12 +80,11 @@ namespace System.Web.Http.Dispatcher
                     IExceptionLogger exceptionLogger = product.ExceptionLogger;
 
                     // Assert
-                    Assert.IsType<CompositeExceptionLogger>(exceptionLogger);
-                    CompositeExceptionLogger compositeLogger = (CompositeExceptionLogger)exceptionLogger;
+                    CompositeExceptionLogger compositeLogger = Assert.IsType<CompositeExceptionLogger>(exceptionLogger);
                     IEnumerable<IExceptionLogger> loggers = compositeLogger.Loggers;
                     Assert.NotNull(loggers);
-                    Assert.Equal(1, loggers.Count());
-                    Assert.Same(expectedExceptionLogger, loggers.Single());
+                    IExceptionLogger logger = Assert.Single(loggers);
+                    Assert.Same(expectedExceptionLogger, logger);
                 }
             }
         }
@@ -106,8 +104,7 @@ namespace System.Web.Http.Dispatcher
                     IExceptionHandler exceptionHandler = product.ExceptionHandler;
 
                     // Assert
-                    Assert.IsType<LastChanceExceptionHandler>(exceptionHandler);
-                    LastChanceExceptionHandler lastChanceHandler = (LastChanceExceptionHandler)exceptionHandler;
+                    LastChanceExceptionHandler lastChanceHandler = Assert.IsType<LastChanceExceptionHandler>(exceptionHandler);
                     Assert.Same(expectedExceptionHandler, lastChanceHandler.InnerHandler);
                 }
             }
@@ -359,7 +356,7 @@ namespace System.Web.Http.Dispatcher
 
                 Assert.Same(exceptionInfo.SourceException, exception);
                 Assert.NotNull(exception.StackTrace);
-                Assert.True(exception.StackTrace.StartsWith(expectedStackTrace));
+                Assert.StartsWith(expectedStackTrace, exception.StackTrace);
             }
         }
 
@@ -486,8 +483,7 @@ namespace System.Web.Http.Dispatcher
                 HttpResponseMessage ignore = await invoker.SendAsync(request, CancellationToken.None);
 
                 // Assert
-                Assert.IsType<RequestBackedHttpRequestContext>(requestContext);
-                RequestBackedHttpRequestContext typedRequestContext = (RequestBackedHttpRequestContext)requestContext;
+                RequestBackedHttpRequestContext typedRequestContext = Assert.IsType<RequestBackedHttpRequestContext>(requestContext);
                 Assert.Same(request, typedRequestContext.Request);
                 Assert.Same(configuration, typedRequestContext.Configuration);
             }
@@ -524,8 +520,7 @@ namespace System.Web.Http.Dispatcher
                 HttpResponseMessage ignore = await invoker.SendAsync(request, CancellationToken.None);
 
                 // Assert
-                Assert.IsType<RequestBackedHttpRequestContext>(requestContext);
-                RequestBackedHttpRequestContext typedRequestContext = (RequestBackedHttpRequestContext)requestContext;
+                RequestBackedHttpRequestContext typedRequestContext = Assert.IsType<RequestBackedHttpRequestContext>(requestContext);
                 Assert.Same(request, typedRequestContext.Request);
                 Assert.Same(configuration, typedRequestContext.Configuration);
             }

--- a/test/System.Web.Http.Test/Dispatcher/HttpRoutingDispatcherTest.cs
+++ b/test/System.Web.Http.Test/Dispatcher/HttpRoutingDispatcherTest.cs
@@ -171,7 +171,7 @@ namespace System.Web.Http.Dispatcher
                 HttpResponseMessage response = await invoker.SendAsync(expectedRequest, CancellationToken.None);
 
                 // Assert
-                Assert.Equal(response.StatusCode, HttpStatusCode.NotFound);
+                Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
                 Assert.True(response.RequestMessage.Properties.ContainsKey(HttpPropertyKeys.NoRouteMatched));
             }
         }

--- a/test/System.Web.Http.Test/ExceptionHandling/CompositeExceptionLoggerTests.cs
+++ b/test/System.Web.Http.Test/ExceptionHandling/CompositeExceptionLoggerTests.cs
@@ -35,8 +35,8 @@ namespace System.Web.Http.ExceptionHandling
 
             // Assert
             Assert.NotNull(loggers);
-            Assert.Equal(1, loggers.Count());
-            Assert.Same(expectedLogger, loggers.Single());
+            IExceptionLogger logger = Assert.Single(loggers);
+            Assert.Same(expectedLogger, logger);
 
         }
 
@@ -54,8 +54,8 @@ namespace System.Web.Http.ExceptionHandling
             expectedLoggers.Clear();
             IEnumerable<IExceptionLogger> loggers = product.Loggers;
             Assert.NotNull(loggers);
-            Assert.Equal(1, loggers.Count());
-            Assert.Same(expectedLogger, loggers.Single());
+            IExceptionLogger logger = Assert.Single(loggers);
+            Assert.Same(expectedLogger, logger);
         }
 
         [Fact]

--- a/test/System.Web.Http.Test/ExceptionHandling/DefaultExceptionHandlerTests.cs
+++ b/test/System.Web.Http.Test/ExceptionHandling/DefaultExceptionHandlerTests.cs
@@ -56,8 +56,7 @@ namespace System.Web.Http.ExceptionHandling
 
                 // Assert
                 IHttpActionResult result = context.Result;
-                Assert.IsType(typeof(ResponseMessageResult), result);
-                ResponseMessageResult typedResult = (ResponseMessageResult)result;
+                ResponseMessageResult typedResult = Assert.IsType<ResponseMessageResult>(result);
                 using (HttpResponseMessage response = typedResult.Response)
                 {
                     Assert.NotNull(response);
@@ -95,14 +94,12 @@ namespace System.Web.Http.ExceptionHandling
         private static void AssertErrorResponse(HttpResponseMessage expected, HttpResponseMessage actual)
         {
             Assert.NotNull(expected); // Guard
-            Assert.IsType(typeof(ObjectContent<HttpError>), expected.Content); // Guard
-            ObjectContent<HttpError> expectedContent = (ObjectContent<HttpError>)expected.Content;
+            ObjectContent<HttpError> expectedContent = Assert.IsType<ObjectContent<HttpError>>(expected.Content); // Guard
             Assert.NotNull(expectedContent.Formatter); // Guard
 
             Assert.NotNull(actual);
             Assert.Equal(expected.StatusCode, actual.StatusCode);
-            Assert.IsType(typeof(ObjectContent<HttpError>), actual.Content);
-            ObjectContent<HttpError> actualContent = (ObjectContent<HttpError>)actual.Content;
+            ObjectContent<HttpError> actualContent = Assert.IsType<ObjectContent<HttpError>>(actual.Content);
             Assert.NotNull(actualContent.Formatter);
             Assert.Same(expectedContent.Formatter.GetType(), actualContent.Formatter.GetType());
             Assert.Equal(expectedContent.Value, actualContent.Value);

--- a/test/System.Web.Http.Test/ExceptionHandling/ExceptionLoggerTests.cs
+++ b/test/System.Web.Http.Test/ExceptionHandling/ExceptionLoggerTests.cs
@@ -141,7 +141,7 @@ namespace System.Web.Http.ExceptionHandling
             bool shouldLog = product.ShouldLog(context);
 
             // Assert
-            Assert.Equal(true, shouldLog);
+            Assert.True(shouldLog);
         }
 
         [Fact]
@@ -169,7 +169,7 @@ namespace System.Web.Http.ExceptionHandling
             bool shouldLog = product.ShouldLog(context);
 
             // Assert
-            Assert.Equal(true, shouldLog);
+            Assert.True(shouldLog);
         }
 
         [Fact]
@@ -188,11 +188,11 @@ namespace System.Web.Http.ExceptionHandling
             bool shouldLog = product.ShouldLog(context);
 
             // Assert
-            Assert.Equal(true, shouldLog);
+            Assert.True(shouldLog);
             Assert.True(data.Contains(ExceptionLogger.LoggedByKey));
             object loggedBy = data[ExceptionLogger.LoggedByKey];
-            Assert.IsAssignableFrom<ICollection<object>>(loggedBy);
-            Assert.Contains(product, (ICollection<object>)loggedBy);
+            ICollection<object> loggedByCollection = Assert.IsAssignableFrom<ICollection<object>>(loggedBy);
+            Assert.Contains(product, loggedByCollection);
         }
 
         [Fact]
@@ -213,7 +213,7 @@ namespace System.Web.Http.ExceptionHandling
             bool shouldLog = product.ShouldLog(context);
 
             // Assert
-            Assert.Equal(true, shouldLog);
+            Assert.True(shouldLog);
             Assert.True(data.Contains(ExceptionLogger.LoggedByKey));
             object updatedLoggedBy = data[ExceptionLogger.LoggedByKey];
             Assert.Same(loggedBy, updatedLoggedBy);
@@ -238,7 +238,7 @@ namespace System.Web.Http.ExceptionHandling
             bool shouldLog = product.ShouldLog(context);
 
             // Assert
-            Assert.Equal(false, shouldLog);
+            Assert.False(shouldLog);
             Assert.True(data.Contains(ExceptionLogger.LoggedByKey));
             object updatedLoggedBy = data[ExceptionLogger.LoggedByKey];
             Assert.Same(loggedBy, updatedLoggedBy);
@@ -262,7 +262,7 @@ namespace System.Web.Http.ExceptionHandling
             bool shouldLog = product.ShouldLog(context);
 
             // Assert
-            Assert.Equal(true, shouldLog);
+            Assert.True(shouldLog);
             Assert.True(data.Contains(ExceptionLogger.LoggedByKey));
             object updatedLoggedBy = data[ExceptionLogger.LoggedByKey];
             Assert.Null(updatedLoggedBy);

--- a/test/System.Web.Http.Test/ExceptionHandling/ExceptionServicesTests.cs
+++ b/test/System.Web.Http.Test/ExceptionHandling/ExceptionServicesTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Web.Http.Controllers;
 using Microsoft.TestCommon;
 using Moq;
@@ -24,10 +23,9 @@ namespace System.Web.Http.ExceptionHandling
                 IExceptionLogger logger = ExceptionServices.GetLogger(services);
 
                 // Assert
-                Assert.IsType<CompositeExceptionLogger>(logger);
-                IEnumerable<IExceptionLogger> loggers = ((CompositeExceptionLogger)logger).Loggers;
-                Assert.Equal(1, loggers.Count());
-                Assert.Same(expectedLogger, loggers.Single());
+                IEnumerable<IExceptionLogger> loggers = Assert.IsType<CompositeExceptionLogger>(logger).Loggers;
+                IExceptionLogger actualLogger = Assert.Single(loggers);
+                Assert.Same(expectedLogger, actualLogger);
             }
         }
 
@@ -71,10 +69,9 @@ namespace System.Web.Http.ExceptionHandling
                 IExceptionLogger logger = ExceptionServices.GetLogger(configuration);
 
                 // Assert
-                Assert.IsType<CompositeExceptionLogger>(logger);
-                IEnumerable<IExceptionLogger> loggers = ((CompositeExceptionLogger)logger).Loggers;
-                Assert.Equal(1, loggers.Count());
-                Assert.Same(expectedLogger, loggers.Single());
+                IEnumerable<IExceptionLogger> loggers = Assert.IsType<CompositeExceptionLogger>(logger).Loggers;
+                IExceptionLogger actualLogger = Assert.Single(loggers);
+                Assert.Same(expectedLogger, actualLogger);
             }
         }
 
@@ -100,8 +97,7 @@ namespace System.Web.Http.ExceptionHandling
                 IExceptionHandler handler = ExceptionServices.GetHandler(services);
 
                 // Assert
-                Assert.IsType<LastChanceExceptionHandler>(handler);
-                IExceptionHandler innerHandler = ((LastChanceExceptionHandler)handler).InnerHandler;
+                IExceptionHandler innerHandler = Assert.IsType<LastChanceExceptionHandler>(handler).InnerHandler;
                 Assert.Same(expectedHandler, innerHandler);
             }
         }
@@ -136,8 +132,7 @@ namespace System.Web.Http.ExceptionHandling
                 IExceptionHandler handler = ExceptionServices.GetHandler(services);
 
                 // Assert
-                Assert.IsType<LastChanceExceptionHandler>(handler);
-                IExceptionHandler innerHandler = ((LastChanceExceptionHandler)handler).InnerHandler;
+                IExceptionHandler innerHandler = Assert.IsType<LastChanceExceptionHandler>(handler).InnerHandler;
                 Assert.IsType<EmptyExceptionHandler>(innerHandler);
             }
         }
@@ -164,8 +159,7 @@ namespace System.Web.Http.ExceptionHandling
                 IExceptionHandler handler = ExceptionServices.GetHandler(configuration);
 
                 // Assert
-                Assert.IsType<LastChanceExceptionHandler>(handler);
-                IExceptionHandler innerHandler = ((LastChanceExceptionHandler)handler).InnerHandler;
+                IExceptionHandler innerHandler = Assert.IsType<LastChanceExceptionHandler>(handler).InnerHandler;
                 Assert.Same(expectedHandler, innerHandler);
             }
         }

--- a/test/System.Web.Http.Test/ExceptionHandling/LastChanceExceptionHandlerTests.cs
+++ b/test/System.Web.Http.Test/ExceptionHandling/LastChanceExceptionHandlerTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Formatting;
 using System.Threading;
@@ -114,15 +113,14 @@ namespace System.Web.Http.ExceptionHandling
                 await product.HandleAsync(context, cancellationToken);
 
                 // Assert
-                Assert.IsType<ExceptionResult>(result);
-                ExceptionResult exceptionResult = (ExceptionResult)result;
+                ExceptionResult exceptionResult = Assert.IsType<ExceptionResult>(result);
                 Assert.Same(expectedException, exceptionResult.Exception);
                 Assert.Equal(includeDetail, exceptionResult.IncludeErrorDetail);
                 Assert.Same(expectedContentNegotiator, exceptionResult.ContentNegotiator);
                 Assert.Same(expectedRequest, exceptionResult.Request);
                 Assert.NotNull(exceptionResult.Formatters);
-                Assert.Equal(1, exceptionResult.Formatters.Count());
-                Assert.Same(expectedFormatter, exceptionResult.Formatters.Single());
+                MediaTypeFormatter formatter = Assert.Single(exceptionResult.Formatters);
+                Assert.Same(expectedFormatter, formatter);
             }
         }
 

--- a/test/System.Web.Http.Test/Filters/ActionFilterAttributeTest.cs
+++ b/test/System.Web.Http.Test/Filters/ActionFilterAttributeTest.cs
@@ -505,7 +505,7 @@ namespace System.Web.Http.Filters
 
                 // Assert
                 Assert.NotNull(expectedStackTrace);
-                Assert.True(exception.StackTrace.StartsWith(expectedStackTrace));
+                Assert.StartsWith(expectedStackTrace, exception.StackTrace);
             }
         }
 

--- a/test/System.Web.Http.Test/Filters/AuthorizationFilterAttributeTest.cs
+++ b/test/System.Web.Http.Test/Filters/AuthorizationFilterAttributeTest.cs
@@ -66,16 +66,22 @@ namespace System.Web.Http.Filters
             Assert.True(flagWhenContinuationInvoked.Value);
         }
 
+        [Fact]
         public async Task ExecuteAuthorizationFilterAsync_IfOnActionExecutingSetsResult_ShortCircuits()
         {
             // Arrange
             HttpActionContext context = ContextUtil.CreateActionContext();
-            Mock<AuthorizationFilterAttribute> filterMock = new Mock<AuthorizationFilterAttribute>();
+            Mock<AuthorizationFilterAttribute> filterMock = new Mock<AuthorizationFilterAttribute>
+            {
+                CallBase = true,
+            };
+
             HttpResponseMessage response = new HttpResponseMessage();
             filterMock.Setup(f => f.OnAuthorization(It.IsAny<HttpActionContext>())).Callback<HttpActionContext>(c =>
             {
                 c.Response = response;
             });
+
             bool continuationCalled = false;
             var filter = (IAuthorizationFilter)filterMock.Object;
 

--- a/test/System.Web.Http.Test/HttpConfigurationExtensionsTest.cs
+++ b/test/System.Web.Http.Test/HttpConfigurationExtensionsTest.cs
@@ -164,8 +164,8 @@ namespace System.Net.Http
             // Assert
             var routes = config.GetAttributeRoutes();
             Assert.Equal(2, routes.Count);
-            Assert.Single(routes.Where(route => route.RouteTemplate == "controller/get1"));
-            Assert.Single(routes.Where(route => route.RouteTemplate == "controller/get2"));
+            Assert.Single(routes, route => route.RouteTemplate == "controller/get1");
+            Assert.Single(routes, route => route.RouteTemplate == "controller/get2");
         }
 
         [Fact]
@@ -179,8 +179,8 @@ namespace System.Net.Http
             config.Services.Clear(typeof(IHttpActionSelector));
             config.Services.Clear(typeof(IActionValueBinder));
 
-            // Call Map, ensure that it's not touching any services yet since all work is deferred. 
-            // This is important since these services aren't ready to be used until after config is finalized. 
+            // Call Map, ensure that it's not touching any services yet since all work is deferred.
+            // This is important since these services aren't ready to be used until after config is finalized.
             // Else we may end up caching objects prematurely.
             config.MapHttpAttributeRoutes();
 

--- a/test/System.Web.Http.Test/HttpErrorKeysTest.cs
+++ b/test/System.Web.Http.Test/HttpErrorKeysTest.cs
@@ -5,14 +5,14 @@ using Microsoft.TestCommon;
 
 namespace System.Web.Http
 {
-    class HttpErrorKeysTest
+    public class HttpErrorKeysTest
     {
         public static TheoryDataSet<Func<string>, string> ErrorKeys
         {
             get
             {
                 return new TheoryDataSet<Func<string>, string>
-                {       
+                {
                     { () => HttpErrorKeys.MessageKey, "Message" },
                     { () => HttpErrorKeys.MessageDetailKey, "MessageDetail" },
                     { () => HttpErrorKeys.ModelStateKey, "ModelState" },

--- a/test/System.Web.Http.Test/HttpRequestMessageExtensionsTest.cs
+++ b/test/System.Web.Http.Test/HttpRequestMessageExtensionsTest.cs
@@ -795,8 +795,8 @@ namespace System.Net.Http
             request.RegisterForDispose(disposable);
 
             var list = Assert.IsType<List<IDisposable>>(request.Properties[HttpPropertyKeys.DisposableRequestResourcesKey]);
-            Assert.Equal(1, list.Count);
-            Assert.Same(disposable, list[0]);
+            IDisposable item = Assert.Single(list);
+            Assert.Same(disposable, item);
         }
 
         [Fact]
@@ -810,8 +810,8 @@ namespace System.Net.Http
             request.RegisterForDispose(disposable);
 
             Assert.Same(list, request.Properties[HttpPropertyKeys.DisposableRequestResourcesKey]);
-            Assert.Equal(1, list.Count);
-            Assert.Same(disposable, list[0]);
+            IDisposable item = Assert.Single(list);
+            Assert.Same(disposable, item);
         }
 
         [Fact]
@@ -1025,7 +1025,7 @@ namespace System.Net.Http
                 bool isLocal = request.IsLocal();
 
                 // Assert
-                Assert.Equal(false, isLocal);
+                Assert.False(isLocal);
             }
         }
 

--- a/test/System.Web.Http.Test/HttpRouteCollectionExtensionsTest.cs
+++ b/test/System.Web.Http.Test/HttpRouteCollectionExtensionsTest.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Threading;
 using System.Web.Http.Batch;
 using System.Web.Http.Routing;
 using Microsoft.TestCommon;
@@ -169,7 +168,7 @@ namespace System.Web.Http
             Assert.NotNull(route);
             Assert.Equal("SomeRouteTemplate", route.RouteTemplate);
             Assert.IsType<StopRoutingHandler>(route.Handler);
-            Assert.True(route.Defaults.Count == 0);
+            Assert.Empty(route.Defaults);
             Assert.Empty(route.Constraints);
         }
 
@@ -188,7 +187,7 @@ namespace System.Web.Http
             Assert.NotNull(route);
             Assert.Equal("SomeRouteTemplate", route.RouteTemplate);
             Assert.IsType<StopRoutingHandler>(route.Handler);
-            Assert.True(route.Defaults.Count == 0);
+            Assert.Empty(route.Defaults);
             Assert.Single(route.Constraints);
             Assert.Equal("DefaultFoo", route.Constraints["Foo"]);
         }

--- a/test/System.Web.Http.Test/HttpServerTest.cs
+++ b/test/System.Web.Http.Test/HttpServerTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Security.Principal;
@@ -150,12 +149,11 @@ namespace System.Web.Http
                     IExceptionLogger exceptionLogger = product.ExceptionLogger;
 
                     // Assert
-                    Assert.IsType<CompositeExceptionLogger>(exceptionLogger);
-                    CompositeExceptionLogger compositeLogger = (CompositeExceptionLogger)exceptionLogger;
+                    CompositeExceptionLogger compositeLogger = Assert.IsType<CompositeExceptionLogger>(exceptionLogger);
                     IEnumerable<IExceptionLogger> loggers = compositeLogger.Loggers;
                     Assert.NotNull(loggers);
-                    Assert.Equal(1, loggers.Count());
-                    Assert.Same(expectedExceptionLogger, loggers.Single());
+                    IExceptionLogger logger = Assert.Single(loggers);
+                    Assert.Same(expectedExceptionLogger, logger);
                 }
             }
         }
@@ -176,8 +174,7 @@ namespace System.Web.Http
                     IExceptionHandler exceptionHandler = product.ExceptionHandler;
 
                     // Assert
-                    Assert.IsType<LastChanceExceptionHandler>(exceptionHandler);
-                    LastChanceExceptionHandler lastChanceHandler = (LastChanceExceptionHandler)exceptionHandler;
+                    LastChanceExceptionHandler lastChanceHandler = Assert.IsType<LastChanceExceptionHandler>(exceptionHandler);
                     Assert.Same(expectedExceptionHandler, lastChanceHandler.InnerHandler);
                 }
             }
@@ -469,7 +466,7 @@ namespace System.Web.Http
 
                 Assert.Same(expectedException, exception);
                 Assert.NotNull(exception.StackTrace);
-                Assert.True(exception.StackTrace.StartsWith(expectedStackTrace));
+                Assert.StartsWith(expectedStackTrace, exception.StackTrace);
             }
         }
 

--- a/test/System.Web.Http.Test/Internal/TypeActivatorTest.cs
+++ b/test/System.Web.Http.Test/Internal/TypeActivatorTest.cs
@@ -28,7 +28,7 @@ namespace System.Web.Http.Internal
                     { typeof(Dictionary<int, int>), typeof(IDictionary<int, int>)},
                     { typeof(HttpRequestMessage), typeof(HttpRequestMessage)},
                     { typeof(HttpConfiguration), typeof(HttpConfiguration)},
-                    { typeof(ReflectedHttpActionDescriptor), typeof(HttpActionDescriptor) }, 
+                    { typeof(ReflectedHttpActionDescriptor), typeof(HttpActionDescriptor) },
                     { typeof(ApiControllerActionSelector), typeof(IHttpActionSelector)},
                     { typeof(ApiControllerActionInvoker), typeof(IHttpActionInvoker)},
                     { typeof(List<HttpStatusCode>), typeof(IEnumerable<HttpStatusCode>)},
@@ -36,9 +36,27 @@ namespace System.Web.Http.Internal
             }
         }
 
+        public static TheoryDataSet<Type> ValidInstanceTypeParameters
+        {
+            get
+            {
+                return new TheoryDataSet<Type>
+                {
+                    { typeof(List<int>) },
+                    { typeof(Dictionary<int, int>) },
+                    { typeof(HttpRequestMessage) },
+                    { typeof(HttpConfiguration) },
+                    { typeof(ReflectedHttpActionDescriptor) },
+                    { typeof(ApiControllerActionSelector) },
+                    { typeof(ApiControllerActionInvoker) },
+                    { typeof(List<HttpStatusCode>) },
+                };
+            }
+        }
+
         [Theory]
-        [PropertyData("ValidTypeParameters")]
-        public void CreateType(Type instanceType, Type baseType)
+        [PropertyData("ValidInstanceTypeParameters")]
+        public void CreateType(Type instanceType)
         {
             // Arrange
             Func<object> instanceDelegate = TypeActivator.Create(instanceType);
@@ -74,8 +92,8 @@ namespace System.Web.Http.Internal
         }
 
         [Theory]
-        [PropertyData("ValidTypeParameters")]
-        public void CreateOfT(Type instanceType, Type baseType)
+        [PropertyData("ValidInstanceTypeParameters")]
+        public void CreateOfT(Type instanceType)
         {
             // Arrange
             Type activatorType = typeof(TypeActivator);

--- a/test/System.Web.Http.Test/Metadata/Providers/AssociatedMetadataProviderTest.cs
+++ b/test/System.Web.Http.Test/Metadata/Providers/AssociatedMetadataProviderTest.cs
@@ -36,24 +36,24 @@ namespace System.Web.Http.Metadata.Providers
             provider.GetMetadataForProperties(model, typeof(PropertyModel)).ToList(); // Call ToList() to force the lazy evaluation to evaluate
 
             // Assert
-            CreateMetadataPrototypeParams local =
-                provider.CreateMetadataPrototypeLog.Single(m => m.ContainerType == typeof(PropertyModel) &&
-                                                       m.PropertyName == "LocalAttributes");
+            CreateMetadataPrototypeParams local = Assert.Single(
+                provider.CreateMetadataPrototypeLog,
+                m => m.ContainerType == typeof(PropertyModel) && m.PropertyName == "LocalAttributes");
             Assert.Equal(typeof(int), local.ModelType);
-            Assert.True(local.Attributes.Any(a => a is RequiredAttribute));
+            Assert.Contains(local.Attributes, a => a is RequiredAttribute);
 
-            CreateMetadataPrototypeParams metadata =
-                provider.CreateMetadataPrototypeLog.Single(m => m.ContainerType == typeof(PropertyModel) &&
-                                                       m.PropertyName == "MetadataAttributes");
+            CreateMetadataPrototypeParams metadata = Assert.Single(
+                provider.CreateMetadataPrototypeLog,
+                m => m.ContainerType == typeof(PropertyModel) && m.PropertyName == "MetadataAttributes");
             Assert.Equal(typeof(string), metadata.ModelType);
-            Assert.True(metadata.Attributes.Any(a => a is RangeAttribute));
+            Assert.Contains(metadata.Attributes, a => a is RangeAttribute);
 
-            CreateMetadataPrototypeParams mixed =
-                provider.CreateMetadataPrototypeLog.Single(m => m.ContainerType == typeof(PropertyModel) &&
-                                                       m.PropertyName == "MixedAttributes");
+            CreateMetadataPrototypeParams mixed = Assert.Single(
+                provider.CreateMetadataPrototypeLog,
+                m => m.ContainerType == typeof(PropertyModel) && m.PropertyName == "MixedAttributes");
             Assert.Equal(typeof(double), mixed.ModelType);
-            Assert.True(mixed.Attributes.Any(a => a is RequiredAttribute));
-            Assert.True(mixed.Attributes.Any(a => a is RangeAttribute));
+            Assert.Contains(mixed.Attributes, a => a is RequiredAttribute);
+            Assert.Contains(mixed.Attributes, a => a is RangeAttribute);
         }
 
         [Fact]
@@ -130,7 +130,10 @@ namespace System.Web.Http.Metadata.Providers
 
             // Assert
             Assert.Same(metadata, result);
-            Assert.True(provider.CreateMetadataPrototypeLog.Single(parameters => parameters.PropertyName == "LocalAttributes").Attributes.Any(a => a is RequiredAttribute));
+            CreateMetadataPrototypeParams metadataPrototypeParams = Assert.Single(
+                provider.CreateMetadataPrototypeLog,
+                parameters => parameters.PropertyName == "LocalAttributes");
+            Assert.Contains(metadataPrototypeParams.Attributes, a => a is RequiredAttribute);
         }
 
         [Fact]
@@ -146,8 +149,10 @@ namespace System.Web.Http.Metadata.Providers
 
             // Assert
             Assert.Same(metadata, result);
-            CreateMetadataPrototypeParams parms = provider.CreateMetadataPrototypeLog.Single(p => p.PropertyName == "MetadataAttributes");
-            Assert.True(parms.Attributes.Any(a => a is RangeAttribute));
+            CreateMetadataPrototypeParams parms = Assert.Single(
+                provider.CreateMetadataPrototypeLog,
+                parameters => parameters.PropertyName == "MetadataAttributes");
+            Assert.Contains(parms.Attributes, a => a is RangeAttribute);
         }
 
         [Fact]
@@ -163,9 +168,11 @@ namespace System.Web.Http.Metadata.Providers
 
             // Assert
             Assert.Same(metadata, result);
-            CreateMetadataPrototypeParams parms = provider.CreateMetadataPrototypeLog.Single(p => p.PropertyName == "MixedAttributes");
-            Assert.True(parms.Attributes.Any(a => a is RequiredAttribute));
-            Assert.True(parms.Attributes.Any(a => a is RangeAttribute));
+            CreateMetadataPrototypeParams parms = Assert.Single(
+                provider.CreateMetadataPrototypeLog,
+                p => p.PropertyName == "MixedAttributes");
+            Assert.Contains(parms.Attributes, a => a is RequiredAttribute);
+            Assert.Contains(parms.Attributes, a => a is RangeAttribute);
         }
 
         // GetMetadataForType
@@ -194,8 +201,10 @@ namespace System.Web.Http.Metadata.Providers
 
             // Assert
             Assert.Same(metadata, result);
-            CreateMetadataPrototypeParams parms = provider.CreateMetadataPrototypeLog.Single(p => p.ModelType == typeof(TypeModel));
-            Assert.True(parms.Attributes.Any(a => a is ReadOnlyAttribute));
+            CreateMetadataPrototypeParams parms = Assert.Single(
+                provider.CreateMetadataPrototypeLog,
+                p => p.ModelType == typeof(TypeModel));
+            Assert.Contains(parms.Attributes, a => a is ReadOnlyAttribute);
         }
 
         // Helpers

--- a/test/System.Web.Http.Test/Metadata/Providers/DataAnnotationsModelMetadataProviderTest.cs
+++ b/test/System.Web.Http.Test/Metadata/Providers/DataAnnotationsModelMetadataProviderTest.cs
@@ -21,9 +21,9 @@ namespace System.Web.Http.Metadata.Providers
             IEnumerable<ModelMetadata> result = provider.GetMetadataForProperties("foo", typeof(string));
 
             // Assert
-            Assert.True(result.Any(m => m.ModelType == typeof(int)
+            Assert.Contains(result, m => m.ModelType == typeof(int)
                                         && m.PropertyName == "Length"
-                                        && (int)m.Model == 3));
+                                        && (int)m.Model == 3);
         }
 
         [Fact]

--- a/test/System.Web.Http.Test/ModelBinding/Binders/CollectionModelBinderTest.cs
+++ b/test/System.Web.Http.Test/ModelBinding/Binders/CollectionModelBinderTest.cs
@@ -326,8 +326,7 @@ namespace System.Web.Http.ModelBinding
 
             // Assert
             Assert.True(result);
-            List<Person> boundModel =
-                Assert.IsType<List<Person>>(bindingContext.Model);
+            List<Person> boundModel = Assert.IsType<List<Person>>(bindingContext.Model);
             Person type = Assert.Single(boundModel);
             Assert.Null(type.Name);
         }

--- a/test/System.Web.Http.Test/ModelBinding/Binders/MutableObjectModelBinderTest.cs
+++ b/test/System.Web.Http.Test/ModelBinding/Binders/MutableObjectModelBinderTest.cs
@@ -347,14 +347,13 @@ namespace System.Web.Http.ModelBinding.Binders
             // Assert
             ModelStateDictionary modelStateDictionary = bindingContext.ModelState;
             Assert.False(modelStateDictionary.IsValid);
-            Assert.Equal(1, modelStateDictionary.Count);
+            Assert.Single(modelStateDictionary);
 
             // Check Age error.
             ModelState modelState;
             Assert.True(modelStateDictionary.TryGetValue("theModel.Age", out modelState));
-            Assert.Equal(1, modelState.Errors.Count);
 
-            ModelError modelError = modelState.Errors[0];
+            ModelError modelError = Assert.Single(modelState.Errors);
             Assert.Null(modelError.Exception);
             Assert.NotNull(modelError.ErrorMessage);
             Assert.Equal("The Age property is required.", modelError.ErrorMessage);
@@ -400,14 +399,13 @@ namespace System.Web.Http.ModelBinding.Binders
             // Assert
             ModelStateDictionary modelStateDictionary = bindingContext.ModelState;
             Assert.False(modelStateDictionary.IsValid);
-            Assert.Equal(1, modelStateDictionary.Count);
+            Assert.Single(modelStateDictionary);
 
             // Check Age error.
             ModelState modelState;
             Assert.True(modelStateDictionary.TryGetValue("theModel.Age", out modelState));
-            Assert.Equal(1, modelState.Errors.Count);
 
-            ModelError modelError = modelState.Errors[0];
+            ModelError modelError = Assert.Single(modelState.Errors);
             Assert.Null(modelError.Exception);
             Assert.NotNull(modelError.ErrorMessage);
             Assert.Equal("A value is required.", modelError.ErrorMessage);
@@ -443,18 +441,16 @@ namespace System.Web.Http.ModelBinding.Binders
             // Check Age error.
             ModelState modelState;
             Assert.True(modelStateDictionary.TryGetValue("theModel.Age", out modelState));
-            Assert.Equal(1, modelState.Errors.Count);
 
-            ModelError modelError = modelState.Errors[0];
+            ModelError modelError = Assert.Single(modelState.Errors);
             Assert.Null(modelError.Exception);
             Assert.NotNull(modelError.ErrorMessage);
             Assert.Equal("The Age field is required.", modelError.ErrorMessage);
 
             // Check City error.
             Assert.True(modelStateDictionary.TryGetValue("theModel.City", out modelState));
-            Assert.Equal(1, modelState.Errors.Count);
 
-            modelError = modelState.Errors[0];
+            modelError = Assert.Single(modelState.Errors);
             Assert.Null(modelError.Exception);
             Assert.NotNull(modelError.ErrorMessage);
             Assert.Equal("The City field is required.", modelError.ErrorMessage);
@@ -492,14 +488,13 @@ namespace System.Web.Http.ModelBinding.Binders
             // Assert
             ModelStateDictionary modelStateDictionary = bindingContext.ModelState;
             Assert.False(modelStateDictionary.IsValid);
-            Assert.Equal(1, modelStateDictionary.Count);
+            Assert.Single(modelStateDictionary);
 
             // Check City error.
             ModelState modelState;
             Assert.True(modelStateDictionary.TryGetValue("theModel.City", out modelState));
-            Assert.Equal(1, modelState.Errors.Count);
 
-            ModelError modelError = modelState.Errors[0];
+            ModelError modelError = Assert.Single(modelState.Errors);
             Assert.Null(modelError.Exception);
             Assert.NotNull(modelError.ErrorMessage);
             Assert.Equal("The City field is required.", modelError.ErrorMessage);
@@ -529,14 +524,13 @@ namespace System.Web.Http.ModelBinding.Binders
             // Assert
             ModelStateDictionary modelStateDictionary = bindingContext.ModelState;
             Assert.False(modelStateDictionary.IsValid);
-            Assert.Equal(1, modelStateDictionary.Count);
+            Assert.Single(modelStateDictionary);
 
             // Check ValueTypeRequired error.
             ModelState modelState;
             Assert.True(modelStateDictionary.TryGetValue("theModel.ValueTypeRequired", out modelState));
-            Assert.Equal(1, modelState.Errors.Count);
 
-            ModelError modelError = modelState.Errors[0];
+            ModelError modelError = Assert.Single(modelState.Errors);
             Assert.Null(modelError.Exception);
             Assert.NotNull(modelError.ErrorMessage);
             Assert.Equal("Sample message", modelError.ErrorMessage);
@@ -570,14 +564,13 @@ namespace System.Web.Http.ModelBinding.Binders
             // Assert
             ModelStateDictionary modelStateDictionary = bindingContext.ModelState;
             Assert.False(modelStateDictionary.IsValid);
-            Assert.Equal(1, modelStateDictionary.Count);
+            Assert.Single(modelStateDictionary);
 
             // Check ValueTypeRequired error.
             ModelState modelState;
             Assert.True(modelStateDictionary.TryGetValue("theModel.ValueTypeRequired", out modelState));
-            Assert.Equal(1, modelState.Errors.Count);
 
-            ModelError modelError = modelState.Errors[0];
+            ModelError modelError = Assert.Single(modelState.Errors);
             Assert.Null(modelError.Exception);
             Assert.NotNull(modelError.ErrorMessage);
             Assert.Equal("Sample message", modelError.ErrorMessage);
@@ -801,10 +794,10 @@ namespace System.Web.Http.ModelBinding.Binders
 
             // Assert
             Assert.False(bindingContext.ModelState.IsValid);
-            Assert.Equal(1, bindingContext.ModelState["foo.NameNoAttribute"].Errors.Count);
-            Assert.Equal("This is a different exception." + Environment.NewLine
-                       + "Parameter name: value",
-                         bindingContext.ModelState["foo.NameNoAttribute"].Errors[0].Exception.Message);
+            ModelError modelError = Assert.Single(bindingContext.ModelState["foo.NameNoAttribute"].Errors);
+            Assert.Equal(
+                "This is a different exception." + Environment.NewLine + "Parameter name: value",
+                modelError.Exception.Message);
         }
 
         [Fact]
@@ -830,8 +823,8 @@ namespace System.Web.Http.ModelBinding.Binders
 
             // Assert
             Assert.False(bindingContext.ModelState.IsValid);
-            Assert.Equal(1, bindingContext.ModelState["foo.Name"].Errors.Count);
-            Assert.Equal("This message comes from the [Required] attribute.", bindingContext.ModelState["foo.Name"].Errors[0].ErrorMessage);
+            ModelError modelError = Assert.Single(bindingContext.ModelState["foo.Name"].Errors);
+            Assert.Equal("This message comes from the [Required] attribute.", modelError.ErrorMessage);
         }
 
         private static ModelMetadata GetMetadataForCanUpdateProperty(string propertyName)

--- a/test/System.Web.Http.Test/ModelBinding/DefaultActionValueBinderTest.cs
+++ b/test/System.Web.Http.Test/ModelBinding/DefaultActionValueBinderTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.ComponentModel;
-using System.Linq;
 using System.Net.Http;
 using System.Reflection;
 using System.Threading;
@@ -13,7 +12,7 @@ using Moq;
 
 namespace System.Web.Http.ModelBinding
 {
-    // These tests primarily focus on getting the right binding contract. They don't actually execute the contract. 
+    // These tests primarily focus on getting the right binding contract. They don't actually execute the contract.
     public class DefaultActionValueBinderTest
     {
         [Fact]
@@ -37,7 +36,7 @@ namespace System.Web.Http.ModelBinding
 
             var binding = binder.GetBinding(GetAction("Action_Int"));
 
-            Assert.Equal(1, binding.ParameterBindings.Length);
+            Assert.Single(binding.ParameterBindings);
             AssertIsModelBound(binding, 0);
         }
 
@@ -51,7 +50,7 @@ namespace System.Web.Http.ModelBinding
 
             var binding = binder.GetBinding(GetAction("Action_Int", config));
 
-            Assert.Equal(1, binding.ParameterBindings.Length);
+            Assert.Single(binding.ParameterBindings);
             AssertIsBody(binding, 0);
         }
 
@@ -65,7 +64,7 @@ namespace System.Web.Http.ModelBinding
 
             var binding = binder.GetBinding(GetAction("Action_Int_FromUri"));
 
-            Assert.Equal(1, binding.ParameterBindings.Length);
+            Assert.Single(binding.ParameterBindings);
             AssertIsModelBound(binding, 0);
         }
 
@@ -94,7 +93,7 @@ namespace System.Web.Http.ModelBinding
 
             var binding = binder.GetBinding(GetAction("Action_ComplexTypeWithStringConverter"));
 
-            Assert.Equal(1, binding.ParameterBindings.Length);
+            Assert.Single(binding.ParameterBindings);
             AssertIsModelBound(binding, 0);
         }
 
@@ -107,7 +106,7 @@ namespace System.Web.Http.ModelBinding
 
             var binding = binder.GetBinding(GetAction("Action_ComplexTypeWithStringConverter_Body_Override"));
 
-            Assert.Equal(1, binding.ParameterBindings.Length);
+            Assert.Single(binding.ParameterBindings);
             AssertIsBody(binding, 0);
         }
 
@@ -120,7 +119,7 @@ namespace System.Web.Http.ModelBinding
 
             var binding = binder.GetBinding(GetAction("Action_NullableInt"));
 
-            Assert.Equal(1, binding.ParameterBindings.Length);
+            Assert.Single(binding.ParameterBindings);
             AssertIsModelBound(binding, 0);
         }
 
@@ -133,7 +132,7 @@ namespace System.Web.Http.ModelBinding
 
             var binding = binder.GetBinding(GetAction("Action_Nullable_ValueType"));
 
-            Assert.Equal(1, binding.ParameterBindings.Length);
+            Assert.Single(binding.ParameterBindings);
             AssertIsBody(binding, 0);
         }
 
@@ -147,7 +146,7 @@ namespace System.Web.Http.ModelBinding
 
             var binding = binder.GetBinding(GetAction("Action_IntArray"));
 
-            Assert.Equal(1, binding.ParameterBindings.Length);
+            Assert.Single(binding.ParameterBindings);
             AssertIsBody(binding, 0);
         }
 
@@ -161,7 +160,7 @@ namespace System.Web.Http.ModelBinding
 
             var binding = binder.GetBinding(GetAction("Action_SimpleType_Body"));
 
-            Assert.Equal(1, binding.ParameterBindings.Length);
+            Assert.Single(binding.ParameterBindings);
             AssertIsBody(binding, 0);
         }
 
@@ -175,7 +174,7 @@ namespace System.Web.Http.ModelBinding
             var binding = binder.GetBinding(GetAction("Action_Empty"));
 
             Assert.NotNull(binding.ParameterBindings);
-            Assert.Equal(0, binding.ParameterBindings.Length);
+            Assert.Empty(binding.ParameterBindings);
         }
 
         private void Action_String_String(string s1, string s2) { }
@@ -201,7 +200,7 @@ namespace System.Web.Http.ModelBinding
 
             var binding = binder.GetBinding(GetAction("Action_Complex_Type"));
 
-            Assert.Equal(1, binding.ParameterBindings.Length);
+            Assert.Single(binding.ParameterBindings);
             AssertIsBody(binding, 0);
         }
 
@@ -214,7 +213,7 @@ namespace System.Web.Http.ModelBinding
 
             var binding = binder.GetBinding(GetAction("Action_Complex_Type", config));
 
-            Assert.Equal(1, binding.ParameterBindings.Length);
+            Assert.Single(binding.ParameterBindings);
             AssertIsModelBound(binding, 0);
         }
 
@@ -228,7 +227,7 @@ namespace System.Web.Http.ModelBinding
 
             var binding = binder.GetBinding(GetAction("Action_Complex_ValueType"));
 
-            Assert.Equal(1, binding.ParameterBindings.Length);
+            Assert.Single(binding.ParameterBindings);
             AssertIsBody(binding, 0);
         }
 
@@ -243,7 +242,7 @@ namespace System.Web.Http.ModelBinding
 
             var binding = binder.GetBinding(GetAction("Action_Default_Custom_Model_Binder"));
 
-            Assert.Equal(1, binding.ParameterBindings.Length);
+            Assert.Single(binding.ParameterBindings);
             AssertIsModelBound(binding, 0);
         }
 
@@ -257,7 +256,7 @@ namespace System.Web.Http.ModelBinding
 
             var binding = binder.GetBinding(GetAction("Action_Complex_Type_Uri"));
 
-            Assert.Equal(1, binding.ParameterBindings.Length);
+            Assert.Single(binding.ParameterBindings);
             AssertIsModelBound(binding, 0);
         }
 
@@ -268,8 +267,8 @@ namespace System.Web.Http.ModelBinding
         {
             DefaultActionValueBinder binder = new DefaultActionValueBinder();
 
-            // It's illegal to have multiple parameters from the body. 
-            // But we should still be able to get a binding for it. We just can't execute it. 
+            // It's illegal to have multiple parameters from the body.
+            // But we should still be able to get a binding for it. We just can't execute it.
             var binding = binder.GetBinding(GetAction("Action_Two_Complex_Types"));
 
             Assert.Equal(2, binding.ParameterBindings.Length);
@@ -300,7 +299,7 @@ namespace System.Web.Http.ModelBinding
 
             var binding = binder.GetBinding(GetAction("Action_CancellationToken"));
 
-            Assert.Equal(1, binding.ParameterBindings.Length);
+            Assert.Single(binding.ParameterBindings);
             AssertIsCancellationToken(binding, 0);
         }
 
@@ -318,15 +317,15 @@ namespace System.Web.Http.ModelBinding
 
             var binding = binder.GetBinding(GetAction("Action_CustomModelBinder_On_Parameter_WithProvider", config));
 
-            Assert.Equal(1, binding.ParameterBindings.Length);
+            Assert.Single(binding.ParameterBindings);
             AssertIsModelBound(binding, 0);
 
             ModelBinderParameterBinding p = (ModelBinderParameterBinding)binding.ParameterBindings[0];
             Assert.IsType<CustomModelBinder>(p.Binder);
 
             // Since the ModelBinderAttribute didn't specify the valueproviders, we should pull those from config.
-            Assert.Equal(1, p.ValueProviderFactories.Count());
-            Assert.IsType<CustomValueProviderFactory>(p.ValueProviderFactories.First());
+            ValueProviderFactory valueProviderFactory = Assert.Single(p.ValueProviderFactories);
+            Assert.IsType<CustomValueProviderFactory>(valueProviderFactory);
         }
 
         // Model binder attribute is on the type's declaration.
@@ -339,7 +338,7 @@ namespace System.Web.Http.ModelBinding
 
             var binding = binder.GetBinding(GetAction("Action_ComplexParameter_With_ModelBinder"));
 
-            Assert.Equal(1, binding.ParameterBindings.Length);
+            Assert.Single(binding.ParameterBindings);
             AssertIsModelBound(binding, 0);
         }
 
@@ -352,8 +351,8 @@ namespace System.Web.Http.ModelBinding
 
             var binding = binder.GetBinding(GetAction("Action_Conflicting_Attributes"));
 
-            // Have 2 attributes that conflict with each other. Still get the contract, but it has an error in it. 
-            Assert.Equal(1, binding.ParameterBindings.Length);
+            // Have 2 attributes that conflict with each other. Still get the contract, but it has an error in it.
+            Assert.Single(binding.ParameterBindings);
             AssertIsError(binding, 0);
         }
 
@@ -370,8 +369,8 @@ namespace System.Web.Http.ModelBinding
 
             var binding = binder.GetBinding(GetAction("Action_Closest_Attribute_Wins"));
 
-            // Have 2 attributes that conflict with each other. Still get the contract, but it has an error in it. 
-            Assert.Equal(1, binding.ParameterBindings.Length);
+            // Have 2 attributes that conflict with each other. Still get the contract, but it has an error in it.
+            Assert.Single(binding.ParameterBindings);
             AssertIsModelBound(binding, 0);
         }
 
@@ -384,7 +383,7 @@ namespace System.Web.Http.ModelBinding
 
             var binding = binder.GetBinding(GetAction("Action_HttpContent_Parameter"));
 
-            Assert.Equal(1, binding.ParameterBindings.Length);
+            Assert.Single(binding.ParameterBindings);
             AssertIsError(binding, 0);
         }
 
@@ -397,7 +396,7 @@ namespace System.Web.Http.ModelBinding
 
             var binding = binder.GetBinding(GetAction("Action_Derived_HttpContent_Parameter"));
 
-            Assert.Equal(1, binding.ParameterBindings.Length);
+            Assert.Single(binding.ParameterBindings);
             AssertIsError(binding, 0);
         }
 
@@ -410,7 +409,7 @@ namespace System.Web.Http.ModelBinding
 
             var binding = binder.GetBinding(GetAction("Action_Request_Parameter"));
 
-            Assert.Equal(1, binding.ParameterBindings.Length);
+            Assert.Single(binding.ParameterBindings);
             AssertIsCustomBinder<HttpRequestParameterBinding>(binding, 0);
         }
 
@@ -424,8 +423,8 @@ namespace System.Web.Http.ModelBinding
 
             var binding = binder.GetBinding(GetAction("Action_CustomBindingAttribute"));
 
-            Assert.Equal(1, binding.ParameterBindings.Length);
-            Assert.Same(CustomBindingAttribute.MockBinding, binding.ParameterBindings[0]);
+            HttpParameterBinding parameterBinding = Assert.Single(binding.ParameterBindings);
+            Assert.Same(CustomBindingAttribute.MockBinding, parameterBinding);
         }
 
         [AttributeUsage(AttributeTargets.Class | AttributeTargets.Parameter, Inherited = true, AllowMultiple = false)]
@@ -472,7 +471,7 @@ namespace System.Web.Http.ModelBinding
             Assert.False(p.WillReadBody);
         }
 
-        // Assert that the binding contract says the given parameter will be bound to the cancellation token. 
+        // Assert that the binding contract says the given parameter will be bound to the cancellation token.
         private void AssertIsCancellationToken(HttpActionBinding binding, int paramIdx)
         {
             AssertIsCustomBinder<CancellationTokenParameterBinding>(binding, paramIdx);
@@ -496,7 +495,7 @@ namespace System.Web.Http.ModelBinding
         }
 
 
-        // Helper to get an ActionDescriptor for a method name. 
+        // Helper to get an ActionDescriptor for a method name.
         private HttpActionDescriptor GetAction(string name)
         {
             return GetAction(name, new HttpConfiguration());
@@ -530,7 +529,7 @@ namespace System.Web.Http.ModelBinding
         {
         }
 
-        // Add Type converter for string, which causes the type to be viewed as a Simple type. 
+        // Add Type converter for string, which causes the type to be viewed as a Simple type.
         [TypeConverter(typeof(MyTypeConverter))]
         public class ComplexTypeWithStringConverter
         {

--- a/test/System.Web.Http.Test/ModelBinding/FormDataCollectionExtensionsTest.cs
+++ b/test/System.Web.Http.Test/ModelBinding/FormDataCollectionExtensionsTest.cs
@@ -299,7 +299,7 @@ namespace System.Web.Http.ModelBinding
                 int actual = formData.ReadAs<int>(actionContext);
 
                 // Assert
-                Assert.Equal<int>(expected, actual);
+                Assert.Equal(expected, actual);
             }
         }
 
@@ -319,7 +319,7 @@ namespace System.Web.Http.ModelBinding
                 int actual = (int)formData.ReadAs(typeof(int), "a", actionContext);
 
                 // Assert
-                Assert.Equal<int>(expected, actual);
+                Assert.Equal(expected, actual);
             }
         }
 
@@ -343,7 +343,7 @@ namespace System.Web.Http.ModelBinding
                 int actual = (int)formData.ReadAs(typeof(int), "a", actionContext);
 
                 // Assert
-                Assert.Equal<int>(expected, actual);
+                Assert.Equal(expected, actual);
             }
         }
 
@@ -366,7 +366,7 @@ namespace System.Web.Http.ModelBinding
                     formatterLogger: (new Mock<IFormatterLogger>()).Object, config: configuration);
 
                 // Assert
-                Assert.Equal<int>(30, actual);
+                Assert.Equal(30, actual);
                 Assert.Same(clonedConfiguration.Services, configuration.Services);
             }
         }

--- a/test/System.Web.Http.Test/ModelBinding/ModelBinderAttributeTest.cs
+++ b/test/System.Web.Http.Test/ModelBinding/ModelBinderAttributeTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Web.Http.Controllers;
 using System.Web.Http.Dependencies;
 using System.Web.Http.ValueProviders;
@@ -52,7 +51,7 @@ namespace System.Web.Http.ModelBinding
         [Fact]
         public void BinderType_From_DependencyResolver()
         {
-            // To test dependency resolver, the registered type and actual type should be different. 
+            // To test dependency resolver, the registered type and actual type should be different.
             HttpConfiguration config = new HttpConfiguration();
             var mockDependencyResolver = new Mock<IDependencyResolver>();
             mockDependencyResolver.Setup(r => r.GetService(typeof(CustomModelBinderProvider)))
@@ -93,8 +92,8 @@ namespace System.Web.Http.ModelBinding
             IEnumerable<ValueProviderFactory> vpfs = attr.GetValueProviderFactories(config);
 
             Assert.IsType<CustomModelBinderProvider>(attr.GetModelBinderProvider(config));
-            Assert.Equal(1, vpfs.Count());
-            Assert.IsType<CustomValueProviderFactory>(vpfs.First());
+            object valueProviderFactory = Assert.Single(vpfs);
+            Assert.IsType<CustomValueProviderFactory>(valueProviderFactory);
         }
 
         [Fact]
@@ -110,7 +109,7 @@ namespace System.Web.Http.ModelBinding
             IModelBinder binder = attr.GetModelBinder(config, null);
 
             // Assert
-            Assert.Null(attr.BinderType); // using the default 
+            Assert.Null(attr.BinderType); // using the default
             Assert.NotNull(binder);
             Assert.IsType<CustomModelBinder>(binder);
         }

--- a/test/System.Web.Http.Test/ModelBinding/ModelBindingEndToEndTests.cs
+++ b/test/System.Web.Http.Test/ModelBinding/ModelBindingEndToEndTests.cs
@@ -140,8 +140,8 @@ namespace System.Web.Http.ModelBinding
             Assert.Equal("98052", address.ZipCode);
 
             address = result.Addresses[1];
-            Assert.Single(address.AddressLines);
-            Assert.Equal("Street Address 10", address.AddressLines[0].Line);
+            StreetAddress streetAddress= streetAddress = Assert.Single(address.AddressLines);
+            Assert.Equal("Street Address 10", streetAddress.Line);
             Assert.Null(address.ZipCode);
         }
 

--- a/test/System.Web.Http.Test/Results/BadRequestErrorMessageResultTests.cs
+++ b/test/System.Web.Http.Test/Results/BadRequestErrorMessageResultTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Net;
 using System.Net.Http;
@@ -212,8 +211,7 @@ namespace System.Web.Http.Results
                     Assert.NotNull(response);
                     Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
                     HttpContent content = response.Content;
-                    Assert.IsType<ObjectContent<HttpError>>(content);
-                    ObjectContent<HttpError> typedContent = (ObjectContent<HttpError>)content;
+                    ObjectContent<HttpError> typedContent = Assert.IsType<ObjectContent<HttpError>>(content);
                     HttpError error = (HttpError)typedContent.Value;
                     Assert.NotNull(error);
                     Assert.Same(expectedMessage, error.Message);
@@ -312,8 +310,7 @@ namespace System.Web.Http.Results
                         Assert.NotNull(response);
                         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
                         HttpContent content = response.Content;
-                        Assert.IsType<ObjectContent<HttpError>>(content);
-                        ObjectContent<HttpError> typedContent = (ObjectContent<HttpError>)content;
+                        ObjectContent<HttpError> typedContent = Assert.IsType<ObjectContent<HttpError>>(content);
                         HttpError error = (HttpError)typedContent.Value;
                         Assert.NotNull(error);
                         Assert.Same(expectedMessage, error.Message);
@@ -410,8 +407,8 @@ namespace System.Web.Http.Results
 
                     // Assert
                     Assert.NotNull(formatters);
-                    Assert.Equal(1, formatters.Count());
-                    Assert.Same(expectedFormatter, formatters.Single());
+                    MediaTypeFormatter formatter = Assert.Single(formatters);
+                    Assert.Same(expectedFormatter, formatter);
                 }
             }
         }
@@ -505,8 +502,8 @@ namespace System.Web.Http.Results
 
                     // Assert
                     Assert.NotNull(formatters);
-                    Assert.Equal(1, formatters.Count());
-                    Assert.Same(expectedFormatter, formatters.Single());
+                    MediaTypeFormatter formatter = Assert.Single(formatters);
+                    Assert.Same(expectedFormatter, formatter);
                 }
             }
         }

--- a/test/System.Web.Http.Test/Results/CreatedAtRouteNegotiatedContentResultTests.cs
+++ b/test/System.Web.Http.Test/Results/CreatedAtRouteNegotiatedContentResultTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Net;
 using System.Net.Http;
@@ -346,8 +345,7 @@ namespace System.Web.Http.Results
                     Assert.Equal(HttpStatusCode.Created, response.StatusCode);
                     Assert.Same(expectedLocation, response.Headers.Location.OriginalString);
                     HttpContent content = response.Content;
-                    Assert.IsType<ObjectContent<object>>(content);
-                    ObjectContent<object> typedContent = (ObjectContent<object>)content;
+                    ObjectContent<object> typedContent = Assert.IsType<ObjectContent<object>>(content);
                     Assert.Same(expectedContent, typedContent.Value);
                     Assert.Same(expectedFormatter, typedContent.Formatter);
                     Assert.NotNull(typedContent.Headers);
@@ -495,8 +493,7 @@ namespace System.Web.Http.Results
                         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
                         Assert.Same(expectedLocation, response.Headers.Location.OriginalString);
                         HttpContent content = response.Content;
-                        Assert.IsType<ObjectContent<object>>(content);
-                        ObjectContent<object> typedContent = (ObjectContent<object>)content;
+                        ObjectContent<object> typedContent = Assert.IsType<ObjectContent<object>>(content);
                         Assert.Same(expectedContent, typedContent.Value);
                         Assert.Same(expectedOutputFormatter, typedContent.Formatter);
                         Assert.NotNull(typedContent.Headers);
@@ -632,8 +629,8 @@ namespace System.Web.Http.Results
 
                     // Assert
                     Assert.NotNull(formatters);
-                    Assert.Equal(1, formatters.Count());
-                    Assert.Same(expectedFormatter, formatters.Single());
+                    MediaTypeFormatter formatter = Assert.Single(formatters);
+                    Assert.Same(expectedFormatter, formatter);
                 }
             }
         }
@@ -769,8 +766,8 @@ namespace System.Web.Http.Results
 
                     // Assert
                     Assert.NotNull(formatters);
-                    Assert.Equal(1, formatters.Count());
-                    Assert.Same(expectedFormatter, formatters.Single());
+                    MediaTypeFormatter formatter = Assert.Single(formatters);
+                    Assert.Same(expectedFormatter, formatter);
                 }
             }
         }

--- a/test/System.Web.Http.Test/Results/CreatedNegotiatedContentResultTests.cs
+++ b/test/System.Web.Http.Test/Results/CreatedNegotiatedContentResultTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Net;
 using System.Net.Http;
@@ -245,8 +244,7 @@ namespace System.Web.Http.Results
                     Assert.Equal(HttpStatusCode.Created, response.StatusCode);
                     Assert.Same(expectedLocation, response.Headers.Location);
                     HttpContent content = response.Content;
-                    Assert.IsType<ObjectContent<object>>(content);
-                    ObjectContent<object> typedContent = (ObjectContent<object>)content;
+                    ObjectContent<object> typedContent = Assert.IsType<ObjectContent<object>>(content);
                     Assert.Same(expectedContent, typedContent.Value);
                     Assert.Same(expectedFormatter, typedContent.Formatter);
                     Assert.NotNull(typedContent.Headers);
@@ -350,8 +348,7 @@ namespace System.Web.Http.Results
                         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
                         Assert.Same(expectedLocation, response.Headers.Location);
                         HttpContent content = response.Content;
-                        Assert.IsType<ObjectContent<object>>(content);
-                        ObjectContent<object> typedContent = (ObjectContent<object>)content;
+                        ObjectContent<object> typedContent = Assert.IsType<ObjectContent<object>>(content);
                         Assert.Same(expectedContent, typedContent.Value);
                         Assert.Same(expectedOutputFormatter, typedContent.Formatter);
                         Assert.NotNull(typedContent.Headers);
@@ -451,8 +448,8 @@ namespace System.Web.Http.Results
 
                     // Assert
                     Assert.NotNull(formatters);
-                    Assert.Equal(1, formatters.Count());
-                    Assert.Same(expectedFormatter, formatters.Single());
+                    MediaTypeFormatter formatter = Assert.Single(formatters);
+                    Assert.Same(expectedFormatter, formatter);
                 }
             }
         }
@@ -549,8 +546,8 @@ namespace System.Web.Http.Results
 
                     // Assert
                     Assert.NotNull(formatters);
-                    Assert.Equal(1, formatters.Count());
-                    Assert.Same(expectedFormatter, formatters.Single());
+                    MediaTypeFormatter formatter = Assert.Single(formatters);
+                    Assert.Same(expectedFormatter, formatter);
                 }
             }
         }

--- a/test/System.Web.Http.Test/Results/ExceptionResultTests.cs
+++ b/test/System.Web.Http.Test/Results/ExceptionResultTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Net;
 using System.Net.Http;
@@ -245,12 +244,11 @@ namespace System.Web.Http.Results
                     Assert.NotNull(response);
                     Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
                     HttpContent content = response.Content;
-                    Assert.IsType<ObjectContent<HttpError>>(content);
-                    ObjectContent<HttpError> typedContent = (ObjectContent<HttpError>)content;
+                    ObjectContent<HttpError> typedContent = Assert.IsType<ObjectContent<HttpError>>(content);
                     HttpError error = (HttpError)typedContent.Value;
                     Assert.NotNull(error);
                     Assert.Equal(expectedException.Message, error.ExceptionMessage);
-                    Assert.Same(expectedException.GetType().FullName, error.ExceptionType);
+                    Assert.Equal(expectedException.GetType().FullName, error.ExceptionType);
                     Assert.Equal(expectedException.StackTrace, error.StackTrace);
                     Assert.Same(expectedFormatter, typedContent.Formatter);
                     Assert.NotNull(typedContent.Headers);
@@ -294,8 +292,7 @@ namespace System.Web.Http.Results
                     Assert.NotNull(response);
                     Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
                     HttpContent content = response.Content;
-                    Assert.IsType<ObjectContent<HttpError>>(content);
-                    ObjectContent<HttpError> typedContent = (ObjectContent<HttpError>)content;
+                    ObjectContent<HttpError> typedContent = Assert.IsType<ObjectContent<HttpError>>(content);
                     HttpError error = (HttpError)typedContent.Value;
                     Assert.NotNull(error);
                     Assert.Null(error.ExceptionMessage);
@@ -400,12 +397,11 @@ namespace System.Web.Http.Results
                         Assert.NotNull(response);
                         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
                         HttpContent content = response.Content;
-                        Assert.IsType<ObjectContent<HttpError>>(content);
-                        ObjectContent<HttpError> typedContent = (ObjectContent<HttpError>)content;
+                        ObjectContent<HttpError> typedContent = Assert.IsType<ObjectContent<HttpError>>(content);
                         HttpError error = (HttpError)typedContent.Value;
                         Assert.NotNull(error);
                         Assert.Equal(expectedException.Message, error.ExceptionMessage);
-                        Assert.Same(expectedException.GetType().FullName, error.ExceptionType);
+                        Assert.Equal(expectedException.GetType().FullName, error.ExceptionType);
                         Assert.Equal(expectedException.StackTrace, error.StackTrace);
                         Assert.Same(expectedOutputFormatter, typedContent.Formatter);
                         Assert.NotNull(typedContent.Headers);
@@ -441,7 +437,7 @@ namespace System.Web.Http.Results
                     IContentNegotiator contentNegotiator = result.ContentNegotiator;
 
                     // Assert
-                    Assert.Equal(false, result.IncludeErrorDetail);
+                    Assert.False(result.IncludeErrorDetail);
                 }
             }
         }
@@ -531,8 +527,8 @@ namespace System.Web.Http.Results
 
                     // Assert
                     Assert.NotNull(formatters);
-                    Assert.Equal(1, formatters.Count());
-                    Assert.Same(expectedFormatter, formatters.Single());
+                    MediaTypeFormatter formatter = Assert.Single(formatters);
+                    Assert.Same(expectedFormatter, formatter);
                 }
             }
         }
@@ -566,7 +562,7 @@ namespace System.Web.Http.Results
                 bool includeErrorDetail = result.IncludeErrorDetail;
 
                 // Assert
-                Assert.Equal(true, includeErrorDetail);
+                Assert.True(includeErrorDetail);
             }
         }
 
@@ -659,8 +655,8 @@ namespace System.Web.Http.Results
 
                     // Assert
                     Assert.NotNull(formatters);
-                    Assert.Equal(1, formatters.Count());
-                    Assert.Same(expectedFormatter, formatters.Single());
+                    MediaTypeFormatter formatter = Assert.Single(formatters);
+                    Assert.Same(expectedFormatter, formatter);
                 }
             }
         }

--- a/test/System.Web.Http.Test/Results/FormattedContentResultTests.cs
+++ b/test/System.Web.Http.Test/Results/FormattedContentResultTests.cs
@@ -184,8 +184,7 @@ namespace System.Web.Http.Results
                     Assert.NotNull(response);
                     Assert.Equal(expectedStatusCode, response.StatusCode);
                     HttpContent content = response.Content;
-                    Assert.IsType<ObjectContent<object>>(content);
-                    ObjectContent<object> typedContent = (ObjectContent<object>)content;
+                    ObjectContent<object> typedContent = Assert.IsType<ObjectContent<object>>(content);
                     Assert.Same(expectedContent, typedContent.Value);
                     Assert.Same(expectedFormatter, typedContent.Formatter);
                     Assert.NotNull(typedContent.Headers);
@@ -239,8 +238,7 @@ namespace System.Web.Http.Results
                     Assert.NotNull(response);
                     Assert.Equal(expectedStatusCode, response.StatusCode);
                     HttpContent content = response.Content;
-                    Assert.IsType<ObjectContent<object>>(content);
-                    ObjectContent<object> typedContent = (ObjectContent<object>)content;
+                    ObjectContent<object> typedContent = Assert.IsType<ObjectContent<object>>(content);
                     Assert.Same(expectedContent, typedContent.Value);
                     Assert.Same(expectedFormatter, typedContent.Formatter);
                     Assert.NotNull(typedContent.Headers);

--- a/test/System.Web.Http.Test/Results/InvalidModelStateResultTests.cs
+++ b/test/System.Web.Http.Test/Results/InvalidModelStateResultTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Net;
 using System.Net.Http;
@@ -249,18 +248,16 @@ namespace System.Web.Http.Results
                     Assert.NotNull(response);
                     Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
                     HttpContent content = response.Content;
-                    Assert.IsType<ObjectContent<HttpError>>(content);
-                    ObjectContent<HttpError> typedContent = (ObjectContent<HttpError>)content;
+                    ObjectContent<HttpError> typedContent = Assert.IsType<ObjectContent<HttpError>>(content);
                     HttpError error = (HttpError)typedContent.Value;
                     Assert.NotNull(error);
                     HttpError modelStateError = error.ModelState;
                     Assert.NotNull(modelStateError);
                     Assert.True(modelState.ContainsKey(expectedModelStateKey));
                     object modelStateValue = modelStateError[expectedModelStateKey];
-                    Assert.IsType(typeof(string[]), modelStateValue);
-                    string[] typedModelStateValue = (string[])modelStateValue;
-                    Assert.Equal(1, typedModelStateValue.Length);
-                    Assert.Same(expectedModelStateExceptionMessage, typedModelStateValue[0]);
+                    string[] typedModelStateValues = Assert.IsType<string[]>(modelStateValue);
+                    string typedModelStateValue = Assert.Single(typedModelStateValues);
+                    Assert.Same(expectedModelStateExceptionMessage, typedModelStateValue);
                     Assert.Same(expectedFormatter, typedContent.Formatter);
                     Assert.NotNull(typedContent.Headers);
                     Assert.Equal(expectedMediaType, typedContent.Headers.ContentType);
@@ -309,18 +306,16 @@ namespace System.Web.Http.Results
                     Assert.NotNull(response);
                     Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
                     HttpContent content = response.Content;
-                    Assert.IsType<ObjectContent<HttpError>>(content);
-                    ObjectContent<HttpError> typedContent = (ObjectContent<HttpError>)content;
+                    ObjectContent<HttpError> typedContent = Assert.IsType<ObjectContent<HttpError>>(content);
                     HttpError error = (HttpError)typedContent.Value;
                     Assert.NotNull(error);
                     HttpError modelStateError = error.ModelState;
                     Assert.NotNull(modelStateError);
                     Assert.True(modelState.ContainsKey(expectedModelStateKey));
                     object modelStateValue = modelStateError[expectedModelStateKey];
-                    Assert.IsType(typeof(string[]), modelStateValue);
-                    string[] typedModelStateValue = (string[])modelStateValue;
-                    Assert.Equal(1, typedModelStateValue.Length);
-                    Assert.Same(expectedModelStateErrorMessage, typedModelStateValue[0]);
+                    string[] typedModelStateValues = Assert.IsType<string[]>(modelStateValue);
+                    string typedModelStateValue = Assert.Single(typedModelStateValues);
+                    Assert.Same(expectedModelStateErrorMessage, typedModelStateValue);
                     Assert.Same(expectedFormatter, typedContent.Formatter);
                     Assert.NotNull(typedContent.Headers);
                     Assert.Equal(expectedMediaType, typedContent.Headers.ContentType);
@@ -424,18 +419,16 @@ namespace System.Web.Http.Results
                         Assert.NotNull(response);
                         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
                         HttpContent content = response.Content;
-                        Assert.IsType<ObjectContent<HttpError>>(content);
-                        ObjectContent<HttpError> typedContent = (ObjectContent<HttpError>)content;
+                        ObjectContent<HttpError> typedContent = Assert.IsType<ObjectContent<HttpError>>(content);
                         HttpError error = (HttpError)typedContent.Value;
                         Assert.NotNull(error);
                         HttpError modelStateError = error.ModelState;
                         Assert.NotNull(modelStateError);
                         Assert.True(modelState.ContainsKey(expectedModelStateKey));
                         object modelStateValue = modelStateError[expectedModelStateKey];
-                        Assert.IsType(typeof(string[]), modelStateValue);
-                        string[] typedModelStateValue = (string[])modelStateValue;
-                        Assert.Equal(1, typedModelStateValue.Length);
-                        Assert.Same(expectedModelStateExceptionMessage, typedModelStateValue[0]);
+                        string[] typedModelStateValues = Assert.IsType<string[]>(modelStateValue);
+                        string typedModelStateValue = Assert.Single(typedModelStateValues);
+                        Assert.Same(expectedModelStateExceptionMessage, typedModelStateValue);
                         Assert.Same(expectedOutputFormatter, typedContent.Formatter);
                         Assert.NotNull(typedContent.Headers);
                         Assert.Equal(expectedMediaType, typedContent.Headers.ContentType);
@@ -470,7 +463,7 @@ namespace System.Web.Http.Results
                     IContentNegotiator contentNegotiator = result.ContentNegotiator;
 
                     // Assert
-                    Assert.Equal(false, result.IncludeErrorDetail);
+                    Assert.False(result.IncludeErrorDetail);
                 }
             }
         }
@@ -560,8 +553,8 @@ namespace System.Web.Http.Results
 
                     // Assert
                     Assert.NotNull(formatters);
-                    Assert.Equal(1, formatters.Count());
-                    Assert.Same(expectedFormatter, formatters.Single());
+                    MediaTypeFormatter formatter = Assert.Single(formatters);
+                    Assert.Same(expectedFormatter, formatter);
                 }
             }
         }
@@ -595,7 +588,7 @@ namespace System.Web.Http.Results
                 bool includeErrorDetail = result.IncludeErrorDetail;
 
                 // Assert
-                Assert.Equal(true, includeErrorDetail);
+                Assert.True(includeErrorDetail);
             }
         }
 
@@ -688,8 +681,8 @@ namespace System.Web.Http.Results
 
                     // Assert
                     Assert.NotNull(formatters);
-                    Assert.Equal(1, formatters.Count());
-                    Assert.Same(expectedFormatter, formatters.Single());
+                    MediaTypeFormatter formatter = Assert.Single(formatters);
+                    Assert.Same(expectedFormatter, formatter);
                 }
             }
         }

--- a/test/System.Web.Http.Test/Results/NegotiatedContentResultTests.cs
+++ b/test/System.Web.Http.Test/Results/NegotiatedContentResultTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Net;
 using System.Net.Http;
@@ -223,8 +222,7 @@ namespace System.Web.Http.Results
                     Assert.NotNull(response);
                     Assert.Equal(expectedStatusCode, response.StatusCode);
                     HttpContent content = response.Content;
-                    Assert.IsType<ObjectContent<object>>(content);
-                    ObjectContent<object> typedContent = (ObjectContent<object>)content;
+                    ObjectContent<object> typedContent = Assert.IsType<ObjectContent<object>>(content);
                     Assert.Same(expectedContent, typedContent.Value);
                     Assert.Same(expectedFormatter, typedContent.Formatter);
                     Assert.NotNull(typedContent.Headers);
@@ -327,8 +325,7 @@ namespace System.Web.Http.Results
                         Assert.NotNull(response);
                         Assert.Equal(expectedStatusCode, response.StatusCode);
                         HttpContent content = response.Content;
-                        Assert.IsType<ObjectContent<object>>(content);
-                        ObjectContent<object> typedContent = (ObjectContent<object>)content;
+                        ObjectContent<object> typedContent = Assert.IsType<ObjectContent<object>>(content);
                         Assert.Same(expectedContent, typedContent.Value);
                         Assert.Same(expectedOutputFormatter, typedContent.Formatter);
                         Assert.NotNull(typedContent.Headers);
@@ -428,8 +425,8 @@ namespace System.Web.Http.Results
 
                     // Assert
                     Assert.NotNull(formatters);
-                    Assert.Equal(1, formatters.Count());
-                    Assert.Same(expectedFormatter, formatters.Single());
+                    MediaTypeFormatter formatter = Assert.Single(formatters);
+                    Assert.Same(expectedFormatter, formatter);
                 }
             }
         }
@@ -528,8 +525,8 @@ namespace System.Web.Http.Results
 
                     // Assert
                     Assert.NotNull(formatters);
-                    Assert.Equal(1, formatters.Count());
-                    Assert.Same(expectedFormatter, formatters.Single());
+                    MediaTypeFormatter formatter = Assert.Single(formatters);
+                    Assert.Same(expectedFormatter, formatter);
                 }
             }
         }

--- a/test/System.Web.Http.Test/Results/OkNegotiatedContentResultTests.cs
+++ b/test/System.Web.Http.Test/Results/OkNegotiatedContentResultTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Net;
 using System.Net.Http;
@@ -192,8 +191,7 @@ namespace System.Web.Http.Results
                     Assert.NotNull(response);
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                     HttpContent content = response.Content;
-                    Assert.IsType<ObjectContent<object>>(content);
-                    ObjectContent<object> typedContent = (ObjectContent<object>)content;
+                    ObjectContent<object> typedContent = Assert.IsType<ObjectContent<object>>(content);
                     Assert.Same(expectedContent, typedContent.Value);
                     Assert.Same(expectedFormatter, typedContent.Formatter);
                     Assert.NotNull(typedContent.Headers);
@@ -292,8 +290,7 @@ namespace System.Web.Http.Results
                         Assert.NotNull(response);
                         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                         HttpContent content = response.Content;
-                        Assert.IsType<ObjectContent<object>>(content);
-                        ObjectContent<object> typedContent = (ObjectContent<object>)content;
+                        ObjectContent<object> typedContent = Assert.IsType<ObjectContent<object>>(content);
                         Assert.Same(expectedContent, typedContent.Value);
                         Assert.Same(expectedOutputFormatter, typedContent.Formatter);
                         Assert.NotNull(typedContent.Headers);
@@ -387,8 +384,8 @@ namespace System.Web.Http.Results
 
                     // Assert
                     Assert.NotNull(formatters);
-                    Assert.Equal(1, formatters.Count());
-                    Assert.Same(expectedFormatter, formatters.Single());
+                    MediaTypeFormatter formatter = Assert.Single(formatters);
+                    Assert.Same(expectedFormatter, formatter);
                 }
             }
         }
@@ -481,8 +478,8 @@ namespace System.Web.Http.Results
 
                     // Assert
                     Assert.NotNull(formatters);
-                    Assert.Equal(1, formatters.Count());
-                    Assert.Same(expectedFormatter, formatters.Single());
+                    MediaTypeFormatter formatter = Assert.Single(formatters);
+                    Assert.Same(expectedFormatter, formatter);
                 }
             }
         }

--- a/test/System.Web.Http.Test/Routing/MediaTypeFormatterExtensionsTests.cs
+++ b/test/System.Web.Http.Test/Routing/MediaTypeFormatterExtensionsTests.cs
@@ -23,10 +23,10 @@ namespace System.Net.Http.Formatting
 
             mockFormatter.AddUriPathExtensionMapping("ext", new MediaTypeHeaderValue("application/test"));
 
-            Assert.Equal(1, mockFormatter.MediaTypeMappings.Count);
-            Assert.IsType(typeof(UriPathExtensionMapping), mockFormatter.MediaTypeMappings[0]);
-            Assert.Equal("ext", (mockFormatter.MediaTypeMappings[0] as UriPathExtensionMapping).UriPathExtension);
-            Assert.Equal("application/test", (mockFormatter.MediaTypeMappings[0] as UriPathExtensionMapping).MediaType.MediaType);
+            MediaTypeMapping mediaTypeMapping = Assert.Single(mockFormatter.MediaTypeMappings);
+            UriPathExtensionMapping uriPathExtensionMapping = Assert.IsType<UriPathExtensionMapping>(mediaTypeMapping);
+            Assert.Equal("ext", uriPathExtensionMapping.UriPathExtension);
+            Assert.Equal("application/test", uriPathExtensionMapping.MediaType.MediaType);
         }
 
         [Fact]
@@ -43,10 +43,10 @@ namespace System.Net.Http.Formatting
 
             mockFormatter.AddUriPathExtensionMapping("ext", "application/test");
 
-            Assert.Equal(1, mockFormatter.MediaTypeMappings.Count);
-            Assert.IsType(typeof(UriPathExtensionMapping), mockFormatter.MediaTypeMappings[0]);
-            Assert.Equal("ext", (mockFormatter.MediaTypeMappings[0] as UriPathExtensionMapping).UriPathExtension);
-            Assert.Equal("application/test", (mockFormatter.MediaTypeMappings[0] as UriPathExtensionMapping).MediaType.MediaType);
+            MediaTypeMapping mediaTypeMapping = Assert.Single(mockFormatter.MediaTypeMappings);
+            UriPathExtensionMapping uriPathExtensionMapping = Assert.IsType<UriPathExtensionMapping>(mediaTypeMapping);
+            Assert.Equal("ext", uriPathExtensionMapping.UriPathExtension);
+            Assert.Equal("application/test", uriPathExtensionMapping.MediaType.MediaType);
         }
     }
 }

--- a/test/System.Web.Http.Test/Routing/UriPathExtensionMappingTests.cs
+++ b/test/System.Web.Http.Test/Routing/UriPathExtensionMappingTests.cs
@@ -3,7 +3,6 @@
 
 using System.Net.Http.Formatting.DataSets;
 using System.Net.Http.Headers;
-using System.Web.Http.Hosting;
 using System.Web.Http.Routing;
 using Microsoft.TestCommon;
 using Moq;
@@ -85,6 +84,7 @@ namespace System.Net.Http.Formatting
             typeof(HttpTestData), "UriTestDataStrings")]
         public void TryMatchMediaType_Returns_MatchWithExtensionInRouteData(string uriPathExtension, string mediaType, string baseUriString)
         {
+            GC.KeepAlive(baseUriString); // Mark parameter as used. See xUnit1026, [Theory] method doesn't use all parameters.
             UriPathExtensionMapping mapping = new UriPathExtensionMapping(uriPathExtension, mediaType);
             HttpRequestMessage request = GetRequestWithExtInRouteData(uriPathExtension);
             Assert.Equal(1.0, mapping.TryMatchMediaType(request));
@@ -97,6 +97,7 @@ namespace System.Net.Http.Formatting
             typeof(HttpTestData), "UriTestDataStrings")]
         public void TryMatchMediaType_Returns_MatchWithExtensionInRouteData_DifferCase(string uriPathExtension, string mediaType, string baseUriString)
         {
+            GC.KeepAlive(baseUriString); // Mark parameter as used. See xUnit1026, [Theory] method doesn't use all parameters.
             UriPathExtensionMapping mapping = new UriPathExtensionMapping(uriPathExtension.ToUpperInvariant(), mediaType);
             HttpRequestMessage request = GetRequestWithExtInRouteData(uriPathExtension.ToLowerInvariant());
             Assert.Equal(1.0, mapping.TryMatchMediaType(request));

--- a/test/System.Web.Http.Test/Services/DefaultServicesTests.cs
+++ b/test/System.Web.Http.Test/Services/DefaultServicesTests.cs
@@ -91,7 +91,7 @@ namespace System.Web.Http.Services
             Assert.IsType<RouteDataValueProviderFactory>(valueProviderFactories[1]);
 
             object[] exceptionLoggers = defaultServices.GetServices(typeof(IExceptionLogger)).ToArray();
-            Assert.Equal(0, exceptionLoggers.Length);
+            Assert.Empty(exceptionLoggers);
         }
 
         // Add tests

--- a/test/System.Web.Http.Test/Services/ServicesExtensionsTests.cs
+++ b/test/System.Web.Http.Test/Services/ServicesExtensionsTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Web.Http.Controllers;
 using System.Web.Http.ExceptionHandling;
 using Microsoft.TestCommon;
@@ -34,7 +33,7 @@ namespace System.Web.Http.Services
 
             // Act
             IExceptionHandler exceptionHandler = ServicesExtensions.GetExceptionHandler(services);
-            
+
             // Assert
             mock.Verify(s => s.GetService(typeof(IExceptionHandler)), Times.Once());
             Assert.Same(expectedExceptionHandler, exceptionHandler);
@@ -58,8 +57,8 @@ namespace System.Web.Http.Services
             // Assert
             mock.Verify(s => s.GetServices(typeof(IExceptionLogger)), Times.Once());
             Assert.NotNull(exceptionLoggers);
-            Assert.Equal(1, exceptionLoggers.Count());
-            Assert.Same(expectedExceptionLogger, exceptionLoggers.Single());
+            IExceptionLogger exceptionLogger = Assert.Single(exceptionLoggers);
+            Assert.Same(expectedExceptionLogger, exceptionLogger);
         }
     }
 }

--- a/test/System.Web.Http.Test/System.Web.Http.Test.csproj
+++ b/test/System.Web.Http.Test/System.Web.Http.Test.csproj
@@ -405,6 +405,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/System.Web.Http.Test/Tracing/FormattingUtilitiesTest.cs
+++ b/test/System.Web.Http.Test/Tracing/FormattingUtilitiesTest.cs
@@ -24,6 +24,7 @@ namespace System.Web.Http.Tracing
         public void ValueToString_Formats(Type variationType, object testData)
         {
             // Arrange
+            GC.KeepAlive(variationType); // Mark parameter as used. See xUnit1026, [Theory] method doesn't use all parameters.
             string expected = Convert.ToString(testData, CultureInfo.CurrentCulture);
 
             // Act

--- a/test/System.Web.Http.Test/Tracing/TracerCorrectnessTest.cs
+++ b/test/System.Web.Http.Test/Tracing/TracerCorrectnessTest.cs
@@ -41,13 +41,13 @@ namespace System.Web.Http.Tracing
                     { typeof(IAuthorizationFilter), typeof(AuthorizationFilterTracer), new string[0] },
                     { typeof(IAuthenticationFilter), typeof(AuthenticationFilterTracer), new string[0] },
                     { typeof(IOverrideFilter), typeof(OverrideFilterTracer), new string[0] },
-                    { typeof(BufferedMediaTypeFormatter), typeof(BufferedMediaTypeFormatterTracer), new string[] 
+                    { typeof(BufferedMediaTypeFormatter), typeof(BufferedMediaTypeFormatterTracer), new string[]
                         {
                             // Values copied in ctor
-                            "get_BufferSize", "set_BufferSize", 
-                            "get_SupportedMediaTypes", 
-                            "get_SupportedEncodings", 
-                            "get_MediaTypeMappings", 
+                            "get_BufferSize", "set_BufferSize",
+                            "get_SupportedMediaTypes",
+                            "get_SupportedEncodings",
+                            "get_MediaTypeMappings",
                             "get_RequiredMemberSelector", "set_RequiredMemberSelector",
                             // Cannot override, inner handles correctly
                             "ReadFromStreamAsync", "WriteToStreamAsync", "SelectCharacterEncoding"
@@ -60,22 +60,22 @@ namespace System.Web.Http.Tracing
                     { typeof(FormatterParameterBinding), typeof(FormatterParameterBindingTracer), new string[]
                         {
                             // Handled in base ctor
-                            "get_Formatters", "set_Formatters", 
-                            "get_BodyModelValidator", "set_BodyModelValidator", 
+                            "get_Formatters", "set_Formatters",
+                            "get_BodyModelValidator", "set_BodyModelValidator",
                             "get_Descriptor",
                             // Cannot override but handled by overriding ErrorMessage
                             "get_IsValid",
                             "GetValue", "SetValue"
                         }
                     },
-                    { typeof(FormUrlEncodedMediaTypeFormatter), typeof(FormUrlEncodedMediaTypeFormatterTracer), new string[] 
+                    { typeof(FormUrlEncodedMediaTypeFormatter), typeof(FormUrlEncodedMediaTypeFormatterTracer), new string[]
                         {
                             // Values copied in ctor
-                            "get_MaxDepth", "set_MaxDepth", 
+                            "get_MaxDepth", "set_MaxDepth",
                             "get_ReadBufferSize", "set_ReadBufferSize",
-                            "get_SupportedMediaTypes", 
-                            "get_SupportedEncodings", 
-                            "get_MediaTypeMappings", 
+                            "get_SupportedMediaTypes",
+                            "get_SupportedEncodings",
+                            "get_MediaTypeMappings",
                             "get_RequiredMemberSelector", "set_RequiredMemberSelector",
                             // Cannot override, base handles correctly via SupportedEncodings
                             "SelectCharacterEncoding",
@@ -84,14 +84,14 @@ namespace System.Web.Http.Tracing
                     { typeof(HttpActionBinding), typeof(HttpActionBindingTracer), new string[]
                         {
                             // Values copied in ctor
-                            "get_ActionDescriptor", "set_ActionDescriptor", 
+                            "get_ActionDescriptor", "set_ActionDescriptor",
                             "get_ParameterBindings", "set_ParameterBindings"
                         }
                     },
                     { typeof(HttpActionDescriptor), typeof(HttpActionDescriptorTracer), new string[]
                         {
                             // Values copied in ctor
-                            "get_Configuration", "set_Configuration", 
+                            "get_Configuration", "set_Configuration",
                             "get_ControllerDescriptor", "set_ControllerDescriptor"
                         }
                     },
@@ -102,7 +102,7 @@ namespace System.Web.Http.Tracing
                     { typeof(HttpControllerDescriptor), typeof(HttpControllerDescriptorTracer), new string[]
                         {
                             // Values copied in ctor
-                            "get_Configuration", "set_Configuration", 
+                            "get_Configuration", "set_Configuration",
                             "get_ControllerType", "set_ControllerType",
                             "get_ControllerName", "set_ControllerName"
                         }
@@ -118,28 +118,28 @@ namespace System.Web.Http.Tracing
                             "GetValue", "SetValue",
                         }
                     },
-                    { typeof(JsonMediaTypeFormatter), typeof(JsonMediaTypeFormatterTracer), new string[] 
+                    { typeof(JsonMediaTypeFormatter), typeof(JsonMediaTypeFormatterTracer), new string[]
                         {
                             // Values copied in ctor
                             "get_MaxDepth", "set_MaxDepth",
-                            "get_SupportedMediaTypes", 
-                            "get_SupportedEncodings", 
-                            "get_MediaTypeMappings", 
+                            "get_SupportedMediaTypes",
+                            "get_SupportedEncodings",
+                            "get_MediaTypeMappings",
                             "get_RequiredMemberSelector", "set_RequiredMemberSelector",
                             "get_Indent", "set_Indent",
                             "get_UseDataContractJsonSerializer", "set_UseDataContractJsonSerializer",
                             "get_SerializerSettings", "set_SerializerSettings",
                             // Cannot override, base handles correctly
-                            "SelectCharacterEncoding", 
+                            "SelectCharacterEncoding",
                             // Cannot override behavior, but copying SerializerSettings in ctor captures inner's result
                             "CreateDefaultSerializerSettings"
                         }
                     },
-                    { typeof(MediaTypeFormatter), typeof(MediaTypeFormatterTracer), new string[] 
+                    { typeof(MediaTypeFormatter), typeof(MediaTypeFormatterTracer), new string[]
                         {
                             // Values copied in ctor
-                            "get_SupportedMediaTypes", "get_SupportedEncodings", 
-                            "get_MediaTypeMappings", 
+                            "get_SupportedMediaTypes", "get_SupportedEncodings",
+                            "get_MediaTypeMappings",
                             "get_RequiredMemberSelector", "set_RequiredMemberSelector",
                             // Cannot override, base handles correctly
                             "SelectCharacterEncoding"
@@ -161,18 +161,18 @@ namespace System.Web.Http.Tracing
                             "Dispose"
                         }
                     },
-                    { typeof(XmlMediaTypeFormatter), typeof(XmlMediaTypeFormatterTracer), new string[] 
+                    { typeof(XmlMediaTypeFormatter), typeof(XmlMediaTypeFormatterTracer), new string[]
                         {
                             // Values copied in ctor
-                            "get_SupportedMediaTypes", 
-                            "get_SupportedEncodings", 
-                            "get_MediaTypeMappings", 
+                            "get_SupportedMediaTypes",
+                            "get_SupportedEncodings",
+                            "get_MediaTypeMappings",
                             "get_RequiredMemberSelector", "set_RequiredMemberSelector",
                             "get_UseXmlSerializer", "set_UseXmlSerializer",
                             "get_Indent", "set_Indent",
                             "get_WriterSettings",
                             "get_MaxDepth", "set_MaxDepth",
-                            "InvokeCreateXmlReader", "InvokeCreateXmlWriter", 
+                            "InvokeCreateXmlReader", "InvokeCreateXmlWriter",
                             "InvokeGetDeserializer", "InvokeGetSerializer",
                             // Cannot override, base handles correctly
                             "SelectCharacterEncoding",
@@ -184,6 +184,49 @@ namespace System.Web.Http.Tracing
                     },
                     { typeof(DefaultHttpControllerTypeResolver), typeof(DefaultHttpControllerTypeResolverTracer), new string[0] },
                 };
+            }
+        }
+
+        // Following filters work best if there are no duplicate tracer types in AllKnownTracers. Currently the case.
+        public static TheoryDataSet<Type, Type> AllKnownTracers_NoExclusions
+        {
+            get
+            {
+                var dataSet = new TheoryDataSet<Type, Type>();
+                foreach (var item in AllKnownTracers)
+                {
+                    dataSet.Add((Type)item[0], (Type)item[1]);
+                }
+
+                return dataSet;
+            }
+        }
+
+        public static TheoryDataSet<Type, string[]> AllKnownTracers_NoInnerType
+        {
+            get
+            {
+                var dataSet = new TheoryDataSet<Type, string[]>();
+                foreach (var item in AllKnownTracers)
+                {
+                    dataSet.Add((Type)item[1], (string[])item[2]);
+                }
+
+                return dataSet;
+            }
+        }
+
+        public static TheoryDataSet<Type> AllKnownTracers_JustTracerType
+        {
+            get
+            {
+                var dataSet = new TheoryDataSet<Type>();
+                foreach (var item in AllKnownTracers)
+                {
+                    dataSet.Add((Type)item[1]);
+                }
+
+                return dataSet;
             }
         }
 
@@ -205,8 +248,8 @@ namespace System.Web.Http.Tracing
         }
 
         [Theory]
-        [PropertyData("AllKnownTracers")]
-        public void All_Tracers_Are_Internal_And_Disposable_When_Inner_Is_Disposable(Type innerType, Type tracerType, string[] exclusions)
+        [PropertyData("AllKnownTracers_NoExclusions")]
+        public void All_Tracers_Are_Internal_And_Disposable_When_Inner_Is_Disposable(Type innerType, Type tracerType)
         {
             // Arrange
             TypeAssert.TypeProperties typeProperties = TypeAssert.TypeProperties.IsClass;
@@ -224,16 +267,16 @@ namespace System.Web.Http.Tracing
         }
 
         [Theory]
-        [PropertyData("AllKnownTracers")]
-        public void All_Tracers_Use_Correct_Namespace(Type innerType, Type tracerType, string[] exclusions)
+        [PropertyData("AllKnownTracers_JustTracerType")]
+        public void All_Tracers_Use_Correct_Namespace(Type tracerType)
         {
             // Arrange & Act & Assert
             Assert.Equal("System.Web.Http.Tracing.Tracers", tracerType.Namespace);
         }
 
         [Theory]
-        [PropertyData("AllKnownTracers")]
-        public void All_Excluded_Members_Are_Declared(Type innerType, Type tracerType, string[] exclusions)
+        [PropertyData("AllKnownTracers_NoInnerType")]
+        public void All_Excluded_Members_Are_Declared(Type tracerType, string[] exclusions)
         {
             // Arrange & Act
             string[] declaredMembers = tracerType.GetMembers(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).Select<MemberInfo, string>(m => m.Name).ToArray();

--- a/test/System.Web.Http.Test/Tracing/Tracers/FilterTracerTest.cs
+++ b/test/System.Web.Http.Test/Tracing/Tracers/FilterTracerTest.cs
@@ -23,11 +23,11 @@ namespace System.Web.Http.Tracing.Tracers
             Mock<IFilter> mockFilter = new Mock<IFilter>();
 
             // Act
-            IFilter[] wrappedFilters = FilterTracer.CreateFilterTracers(mockFilter.Object, new TestTraceWriter()).ToArray();
+            IEnumerable<IFilter> wrappedFilters = FilterTracer.CreateFilterTracers(mockFilter.Object, new TestTraceWriter());
 
             // Assert
-            Assert.Equal(1, wrappedFilters.Length);
-            Assert.IsType<FilterTracer>(wrappedFilters[0]);
+            IFilter wrappedFilter = Assert.Single(wrappedFilters);
+            Assert.IsType<FilterTracer>(wrappedFilter);
         }
 
         [Fact]
@@ -37,11 +37,11 @@ namespace System.Web.Http.Tracing.Tracers
             Mock<IActionFilter> mockFilter = new Mock<IActionFilter>();
 
             // Act
-            IFilter[] wrappedFilters = FilterTracer.CreateFilterTracers(mockFilter.Object, new TestTraceWriter()).ToArray();
+            IEnumerable<IFilter> wrappedFilters = FilterTracer.CreateFilterTracers(mockFilter.Object, new TestTraceWriter());
 
             // Assert
-            Assert.Equal(1, wrappedFilters.Length);
-            Assert.IsType<ActionFilterTracer>(wrappedFilters[0]);
+            IFilter wrappedFilter = Assert.Single(wrappedFilters);
+            Assert.IsType<ActionFilterTracer>(wrappedFilter);
         }
 
         [Fact]
@@ -51,11 +51,11 @@ namespace System.Web.Http.Tracing.Tracers
             Mock<IExceptionFilter> mockFilter = new Mock<IExceptionFilter>();
 
             // Act
-            IFilter[] wrappedFilters = FilterTracer.CreateFilterTracers(mockFilter.Object, new TestTraceWriter()).ToArray();
+            IEnumerable<IFilter> wrappedFilters = FilterTracer.CreateFilterTracers(mockFilter.Object, new TestTraceWriter());
 
             // Assert
-            Assert.Equal(1, wrappedFilters.Length);
-            Assert.IsType<ExceptionFilterTracer>(wrappedFilters[0]);
+            IFilter wrappedFilter = Assert.Single(wrappedFilters);
+            Assert.IsType<ExceptionFilterTracer>(wrappedFilter);
         }
 
         [Fact]
@@ -70,10 +70,8 @@ namespace System.Web.Http.Tracing.Tracers
 
             // Assert
             Assert.NotNull(tracers);
-            Assert.Equal(1, tracers.Count());
-            IFilter untypedFilter = tracers.Single();
-            Assert.IsType<AuthenticationFilterTracer>(untypedFilter);
-            AuthenticationFilterTracer tracer = (AuthenticationFilterTracer)untypedFilter;
+            IFilter untypedFilter = Assert.Single(tracers);
+            AuthenticationFilterTracer tracer = Assert.IsType<AuthenticationFilterTracer>(untypedFilter);
             Assert.Same(expectedInner, tracer.InnerFilter);
             Assert.Same(expectedTraceWriter, tracer.TraceWriter);
         }
@@ -85,11 +83,11 @@ namespace System.Web.Http.Tracing.Tracers
             Mock<IAuthorizationFilter> mockFilter = new Mock<IAuthorizationFilter>();
 
             // Act
-            IFilter[] wrappedFilters = FilterTracer.CreateFilterTracers(mockFilter.Object, new TestTraceWriter()).ToArray();
+            IEnumerable<IFilter> wrappedFilters = FilterTracer.CreateFilterTracers(mockFilter.Object, new TestTraceWriter());
 
             // Assert
-            Assert.Equal(1, wrappedFilters.Length);
-            Assert.IsType<AuthorizationFilterTracer>(wrappedFilters[0]);
+            IFilter wrappedFilter = Assert.Single(wrappedFilters);
+            Assert.IsType<AuthorizationFilterTracer>(wrappedFilter);
         }
 
         [Fact]
@@ -104,10 +102,8 @@ namespace System.Web.Http.Tracing.Tracers
 
             // Assert
             Assert.NotNull(tracers);
-            Assert.Equal(1, tracers.Count());
-            IFilter untypedFilter = tracers.Single();
-            Assert.IsType<OverrideFilterTracer>(untypedFilter);
-            OverrideFilterTracer tracer = (OverrideFilterTracer)untypedFilter;
+            IFilter untypedFilter = Assert.Single(tracers);
+            OverrideFilterTracer tracer = Assert.IsType<OverrideFilterTracer>(untypedFilter);
             Assert.Same(expectedInner, tracer.InnerFilter);
             Assert.Same(expectedTraceWriter, tracer.TraceWriter);
         }
@@ -119,11 +115,11 @@ namespace System.Web.Http.Tracing.Tracers
             Mock<ActionFilterAttribute> mockFilter = new Mock<ActionFilterAttribute>();
 
             // Act
-            IFilter[] wrappedFilters = FilterTracer.CreateFilterTracers(mockFilter.Object, new TestTraceWriter()).ToArray();
+            IEnumerable<IFilter> wrappedFilters = FilterTracer.CreateFilterTracers(mockFilter.Object, new TestTraceWriter());
 
             // Assert
-            Assert.Equal(1, wrappedFilters.Length);
-            Assert.IsType<ActionFilterAttributeTracer>(wrappedFilters[0]);
+            IFilter wrappedFilter = Assert.Single(wrappedFilters);
+            Assert.IsType<ActionFilterAttributeTracer>(wrappedFilter);
         }
 
         [Fact]
@@ -133,11 +129,11 @@ namespace System.Web.Http.Tracing.Tracers
             Mock<ExceptionFilterAttribute> mockFilter = new Mock<ExceptionFilterAttribute>();
 
             // Act
-            IFilter[] wrappedFilters = FilterTracer.CreateFilterTracers(mockFilter.Object, new TestTraceWriter()).ToArray();
+            IEnumerable<IFilter> wrappedFilters = FilterTracer.CreateFilterTracers(mockFilter.Object, new TestTraceWriter());
 
             // Assert
-            Assert.Equal(1, wrappedFilters.Length);
-            Assert.IsType<ExceptionFilterAttributeTracer>(wrappedFilters[0]);
+            IFilter wrappedFilter = Assert.Single(wrappedFilters);
+            Assert.IsType<ExceptionFilterAttributeTracer>(wrappedFilter);
         }
 
         [Fact]
@@ -147,11 +143,11 @@ namespace System.Web.Http.Tracing.Tracers
             Mock<AuthorizationFilterAttribute> mockFilter = new Mock<AuthorizationFilterAttribute>();
 
             // Act
-            IFilter[] wrappedFilters = FilterTracer.CreateFilterTracers(mockFilter.Object, new TestTraceWriter()).ToArray();
+            IEnumerable<IFilter> wrappedFilters = FilterTracer.CreateFilterTracers(mockFilter.Object, new TestTraceWriter());
 
             // Assert
-            Assert.Equal(1, wrappedFilters.Length);
-            Assert.IsType<AuthorizationFilterAttributeTracer>(wrappedFilters[0]);
+            IFilter wrappedFilter = Assert.Single(wrappedFilters);
+            Assert.IsType<AuthorizationFilterAttributeTracer>(wrappedFilter);
         }
 
         [Fact]
@@ -165,11 +161,11 @@ namespace System.Web.Http.Tracing.Tracers
 
             // Assert
             Assert.Equal(5, wrappedFilters.Length);
-            Assert.Equal(1, wrappedFilters.OfType<ActionFilterTracer>().Count());
-            Assert.Equal(1, wrappedFilters.OfType<AuthorizationFilterTracer>().Count());
-            Assert.Equal(1, wrappedFilters.OfType<AuthenticationFilterTracer>().Count());
-            Assert.Equal(1, wrappedFilters.OfType<ExceptionFilterTracer>().Count());
-            Assert.Equal(1, wrappedFilters.OfType<OverrideFilterTracer>().Count());
+            Assert.Single(wrappedFilters.OfType<ActionFilterTracer>());
+            Assert.Single(wrappedFilters.OfType<AuthorizationFilterTracer>());
+            Assert.Single(wrappedFilters.OfType<AuthenticationFilterTracer>());
+            Assert.Single(wrappedFilters.OfType<ExceptionFilterTracer>());
+            Assert.Single(wrappedFilters.OfType<OverrideFilterTracer>());
         }
 
         [Fact]
@@ -180,11 +176,11 @@ namespace System.Web.Http.Tracing.Tracers
             FilterInfo filter = new FilterInfo(mockFilter.Object, FilterScope.Action);
 
             // Act
-            FilterInfo[] wrappedFilters = FilterTracer.CreateFilterTracers(filter, new TestTraceWriter()).ToArray();
+            IEnumerable<FilterInfo> wrappedFilters = FilterTracer.CreateFilterTracers(filter, new TestTraceWriter());
 
             // Assert
-            Assert.Equal(1, wrappedFilters.Length);
-            Assert.IsType<FilterTracer>(wrappedFilters[0].Instance);
+            FilterInfo wrappedFilter = Assert.Single(wrappedFilters);
+            Assert.IsType<FilterTracer>(wrappedFilter.Instance);
         }
 
         [Fact]
@@ -195,11 +191,11 @@ namespace System.Web.Http.Tracing.Tracers
             FilterInfo filter = new FilterInfo(mockFilter.Object, FilterScope.Action);
 
             // Act
-            FilterInfo[] wrappedFilters = FilterTracer.CreateFilterTracers(filter, new TestTraceWriter()).ToArray();
+            IEnumerable<FilterInfo> wrappedFilters = FilterTracer.CreateFilterTracers(filter, new TestTraceWriter());
 
             // Assert
-            Assert.Equal(1, wrappedFilters.Length);
-            Assert.IsType<ActionFilterTracer>(wrappedFilters[0].Instance);
+            FilterInfo wrappedFilter = Assert.Single(wrappedFilters);
+            Assert.IsType<ActionFilterTracer>(wrappedFilter.Instance);
         }
 
         [Fact]
@@ -210,11 +206,11 @@ namespace System.Web.Http.Tracing.Tracers
             FilterInfo filter = new FilterInfo(mockFilter.Object, FilterScope.Action);
 
             // Act
-            FilterInfo[] wrappedFilters = FilterTracer.CreateFilterTracers(filter, new TestTraceWriter()).ToArray();
+            IEnumerable<FilterInfo> wrappedFilters = FilterTracer.CreateFilterTracers(filter, new TestTraceWriter());
 
             // Assert
-            Assert.Equal(1, wrappedFilters.Length);
-            Assert.IsType<ExceptionFilterTracer>(wrappedFilters[0].Instance);
+            FilterInfo wrappedFilter = Assert.Single(wrappedFilters);
+            Assert.IsType<ExceptionFilterTracer>(wrappedFilter.Instance);
         }
 
         [Fact]
@@ -230,12 +226,10 @@ namespace System.Web.Http.Tracing.Tracers
 
             // Assert
             Assert.NotNull(filters);
-            Assert.Equal(1, filters.Count());
-            FilterInfo filterInfo = filters.Single();
+            FilterInfo filterInfo = Assert.Single(filters);
             Assert.NotNull(filterInfo);
             IFilter untypedFilter = filterInfo.Instance;
-            Assert.IsType<AuthenticationFilterTracer>(untypedFilter);
-            AuthenticationFilterTracer tracer = (AuthenticationFilterTracer)untypedFilter;
+            AuthenticationFilterTracer tracer = Assert.IsType<AuthenticationFilterTracer>(untypedFilter);
             Assert.Same(expectedInner, tracer.InnerFilter);
             Assert.Same(expectedTraceWriter, tracer.TraceWriter);
         }
@@ -248,11 +242,11 @@ namespace System.Web.Http.Tracing.Tracers
             FilterInfo filter = new FilterInfo(mockFilter.Object, FilterScope.Action);
 
             // Act
-            FilterInfo[] wrappedFilters = FilterTracer.CreateFilterTracers(filter, new TestTraceWriter()).ToArray();
+            IEnumerable<FilterInfo> wrappedFilters = FilterTracer.CreateFilterTracers(filter, new TestTraceWriter());
 
             // Assert
-            Assert.Equal(1, wrappedFilters.Length);
-            Assert.IsType<AuthorizationFilterTracer>(wrappedFilters[0].Instance);
+            FilterInfo wrappedFilter = Assert.Single(wrappedFilters);
+            Assert.IsType<AuthorizationFilterTracer>(wrappedFilter.Instance);
         }
 
         [Fact]
@@ -268,12 +262,10 @@ namespace System.Web.Http.Tracing.Tracers
 
             // Assert
             Assert.NotNull(filters);
-            Assert.Equal(1, filters.Count());
-            FilterInfo filterInfo = filters.Single();
+            FilterInfo filterInfo = Assert.Single(filters);
             Assert.NotNull(filterInfo);
             IFilter untypedFilter = filterInfo.Instance;
-            Assert.IsType<OverrideFilterTracer>(untypedFilter);
-            OverrideFilterTracer tracer = (OverrideFilterTracer)untypedFilter;
+            OverrideFilterTracer tracer = Assert.IsType<OverrideFilterTracer>(untypedFilter);
             Assert.Same(expectedInner, tracer.InnerFilter);
             Assert.Same(expectedTraceWriter, tracer.TraceWriter);
         }
@@ -286,11 +278,11 @@ namespace System.Web.Http.Tracing.Tracers
             FilterInfo filter = new FilterInfo(mockFilter.Object, FilterScope.Action);
 
             // Act
-            FilterInfo[] wrappedFilters = FilterTracer.CreateFilterTracers(filter, new TestTraceWriter()).ToArray();
+            IEnumerable<FilterInfo> wrappedFilters = FilterTracer.CreateFilterTracers(filter, new TestTraceWriter());
 
             // Assert
-            Assert.Equal(1, wrappedFilters.Length);
-            Assert.IsType<ActionFilterAttributeTracer>(wrappedFilters[0].Instance);
+            FilterInfo wrappedFilter = Assert.Single(wrappedFilters);
+            Assert.IsType<ActionFilterAttributeTracer>(wrappedFilter.Instance);
         }
 
         [Fact]
@@ -301,11 +293,11 @@ namespace System.Web.Http.Tracing.Tracers
             FilterInfo filter = new FilterInfo(mockFilter.Object, FilterScope.Action);
 
             // Act
-            FilterInfo[] wrappedFilters = FilterTracer.CreateFilterTracers(filter, new TestTraceWriter()).ToArray();
+            IEnumerable<FilterInfo> wrappedFilters = FilterTracer.CreateFilterTracers(filter, new TestTraceWriter());
 
             // Assert
-            Assert.Equal(1, wrappedFilters.Length);
-            Assert.IsType<ExceptionFilterAttributeTracer>(wrappedFilters[0].Instance);
+            FilterInfo wrappedFilter = Assert.Single(wrappedFilters);
+            Assert.IsType<ExceptionFilterAttributeTracer>(wrappedFilter.Instance);
         }
 
         [Fact]
@@ -316,11 +308,11 @@ namespace System.Web.Http.Tracing.Tracers
             FilterInfo filter = new FilterInfo(mockFilter.Object, FilterScope.Action);
 
             // Act
-            FilterInfo[] wrappedFilters = FilterTracer.CreateFilterTracers(filter, new TestTraceWriter()).ToArray();
+            IEnumerable<FilterInfo> wrappedFilters = FilterTracer.CreateFilterTracers(filter, new TestTraceWriter());
 
             // Assert
-            Assert.Equal(1, wrappedFilters.Length);
-            Assert.IsType<AuthorizationFilterAttributeTracer>(wrappedFilters[0].Instance);
+            FilterInfo wrappedFilter = Assert.Single(wrappedFilters);
+            Assert.IsType<AuthorizationFilterAttributeTracer>(wrappedFilter.Instance);
         }
 
         [Fact]
@@ -334,11 +326,11 @@ namespace System.Web.Http.Tracing.Tracers
 
             // Assert
             Assert.Equal(5, wrappedFilters.Length);
-            Assert.Equal(1, wrappedFilters.Where(f => f.Instance.GetType() == typeof(ActionFilterTracer)).Count());
-            Assert.Equal(1, wrappedFilters.Where(f => f.Instance.GetType() == typeof(AuthorizationFilterTracer)).Count());
-            Assert.Equal(1, wrappedFilters.Where(f => f.Instance.GetType() == typeof(AuthenticationFilterTracer)).Count());
-            Assert.Equal(1, wrappedFilters.Where(f => f.Instance.GetType() == typeof(ExceptionFilterTracer)).Count());
-            Assert.Equal(1, wrappedFilters.Where(f => f.Instance.GetType() == typeof(OverrideFilterTracer)).Count());
+            Assert.Single(wrappedFilters, f => f.Instance.GetType() == typeof(ActionFilterTracer));
+            Assert.Single(wrappedFilters, f => f.Instance.GetType() == typeof(AuthorizationFilterTracer));
+            Assert.Single(wrappedFilters, f => f.Instance.GetType() == typeof(AuthenticationFilterTracer));
+            Assert.Single(wrappedFilters, f => f.Instance.GetType() == typeof(ExceptionFilterTracer));
+            Assert.Single(wrappedFilters, f => f.Instance.GetType() == typeof(OverrideFilterTracer));
         }
 
         [Fact]

--- a/test/System.Web.Http.Test/Tracing/Tracers/HttpParameterBindingTracerTest.cs
+++ b/test/System.Web.Http.Test/Tracing/Tracers/HttpParameterBindingTracerTest.cs
@@ -103,7 +103,7 @@ namespace System.Web.Http.Tracing.Tracers
             ValueProviderFactory[] actualFactories = tracer.ValueProviderFactories.ToArray();
 
             // Assert
-            Assert.Equal(0, actualFactories.Length);
+            Assert.Empty(actualFactories);
         }
 
         [Fact]

--- a/test/System.Web.Http.Test/Validation/DefaultBodyModelValidatorTest.cs
+++ b/test/System.Web.Http.Test/Validation/DefaultBodyModelValidatorTest.cs
@@ -100,7 +100,7 @@ namespace System.Web.Http.Validation
                             { "[0].Property3", "Error3" }
                         }
                     },
-                    
+
                     // Testing we don't blow up on cycles
                     { LonelyPerson, typeof(Person), new Dictionary<string, string>()
                         {
@@ -111,7 +111,7 @@ namespace System.Web.Http.Validation
 
                     // Testing that we don't bubble up exceptions when property getters throw
                     { new Uri("/api/values", UriKind.Relative), typeof(Uri), new Dictionary<string, string>() },
-                    
+
                     // Testing that excluded types don't result in any errors
                     { typeof(string), typeof(Type), new Dictionary<string, string>() },
                     { new byte[] { (byte)'a', (byte)'b' }, typeof(byte[]), new Dictionary<string, string>() },
@@ -204,7 +204,7 @@ namespace System.Web.Http.Validation
             // Assert
             Assert.False(actionContext.ModelState.IsValid);
             ModelState modelState = actionContext.ModelState["Owner"];
-            Assert.Equal(1, modelState.Errors.Count);
+            Assert.Single(modelState.Errors);
         }
 
         [Fact]

--- a/test/System.Web.Http.Test/Validation/ModelStateFormatterLoggerTest.cs
+++ b/test/System.Web.Http.Test/Validation/ModelStateFormatterLoggerTest.cs
@@ -19,8 +19,8 @@ namespace System.Web.Http.Validation
             formatterLogger.LogError("property", "error");
 
             Assert.True(modelState.ContainsKey("prefix.property"));
-            Assert.Equal(1, modelState["prefix.property"].Errors.Count);
-            Assert.Equal("error", modelState["prefix.property"].Errors[0].ErrorMessage);
+            ModelError error = Assert.Single(modelState["prefix.property"].Errors);
+            Assert.Equal("error", error.ErrorMessage);
         }
 
         [Fact]
@@ -35,8 +35,8 @@ namespace System.Web.Http.Validation
             formatterLogger.LogError("property", e);
 
             Assert.True(modelState.ContainsKey("prefix.property"));
-            Assert.Equal(1, modelState["prefix.property"].Errors.Count);
-            Assert.Equal(e, modelState["prefix.property"].Errors[0].Exception);
+            ModelError error = Assert.Single(modelState["prefix.property"].Errors);
+            Assert.Equal(e, error.Exception);
         }
     }
 }

--- a/test/System.Web.Http.Test/Validation/Providers/AssociatedValidatorProviderTest.cs
+++ b/test/System.Web.Http.Test/Validation/Providers/AssociatedValidatorProviderTest.cs
@@ -49,7 +49,7 @@ namespace System.Web.Http.Validation.Providers
 
             // Assert
             provider.Verify();
-            Assert.True(callbackAttributes.Any(a => a is RequiredAttribute));
+            Assert.Contains(callbackAttributes, a => a is RequiredAttribute);
         }
 
         [Fact]
@@ -69,7 +69,7 @@ namespace System.Web.Http.Validation.Providers
 
             // Assert
             provider.Verify();
-            Assert.True(callbackAttributes.Any(a => a is RangeAttribute));
+            Assert.Contains(callbackAttributes, a => a is RangeAttribute);
         }
 
         [Fact]
@@ -89,8 +89,8 @@ namespace System.Web.Http.Validation.Providers
 
             // Assert
             provider.Verify();
-            Assert.True(callbackAttributes.Any(a => a is RangeAttribute));
-            Assert.True(callbackAttributes.Any(a => a is RequiredAttribute));
+            Assert.Contains(callbackAttributes, a => a is RangeAttribute);
+            Assert.Contains(callbackAttributes, a => a is RequiredAttribute);
         }
 
         [MetadataType(typeof(Metadata))]

--- a/test/System.Web.Http.Test/Validation/Providers/InvalidModelValidatorProviderTest.cs
+++ b/test/System.Web.Http.Test/Validation/Providers/InvalidModelValidatorProviderTest.cs
@@ -46,8 +46,8 @@ namespace System.Web.Http.Validation.Providers
 
             IEnumerable<ModelValidator> validators = validatorProvider.GetValidators(_metadataProvider.GetMetadataForProperty(null, typeof(InvalidModel), "Value"), _noValidatorProviders);
 
-            Assert.Equal(1, validators.Count());
-            Assert.Throws<InvalidOperationException>(() => validators.First().Validate(null, null),
+            ModelValidator validator = Assert.Single(validators);
+            Assert.Throws<InvalidOperationException>(() => validator.Validate(null, null),
                 "Property 'Value' on type 'System.Web.Http.Validation.Providers.InvalidModelValidatorProviderTest+InvalidModel' is invalid. Value-typed properties marked as [Required] must also be marked with [DataMember(IsRequired=true)] to be recognized as required. Consider attributing the declaring type with [DataContract] and the property with [DataMember(IsRequired=true)].");
         }
 

--- a/test/System.Web.Http.Test/ValueProviders/Providers/QueryStringValueProviderTest.cs
+++ b/test/System.Web.Http.Test/ValueProviders/Providers/QueryStringValueProviderTest.cs
@@ -28,7 +28,7 @@ namespace System.Web.Http.ValueProviders.Providers
             NameValueCollection result = ParseQueryString(null);
 
             // Assert
-            Assert.Equal(0, result.Count);
+            Assert.Empty(result);
         }
 
         [Fact]

--- a/test/System.Web.Http.Test/packages.config
+++ b/test/System.Web.Http.Test/packages.config
@@ -3,7 +3,9 @@
   <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />


### PR DESCRIPTION
- part of #65
- change `ExceptionResultTests` to not use `Assert.Same(...)` for `string`s (failed occassionally)

Few manual changes:
- workaround xUnit1026, `[Theory]` method doesn't use all parameters
  - add new data set properties or `GC.KeepAlive(...)`
- `Assert.Equal<T>(...)` -> `Assert.Equal(...)`
- use `Assert.IsAssignableFrom<T>(...)`, `Assert.IsType<T>(...)` and `Assert.Single(...)` return values
- avoid Linq's `.Where` inside `Assert.Contains(...)` and similar