### PR TITLE
Add xUnit analyzers and take fixer suggestions (4 of 5): System.Web.Http.Tracing.Test to System.Web.Mvc.Test

### DIFF
--- a/test/Common/AttributeListTest.cs
+++ b/test/Common/AttributeListTest.cs
@@ -54,14 +54,14 @@ namespace System.ComponentModel
         public void AttributeListContainsWrappedTrue()
         {
             Attribute presentAttribute = _collection[2];
-            Assert.True(_list.Contains(presentAttribute));
+            Assert.Contains(presentAttribute, _list);
         }
 
         [Fact]
         public void AttributeListContainsMissingFalse()
         {
             Attribute missingAttribute = new MissingAttribute();
-            Assert.False(_list.Contains(missingAttribute));
+            Assert.DoesNotContain(missingAttribute, _list);
         }
 
         [Fact]

--- a/test/Common/CollectionExtensionsTest.cs
+++ b/test/Common/CollectionExtensionsTest.cs
@@ -107,7 +107,7 @@ namespace System.Collections.Generic
             Assert.Equal(expected, enumerableAsIList);
             Assert.NotSame(expected, enumerableAsIList);
         }
-        
+
         [Fact]
         public void AsList_List_ReturnsSameInstance()
         {
@@ -131,6 +131,7 @@ namespace System.Collections.Generic
             Assert.NotSame(array, arrayAsList);
         }
 
+        [Fact]
         public void AsList_ListWrapperCollection_ReturnsSameInstance()
         {
             List<object> list = new List<object> { new object(), new object() };
@@ -270,7 +271,7 @@ namespace System.Collections.Generic
             Assert.Equal(hasNulls[2], hasNullsResult[1]);
         }
 
-        [Fact] 
+        [Fact]
         public void ToDictionaryFastArray2Element()
         {
             string[] input = new string[] {"AA", "BB"};
@@ -283,7 +284,7 @@ namespace System.Collections.Generic
             Assert.Equal(StringComparer.OrdinalIgnoreCase, result.Comparer);
         }
 
-        [Fact] 
+        [Fact]
         public void ToDictionaryFastIListList2Element()
         {
             string[] input = new string[] {"AA", "BB"};
@@ -311,7 +312,7 @@ namespace System.Collections.Generic
             Assert.Equal(StringComparer.OrdinalIgnoreCase, arrayResult.Comparer);
         }
 
-        [Fact] 
+        [Fact]
         public void ToDictionaryFastIEnumerableArray2Element()
         {
             string[] input = new string[] {"AA", "BB"};

--- a/test/Common/Routing/RouteFactoryAttributeTests.cs
+++ b/test/Common/Routing/RouteFactoryAttributeTests.cs
@@ -500,8 +500,8 @@ namespace System.Web.Mvc.Routing
             // Assert
             Assert.NotNull(usage);
             Assert.Equal(AttributeTargets.Class | AttributeTargets.Method, usage.ValidOn);
-            Assert.Equal(false, usage.Inherited);
-            Assert.Equal(true, usage.AllowMultiple);
+            Assert.False(usage.Inherited);
+            Assert.True(usage.AllowMultiple);
         }
 
         private static IDirectRouteBuilder CreateBuilder(Func<RouteEntry> build)

--- a/test/System.Web.Http.Tracing.Test/System.Web.Http.Tracing.Test.csproj
+++ b/test/System.Web.Http.Tracing.Test/System.Web.Http.Tracing.Test.csproj
@@ -69,6 +69,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/System.Web.Http.Tracing.Test/packages.config
+++ b/test/System.Web.Http.Tracing.Test/packages.config
@@ -1,7 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />

--- a/test/System.Web.Http.WebHost.Test/GlobalConfigurationTest.cs
+++ b/test/System.Web.Http.WebHost.Test/GlobalConfigurationTest.cs
@@ -66,8 +66,7 @@ namespace System.Web.Http
             object service = configuration.Services.GetService(typeof(IExceptionHandler));
 
             // Assert
-            Assert.IsType(typeof(WebHostExceptionHandler), service); // Guard
-            WebHostExceptionHandler typedHandler = (WebHostExceptionHandler)service;
+            WebHostExceptionHandler typedHandler = Assert.IsType<WebHostExceptionHandler>(service); // Guard
             Assert.IsType(defaultExceptionHandlerType, typedHandler.InnerHandler);
         }
 

--- a/test/System.Web.Http.WebHost.Test/HttpControllerHandlerTest.cs
+++ b/test/System.Web.Http.WebHost.Test/HttpControllerHandlerTest.cs
@@ -286,10 +286,8 @@ namespace System.Web.Http.WebHost
             Assert.Equal(inputStreamMessage, result);
         }
 
-        [Theory]
-        [InlineData(ReadEntityBodyMode.None)]
-        [InlineData(ReadEntityBodyMode.Bufferless)]
-        public async Task ConvertRequest_DoesLazyGetBufferlessInputStream_IfRequestStreamHasNotBeenRead(ReadEntityBodyMode readEntityBodyMode)
+        [Fact]
+        public async Task ConvertRequest_DoesLazyGetBufferlessInputStream_IfRequestStreamHasNotBeenRead()
         {
             // Arrange
             bool inputStreamCalled = false;
@@ -404,8 +402,7 @@ namespace System.Web.Http.WebHost
             {
                 // Assert
                 HttpRequestContext context = expectedRequest.GetRequestContext();
-                Assert.IsType<WebHostHttpRequestContext>(context);
-                WebHostHttpRequestContext typedContext = (WebHostHttpRequestContext)context;
+                WebHostHttpRequestContext typedContext = Assert.IsType<WebHostHttpRequestContext>(context);
                 Assert.Same(contextBase, typedContext.Context);
                 Assert.Same(requestBase, typedContext.WebRequest);
                 Assert.Same(expectedRequest, typedContext.Request);
@@ -613,8 +610,8 @@ namespace System.Web.Http.WebHost
             }
 
             // Assert
-            Assert.Equal<int>((int)HttpStatusCode.OK, responseBase.StatusCode);
-            Assert.True(responseBase.Headers["Content-Type"].StartsWith(JsonMediaTypeFormatter.DefaultMediaType.MediaType));
+            Assert.Equal((int)HttpStatusCode.OK, responseBase.StatusCode);
+            Assert.StartsWith(JsonMediaTypeFormatter.DefaultMediaType.MediaType, responseBase.Headers["Content-Type"]);
             Assert.Equal("\"hello\"", responseString);
         }
 
@@ -772,8 +769,8 @@ namespace System.Web.Http.WebHost
             }
 
             // Assert
-            Assert.Equal<int>((int)HttpStatusCode.InternalServerError, responseBase.StatusCode);
-            Assert.True(responseBase.Headers["Content-Type"].StartsWith(JsonMediaTypeFormatter.DefaultMediaType.MediaType));
+            Assert.Equal((int)HttpStatusCode.InternalServerError, responseBase.StatusCode);
+            Assert.StartsWith(JsonMediaTypeFormatter.DefaultMediaType.MediaType, responseBase.Headers["Content-Type"]);
             Assert.Equal("An error has occurred.", httpError["Message"]);
             Assert.Equal("The 'ObjectContent`1' type failed to serialize the response body for content type 'application/json; charset=utf-8'.", httpError["ExceptionMessage"]);
             Assert.Equal(typeof(InvalidOperationException).FullName, httpError["ExceptionType"]);
@@ -820,8 +817,8 @@ namespace System.Web.Http.WebHost
             }
 
             // Assert
-            Assert.Equal<int>((int)HttpStatusCode.InternalServerError, responseBase.StatusCode);
-            Assert.True(responseBase.Headers["Content-Type"].StartsWith(JsonMediaTypeFormatter.DefaultMediaType.MediaType));
+            Assert.Equal((int)HttpStatusCode.InternalServerError, responseBase.StatusCode);
+            Assert.StartsWith(JsonMediaTypeFormatter.DefaultMediaType.MediaType, responseBase.Headers["Content-Type"]);
             Assert.Equal("An error has occurred.", httpError["Message"]);
             Assert.Equal("The 'ObjectContent`1' type failed to serialize the response body for content type 'application/json; charset=utf-8'.", httpError["ExceptionMessage"]);
             Assert.Equal(typeof(InvalidOperationException).FullName, httpError["ExceptionType"]);
@@ -861,7 +858,7 @@ namespace System.Web.Http.WebHost
             memoryStream.Seek(0L, SeekOrigin.Begin);
 
             // Assert
-            Assert.Equal<int>((int)errorResponse.StatusCode, responseBase.StatusCode);
+            Assert.Equal((int)errorResponse.StatusCode, responseBase.StatusCode);
             Assert.Equal(0, memoryStream.Length);
             Assert.Equal("myValue", responseBase.Headers["myHeader"]);
             Assert.Null(responseBase.Headers["Content-Type"]);
@@ -903,8 +900,8 @@ namespace System.Web.Http.WebHost
             }
 
             // Assert
-            Assert.Equal<int>((int)errorResponse.StatusCode, responseBase.StatusCode);
-            Assert.True(responseBase.Headers["Content-Type"].StartsWith("application/fake"));
+            Assert.Equal((int)errorResponse.StatusCode, responseBase.StatusCode);
+            Assert.StartsWith("application/fake", responseBase.Headers["Content-Type"]);
             Assert.Equal("user message", responseContent);
             Assert.Equal("myValue", responseBase.Headers["myHeader"]);
         }
@@ -946,7 +943,7 @@ namespace System.Web.Http.WebHost
                 exceptionHandler, CancellationToken.None);
 
             // Assert
-            Assert.Equal<int>((int)HttpStatusCode.InternalServerError, responseBase.StatusCode);
+            Assert.Equal((int)HttpStatusCode.InternalServerError, responseBase.StatusCode);
             Assert.Equal(0, memoryStream.Length);
             Assert.Null(responseBase.Headers["Content-Type"]);
         }
@@ -986,7 +983,7 @@ namespace System.Web.Http.WebHost
                 exceptionHandler, CancellationToken.None);
 
             // Assert
-            Assert.Equal<int>((int)HttpStatusCode.InternalServerError, responseBase.StatusCode);
+            Assert.Equal((int)HttpStatusCode.InternalServerError, responseBase.StatusCode);
             Assert.Equal(0, memoryStream.Length);
             Assert.Null(responseBase.Headers["Content-Type"]);
         }
@@ -1038,7 +1035,7 @@ namespace System.Web.Http.WebHost
                 exceptionHandler, CancellationToken.None);
 
             // Assert
-            Assert.Equal<int>((int)HttpStatusCode.InternalServerError, responseBase.StatusCode);
+            Assert.Equal((int)HttpStatusCode.InternalServerError, responseBase.StatusCode);
             Assert.Equal(0, memoryStream.Length);
             Assert.Null(responseBase.Headers["Content-Type"]);
         }
@@ -1079,7 +1076,7 @@ namespace System.Web.Http.WebHost
                 exceptionHandler, CancellationToken.None);
 
             // Assert
-            Assert.Equal<int>((int)HttpStatusCode.InternalServerError, responseBase.StatusCode);
+            Assert.Equal((int)HttpStatusCode.InternalServerError, responseBase.StatusCode);
             Assert.Equal(0, memoryStream.Length);
             Assert.Null(responseBase.Headers["Content-Type"]);
         }
@@ -1097,7 +1094,7 @@ namespace System.Web.Http.WebHost
             await CopyResponseAsync(contextMock.Object, request: new HttpRequestMessage(), response: null);
 
             // Assert
-            Assert.Equal<int>((int)HttpStatusCode.InternalServerError, responseBase.StatusCode);
+            Assert.Equal((int)HttpStatusCode.InternalServerError, responseBase.StatusCode);
             Assert.Equal(0, memoryStream.Length);
             Assert.Null(responseBase.Headers["Content-Type"]);
         }
@@ -1390,7 +1387,7 @@ namespace System.Web.Http.WebHost
 
                 Assert.Same(expectedException, exception);
                 Assert.NotNull(exception.StackTrace);
-                Assert.True(exception.StackTrace.StartsWith(expectedStackTrace));
+                Assert.StartsWith(expectedStackTrace, exception.StackTrace);
             }
         }
 

--- a/test/System.Web.Http.WebHost.Test/RouteCollectionExtensionsTest.cs
+++ b/test/System.Web.Http.WebHost.Test/RouteCollectionExtensionsTest.cs
@@ -34,7 +34,7 @@ namespace System.Web.Http
             // Assert
             Assert.NotNull(route);
             Assert.Equal("template", route.Url);
-            Assert.Equal(1, route.Defaults.Count);
+            Assert.Single(route.Defaults);
             Assert.Equal("D1", route.Defaults["d1"]);
             Assert.Same(route, routes["name"]);
         }
@@ -52,7 +52,7 @@ namespace System.Web.Http
             // Assert
             Assert.NotNull(route);
             Assert.Equal("template", route.Url);
-            Assert.Equal(1, route.Defaults.Count);
+            Assert.Single(route.Defaults);
             Assert.Equal("D1", route.Defaults["d1"]);
             Assert.Same(route, routes["name"]);
         }
@@ -77,9 +77,9 @@ namespace System.Web.Http
             // Assert
             Assert.NotNull(route);
             Assert.Equal("template", route.Url);
-            Assert.Equal(1, route.Defaults.Count);
+            Assert.Single(route.Defaults);
             Assert.Equal("D1", route.Defaults["d1"]);
-            Assert.Equal(1, route.Defaults.Count);
+            Assert.Single(route.Constraints);
             Assert.Equal("C1", route.Constraints["c1"]);
             Assert.Same(route, routes["name"]);
         }
@@ -98,9 +98,9 @@ namespace System.Web.Http
             // Assert
             Assert.NotNull(route);
             Assert.Equal("template", route.Url);
-            Assert.Equal(1, route.Defaults.Count);
+            Assert.Single(route.Defaults);
             Assert.Equal("D1", route.Defaults["d1"]);
-            Assert.Equal(1, route.Defaults.Count);
+            Assert.Single(route.Constraints);
             Assert.Equal("C1", route.Constraints["c1"]);
             Assert.Same(route, routes["name"]);
         }

--- a/test/System.Web.Http.WebHost.Test/Routing/HostedHttpRouteCollectionTest.cs
+++ b/test/System.Web.Http.WebHost.Test/Routing/HostedHttpRouteCollectionTest.cs
@@ -307,7 +307,7 @@ namespace System.Web.Http.WebHost.Routing
 
             // Assert
             // Altough it contains the ignore route, GetVirtualPath from the ignored route will always return null.
-            Assert.Equal(collection.Count, 1);
+            Assert.Equal(1, collection.Count);
             Assert.Null(httpvPathData);
         }
 
@@ -322,7 +322,7 @@ namespace System.Web.Http.WebHost.Routing
 
             var response = await SubmitRequestAsync(request);
 
-            Assert.Equal(response.StatusCode, Net.HttpStatusCode.NotFound);
+            Assert.Equal(Net.HttpStatusCode.NotFound, response.StatusCode);
             Assert.True(response.RequestMessage.Properties.ContainsKey(HttpPropertyKeys.NoRouteMatched));
         }
 
@@ -411,7 +411,7 @@ namespace System.Web.Http.WebHost.Routing
 
             var response = await SubmitRequestAsync(request);
 
-            Assert.Equal(response.StatusCode, Net.HttpStatusCode.NotFound);
+            Assert.Equal(Net.HttpStatusCode.NotFound, response.StatusCode);
             Assert.True(response.RequestMessage.Properties.ContainsKey(HttpPropertyKeys.NoRouteMatched));
         }
 
@@ -427,7 +427,7 @@ namespace System.Web.Http.WebHost.Routing
 
             var response = await SubmitRequestAsync(request);
 
-            Assert.Equal(response.StatusCode, Net.HttpStatusCode.OK);
+            Assert.Equal(Net.HttpStatusCode.OK, response.StatusCode);
             Assert.Equal(String.Concat("values/", await response.Content.ReadAsStringAsync()), requestPath);
         }
 

--- a/test/System.Web.Http.WebHost.Test/Routing/HttpContextBaseExtensionsTest.cs
+++ b/test/System.Web.Http.WebHost.Test/Routing/HttpContextBaseExtensionsTest.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
-using System.Linq;
 using System.Net.Http;
 using Microsoft.TestCommon;
 using Moq;
@@ -27,7 +26,7 @@ namespace System.Web.Http.WebHost.Routing
             col.Add("customHeader", "customHeaderValue");
             requestMock.Setup(r => r.Headers).Returns(col);
             contextMock.Setup(o => o.Request).Returns(requestMock.Object);
-            
+
             // Act
             contextMock.Object.GetOrCreateHttpRequestMessage();
 
@@ -37,8 +36,8 @@ namespace System.Web.Http.WebHost.Routing
             Assert.Equal(HttpMethod.Get, request.Method);
             IEnumerable<string> headerValues;
             Assert.True(request.Headers.TryGetValues("customHeader", out headerValues));
-            Assert.Equal(1, headerValues.Count());
-            Assert.Equal("customHeaderValue", headerValues.First());
+            string headerValue = Assert.Single(headerValues);
+            Assert.Equal("customHeaderValue", headerValue);
         }
     }
 }

--- a/test/System.Web.Http.WebHost.Test/Routing/HttpRouteExceptionHandlerTests.cs
+++ b/test/System.Web.Http.WebHost.Test/Routing/HttpRouteExceptionHandlerTests.cs
@@ -243,7 +243,7 @@ namespace System.Web.Http.WebHost.Routing
 
                 Assert.Same(expectedException, exception);
                 Assert.NotNull(exception.StackTrace);
-                Assert.True(exception.StackTrace.StartsWith(expectedStackTrace));
+                Assert.StartsWith(expectedStackTrace, exception.StackTrace);
             }
 
         }

--- a/test/System.Web.Http.WebHost.Test/Routing/HttpRouteExceptionRouteHandlerTests.cs
+++ b/test/System.Web.Http.WebHost.Test/Routing/HttpRouteExceptionRouteHandlerTests.cs
@@ -1,12 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.ExceptionServices;
-using System.Text;
-using System.Threading.Tasks;
 using System.Web.Routing;
 using Microsoft.TestCommon;
 
@@ -40,8 +35,7 @@ namespace System.Web.Http.WebHost.Routing
             IHttpHandler handler = product.GetHttpHandler(requestContext);
 
             // Assert
-            Assert.IsType<HttpRouteExceptionHandler>(handler);
-            HttpRouteExceptionHandler typedHandler = (HttpRouteExceptionHandler)handler;
+            HttpRouteExceptionHandler typedHandler = Assert.IsType<HttpRouteExceptionHandler>(handler);
             Assert.Same(expectedExceptionInfo, typedHandler.ExceptionInfo);
         }
 

--- a/test/System.Web.Http.WebHost.Test/Routing/HttpWebRouteTests.cs
+++ b/test/System.Web.Http.WebHost.Test/Routing/HttpWebRouteTests.cs
@@ -36,8 +36,7 @@ namespace System.Web.Http.WebHost.Routing
                 // Assert
                 Assert.NotNull(routeData);
                 Assert.Same(product, routeData.Route);
-                Assert.IsType<HttpRouteExceptionRouteHandler>(routeData.RouteHandler);
-                HttpRouteExceptionRouteHandler typedHandler = (HttpRouteExceptionRouteHandler)routeData.RouteHandler;
+                HttpRouteExceptionRouteHandler typedHandler = Assert.IsType<HttpRouteExceptionRouteHandler>(routeData.RouteHandler);
                 ExceptionDispatchInfo exceptionInfo = typedHandler.ExceptionInfo;
                 Assert.NotNull(exceptionInfo); // Guard
                 Assert.Same(expectedException, exceptionInfo.SourceException);

--- a/test/System.Web.Http.WebHost.Test/SuppressFormsAuthRedirectHelperTest.cs
+++ b/test/System.Web.Http.WebHost.Test/SuppressFormsAuthRedirectHelperTest.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections;
 using System.Collections.Specialized;
 using System.Web.WebPages.TestUtils;
 using Microsoft.TestCommon;
-using Moq;
 
 namespace System.Web.Http.WebHost
 {
@@ -29,7 +27,7 @@ namespace System.Web.Http.WebHost
 #pragma warning restore
             PreAppStartTestHelper.TestPreAppStartClass(preApplicationStartType);
             object[] attrs = preApplicationStartType.GetCustomAttributes(typeof(ObsoleteAttribute), true);
-            Assert.Equal(1, attrs.Length);
+            Assert.Single(attrs);
         }
     }
 }

--- a/test/System.Web.Http.WebHost.Test/System.Web.Http.WebHost.Test.csproj
+++ b/test/System.Web.Http.WebHost.Test/System.Web.Http.WebHost.Test.csproj
@@ -104,6 +104,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/System.Web.Http.WebHost.Test/WebHostBufferPolicySelectorTest.cs
+++ b/test/System.Web.Http.WebHost.Test/WebHostBufferPolicySelectorTest.cs
@@ -41,6 +41,20 @@ namespace System.Web.Http.WebHost
             }
         }
 
+        public static TheoryDataSet<HttpContent> OutputBufferingTestData_NoExpectedResult
+        {
+            get
+            {
+                var dataSet = new TheoryDataSet<HttpContent>();
+                foreach (var item in OutputBufferingTestData)
+                {
+                    dataSet.Add((HttpContent)item[0]);
+                }
+
+                return dataSet;
+            }
+        }
+
         [Fact]
         void UseBufferedInputStream_Returns_True()
         {
@@ -94,8 +108,8 @@ namespace System.Web.Http.WebHost
         }
 
         [Theory]
-        [PropertyData("OutputBufferingTestData")]
-        public void UseBufferedOutputStream_CausesContentLengthHeaderToBeSet(HttpContent content, bool expectedResult)
+        [PropertyData("OutputBufferingTestData_NoExpectedResult")]
+        public void UseBufferedOutputStream_CausesContentLengthHeaderToBeSet(HttpContent content)
         {
             // Arrange & Act
             WebHostBufferPolicySelector selector = new WebHostBufferPolicySelector();

--- a/test/System.Web.Http.WebHost.Test/WebHostExceptionHandlerTests.cs
+++ b/test/System.Web.Http.WebHost.Test/WebHostExceptionHandlerTests.cs
@@ -97,8 +97,7 @@ namespace System.Web.Http.WebHost
 
                 // Assert
                 IHttpActionResult result = context.Result;
-                Assert.IsType(typeof(ResponseMessageResult), result);
-                ResponseMessageResult typedResult = (ResponseMessageResult)result;
+                ResponseMessageResult typedResult = Assert.IsType<ResponseMessageResult>(result);
 
                 using (HttpResponseMessage response = typedResult.Response)
                 using (HttpResponseMessage expectedResponse = expectedRequest.CreateErrorResponse(
@@ -134,8 +133,7 @@ namespace System.Web.Http.WebHost
 
                 // Assert
                 IHttpActionResult result = context.Result;
-                Assert.IsType(typeof(ResponseMessageResult), result);
-                ResponseMessageResult typedResult = (ResponseMessageResult)result;
+                ResponseMessageResult typedResult = Assert.IsType<ResponseMessageResult>(result);
 
                 using (HttpResponseMessage response = typedResult.Response)
                 using (HttpResponseMessage expectedResponse = expectedRequest.CreateErrorResponse(
@@ -177,8 +175,7 @@ namespace System.Web.Http.WebHost
 
                 // Assert
                 IHttpActionResult result = context.Result;
-                Assert.IsType(typeof(ResponseMessageResult), result);
-                ResponseMessageResult typedResult = (ResponseMessageResult)result;
+                ResponseMessageResult typedResult = Assert.IsType<ResponseMessageResult>(result);
                 using (HttpResponseMessage response = typedResult.Response)
                 {
                     Assert.NotNull(response);
@@ -218,8 +215,7 @@ namespace System.Web.Http.WebHost
 
                 // Assert
                 IHttpActionResult result = context.Result;
-                Assert.IsType(typeof(ResponseMessageResult), result);
-                ResponseMessageResult typedResult = (ResponseMessageResult)result;
+                ResponseMessageResult typedResult = Assert.IsType<ResponseMessageResult>(result);
                 using (HttpResponseMessage response = typedResult.Response)
                 {
                     Assert.NotNull(response);
@@ -296,14 +292,12 @@ namespace System.Web.Http.WebHost
         private static void AssertErrorResponse(HttpResponseMessage expected, HttpResponseMessage actual)
         {
             Assert.NotNull(expected); // Guard
-            Assert.IsType(typeof(ObjectContent<HttpError>), expected.Content); // Guard
-            ObjectContent<HttpError> expectedContent = (ObjectContent<HttpError>)expected.Content;
+            ObjectContent<HttpError> expectedContent = Assert.IsType<ObjectContent<HttpError>>(expected.Content); // Guard
             Assert.NotNull(expectedContent.Formatter); // Guard
 
             Assert.NotNull(actual);
             Assert.Equal(expected.StatusCode, actual.StatusCode);
-            Assert.IsType(typeof(ObjectContent<HttpError>), actual.Content);
-            ObjectContent<HttpError> actualContent = (ObjectContent<HttpError>)actual.Content;
+            ObjectContent<HttpError> actualContent = Assert.IsType<ObjectContent<HttpError>>(actual.Content);
             Assert.NotNull(actualContent.Formatter);
             Assert.Same(expectedContent.Formatter.GetType(), actualContent.Formatter.GetType());
             Assert.Equal(Flatten(expectedContent.Value), Flatten(actualContent.Value));

--- a/test/System.Web.Http.WebHost.Test/WebHostHttpRequestContextTests.cs
+++ b/test/System.Web.Http.WebHost.Test/WebHostHttpRequestContextTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.IO;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Principal;
@@ -352,7 +351,7 @@ namespace System.Web.Http.WebHost
                 bool includeErrorDetail = context.IncludeErrorDetail;
 
                 // Assert
-                Assert.Equal(true, includeErrorDetail);
+                Assert.True(includeErrorDetail);
             }
         }
 
@@ -374,7 +373,7 @@ namespace System.Web.Http.WebHost
                 bool includeErrorDetail = context.IncludeErrorDetail;
 
                 // Assert
-                Assert.Equal(false, includeErrorDetail);
+                Assert.False(includeErrorDetail);
             }
         }
 
@@ -468,7 +467,7 @@ namespace System.Web.Http.WebHost
                 bool isLocal = context.IsLocal;
 
                 // Assert
-                Assert.Equal(false, isLocal);
+                Assert.False(isLocal);
             }
         }
 

--- a/test/System.Web.Http.WebHost.Test/packages.config
+++ b/test/System.Web.Http.WebHost.Test/packages.config
@@ -3,7 +3,9 @@
   <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />

--- a/test/System.Web.Mvc.Test/Ajax/Test/AjaxExtensionsTest.cs
+++ b/test/System.Web.Mvc.Test/Ajax/Test/AjaxExtensionsTest.cs
@@ -79,7 +79,7 @@ namespace System.Web.Mvc.Ajax.Test
             form.Dispose();
 
             // Assert
-            Assert.True(writer.ToString().EndsWith("</form>"));
+            Assert.EndsWith("</form>", writer.ToString());
         }
 
         // GlobalizationScript

--- a/test/System.Web.Mvc.Test/Ajax/Test/AjaxOptionsTest.cs
+++ b/test/System.Web.Mvc.Test/Ajax/Test/AjaxOptionsTest.cs
@@ -36,9 +36,9 @@ namespace System.Web.Mvc.Ajax.Test
         public void InsertionModeStringTests()
         {
             // Act & Assert
-            Assert.Equal(new AjaxOptions { InsertionMode = InsertionMode.Replace }.InsertionModeString, "Sys.Mvc.InsertionMode.replace");
-            Assert.Equal(new AjaxOptions { InsertionMode = InsertionMode.InsertAfter }.InsertionModeString, "Sys.Mvc.InsertionMode.insertAfter");
-            Assert.Equal(new AjaxOptions { InsertionMode = InsertionMode.InsertBefore }.InsertionModeString, "Sys.Mvc.InsertionMode.insertBefore");
+            Assert.Equal("Sys.Mvc.InsertionMode.replace", new AjaxOptions { InsertionMode = InsertionMode.Replace }.InsertionModeString);
+            Assert.Equal("Sys.Mvc.InsertionMode.insertAfter", new AjaxOptions { InsertionMode = InsertionMode.InsertAfter }.InsertionModeString);
+            Assert.Equal("Sys.Mvc.InsertionMode.insertBefore", new AjaxOptions { InsertionMode = InsertionMode.InsertBefore }.InsertionModeString);
         }
 
         [Theory]
@@ -53,7 +53,7 @@ namespace System.Web.Mvc.Ajax.Test
 
             // Act
             string result = options.InsertionModeUnobtrusive;
-            
+
             // Assert
             Assert.Equal(expected, result);
         }

--- a/test/System.Web.Mvc.Test/Async/Test/AsyncActionMethodSelectorTest.cs
+++ b/test/System.Web.Mvc.Test/Async/Test/AsyncActionMethodSelectorTest.cs
@@ -5,9 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using System.Web.Mvc.Routing;
-using System.Web.Routing;
-using System.Web.Routing.Test;
 using Microsoft.TestCommon;
 using Moq;
 
@@ -239,23 +236,23 @@ namespace System.Web.Mvc.Async.Test
             // Assert
             Assert.Equal(6, selector.NonAliasedMethods.Count);
 
-            List<MethodInfo> sortedMethods = selector.NonAliasedMethods["foo"].OrderBy(methodInfo => methodInfo.GetParameters().Length).ToList();
+            List<MethodInfo> sortedMethods = selector.NonAliasedMethods["foo"].OrderBy(method => method.GetParameters().Length).ToList();
             Assert.Equal("Foo", sortedMethods[0].Name);
             Assert.Empty(sortedMethods[0].GetParameters());
             Assert.Equal("Foo", sortedMethods[1].Name);
             Assert.Equal(typeof(string), sortedMethods[1].GetParameters()[0].ParameterType);
 
-            Assert.Equal(1, selector.NonAliasedMethods["EventPattern"].Count());
-            Assert.Equal("EventPatternAsync", selector.NonAliasedMethods["EventPattern"].First().Name);
-            Assert.Equal(1, selector.NonAliasedMethods["EventPatternAmbiguous"].Count());
-            Assert.Equal("EventPatternAmbiguousAsync", selector.NonAliasedMethods["EventPatternAmbiguous"].First().Name);
-            Assert.Equal(1, selector.NonAliasedMethods["EventPatternWithoutCompletionMethod"].Count());
-            Assert.Equal("EventPatternWithoutCompletionMethodAsync", selector.NonAliasedMethods["EventPatternWithoutCompletionMethod"].First().Name);
+            MethodInfo methodInfo = Assert.Single(selector.NonAliasedMethods["EventPattern"]);
+            Assert.Equal("EventPatternAsync", methodInfo.Name);
+            methodInfo = Assert.Single(selector.NonAliasedMethods["EventPatternAmbiguous"]);
+            Assert.Equal("EventPatternAmbiguousAsync", methodInfo.Name);
+            methodInfo = Assert.Single(selector.NonAliasedMethods["EventPatternWithoutCompletionMethod"]);
+            Assert.Equal("EventPatternWithoutCompletionMethodAsync", methodInfo.Name);
 
-            Assert.Equal(1, selector.NonAliasedMethods["TaskPattern"].Count());
-            Assert.Equal("TaskPattern", selector.NonAliasedMethods["TaskPattern"].First().Name);
-            Assert.Equal(1, selector.NonAliasedMethods["GenericTaskPattern"].Count());
-            Assert.Equal("GenericTaskPattern", selector.NonAliasedMethods["GenericTaskPattern"].First().Name);
+            methodInfo = Assert.Single(selector.NonAliasedMethods["TaskPattern"]);
+            Assert.Equal("TaskPattern", methodInfo.Name);
+            methodInfo = Assert.Single(selector.NonAliasedMethods["GenericTaskPattern"]);
+            Assert.Equal("GenericTaskPattern", methodInfo.Name);
         }
 
         private class MethodLocatorController : Controller

--- a/test/System.Web.Mvc.Test/Async/Test/ReflectedAsyncActionDescriptorTest.cs
+++ b/test/System.Web.Mvc.Test/Async/Test/ReflectedAsyncActionDescriptorTest.cs
@@ -192,8 +192,8 @@ namespace System.Web.Mvc.Async.Test
             object[] attributes = ad.GetCustomAttributes(true /* inherit */);
 
             // Assert
-            Assert.Single(attributes);
-            Assert.Equal(typeof(AuthorizeAttribute), attributes[0].GetType());
+            object attribute = Assert.Single(attributes);
+            Assert.IsType<AuthorizeAttribute>(attribute);
         }
 
         [Fact]
@@ -225,9 +225,9 @@ namespace System.Web.Mvc.Async.Test
             // Assert
             Assert.NotSame(pDescsFirstCall, pDescsSecondCall);
             Assert.Equal(pDescsFirstCall, pDescsSecondCall);
-            Assert.Single(pDescsFirstCall);
 
-            ReflectedParameterDescriptor pDesc = pDescsFirstCall[0] as ReflectedParameterDescriptor;
+            ParameterDescriptor parameterDescriptor = Assert.Single(pDescsFirstCall);
+            ReflectedParameterDescriptor pDesc = Assert.IsType<ReflectedParameterDescriptor>(parameterDescriptor);
 
             Assert.NotNull(pDesc);
             Assert.Same(ad, pDesc.ActionDescriptor);

--- a/test/System.Web.Mvc.Test/Async/Test/TaskAsyncActionDescriptorTest.cs
+++ b/test/System.Web.Mvc.Test/Async/Test/TaskAsyncActionDescriptorTest.cs
@@ -145,7 +145,7 @@ namespace System.Web.Mvc.Async.Test
                 "Test exception from action"
                 );
 
-            Assert.True(ex.StackTrace.Contains("System.Web.Mvc.Async.Test.TaskAsyncActionDescriptorTest.ExecuteController."));
+            Assert.Contains("System.Web.Mvc.Async.Test.TaskAsyncActionDescriptorTest.ExecuteController.", ex.StackTrace);
         }
 
         [Fact]
@@ -169,7 +169,7 @@ namespace System.Web.Mvc.Async.Test
                 "Test exception from action"
                 );
 
-            Assert.True(ex.StackTrace.Contains("System.Web.Mvc.Async.Test.TaskAsyncActionDescriptorTest.ExecuteController."));
+            Assert.Contains("System.Web.Mvc.Async.Test.TaskAsyncActionDescriptorTest.ExecuteController.", ex.StackTrace);
         }
 
         [Fact]
@@ -389,9 +389,9 @@ namespace System.Web.Mvc.Async.Test
             // Assert
             Assert.NotSame(pDescsFirstCall, pDescsSecondCall); // Should get a new array every time
             Assert.Equal(pDescsFirstCall, pDescsSecondCall);
-            Assert.Single(pDescsFirstCall);
 
-            ReflectedParameterDescriptor pDesc = pDescsFirstCall[0] as ReflectedParameterDescriptor;
+            ParameterDescriptor parameterDescriptor = Assert.Single(pDescsFirstCall);
+            ReflectedParameterDescriptor pDesc = Assert.IsType<ReflectedParameterDescriptor>(parameterDescriptor);
 
             Assert.NotNull(pDesc);
             Assert.Same(ad, pDesc.ActionDescriptor);

--- a/test/System.Web.Mvc.Test/Html/Test/DisplayExtensionsTest.cs
+++ b/test/System.Web.Mvc.Test/Html/Test/DisplayExtensionsTest.cs
@@ -150,11 +150,8 @@ namespace System.Web.Mvc.Html.Test
 
         // Inconsistent but long-standing behavior.
         [Theory]
-        [PropertyData("HtmlEncodedData", PropertyType = typeof(EncodedDataSets))]
-        public void ObjectTemplate_DoesNotEncodeNullDisplayText(
-            string text,
-            bool htmlEncode,
-            string unusedText)
+        [PropertyData("HtmlEncodedData_JustText", PropertyType = typeof(EncodedDataSets))]
+        public void ObjectTemplate_DoesNotEncodeNullDisplayText(string text)
         {
             // Arrange
             var viewData = new ViewDataDictionary<ObjectTemplateModel>(model: null);

--- a/test/System.Web.Mvc.Test/Html/Test/EditorExtensionsTest.cs
+++ b/test/System.Web.Mvc.Test/Html/Test/EditorExtensionsTest.cs
@@ -21,11 +21,8 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("AttributeEncodedData", PropertyType = typeof(EncodedDataSets))]
-        public void BooleanTemplate_AttributeEncodes_AddedHtmlAttributes(
-            string text,
-            bool htmlEncode,
-            string htmlEncodedText)
+        [PropertyData("AttributeEncodedData_NoHtmlEncode", PropertyType = typeof(EncodedDataSets))]
+        public void BooleanTemplate_AttributeEncodes_AddedHtmlAttributes(string text, string htmlEncodedText)
         {
             // Arrange
             var expectedResult = "<input attribute=\"" +
@@ -110,11 +107,10 @@ namespace System.Web.Mvc.Html.Test
 
         // Inconsistent but long-standing behavior.
         [Theory]
-        [PropertyData("ConditionallyHtmlEncodedData", PropertyType = typeof(EncodedDataSets))]
+        [PropertyData("ConditionallyHtmlEncodedData_NoEncodedText", PropertyType = typeof(EncodedDataSets))]
         public void CollectionTemplateWrappingObjectTemplate_DoesNotEncodeNullDisplayText_IfNull(
             string text,
-            bool htmlEncode,
-            string unusedText)
+            bool htmlEncode)
         {
             // Arrange
             var model = new[] { (ObjectTemplateModel)null, };
@@ -154,11 +150,8 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("AttributeEncodedData", PropertyType = typeof(EncodedDataSets))]
-        public void StringTemplate_AttributeEncodes_AddedHtmlAttributes(
-            string text,
-            bool htmlEncode,
-            string htmlEncodedText)
+        [PropertyData("AttributeEncodedData_NoHtmlEncode", PropertyType = typeof(EncodedDataSets))]
+        public void StringTemplate_AttributeEncodes_AddedHtmlAttributes(string text, string htmlEncodedText)
         {
             // Arrange
             var expectedResult = "<input attribute=\"" +
@@ -193,11 +186,8 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("AttributeEncodedData", PropertyType = typeof(EncodedDataSets))]
-        public void StringTemplate_AttributeEncodesText(
-            string text,
-            bool htmlEncode,
-            string htmlEncodedText)
+        [PropertyData("AttributeEncodedData_NoHtmlEncode", PropertyType = typeof(EncodedDataSets))]
+        public void StringTemplate_AttributeEncodesText(string text, string htmlEncodedText)
         {
             // Arrange
             var expectedResult =

--- a/test/System.Web.Mvc.Test/Html/Test/EncodedDataSets.cs
+++ b/test/System.Web.Mvc.Test/Html/Test/EncodedDataSets.cs
@@ -86,6 +86,35 @@ namespace System.Web.Mvc.Html.Test
             }
         }
 
+        public static TheoryDataSet<string, bool> AttributeEncodedData_NoEncodedText
+        {
+            get
+            {
+                var dataSet = new TheoryDataSet<string, bool>();
+                foreach (var stringSet in StringSets)
+                {
+                    dataSet.Add(stringSet.Text, false);
+                    dataSet.Add(stringSet.Text, true);
+                }
+
+                return dataSet;
+            }
+        }
+
+        public static TheoryDataSet<string, string> AttributeEncodedData_NoHtmlEncode
+        {
+            get
+            {
+                var dataSet = new TheoryDataSet<string, string>();
+                foreach (var stringSet in StringSets)
+                {
+                    dataSet.Add(stringSet.Text, stringSet.AttributeEncodedText);
+                }
+
+                return dataSet;
+            }
+        }
+
         public static TheoryDataSet<string, bool, string> ConditionallyHtmlEncodedData
         {
             get
@@ -98,6 +127,21 @@ namespace System.Web.Mvc.Html.Test
                 }
 
                 return result;
+            }
+        }
+
+        public static TheoryDataSet<string, bool> ConditionallyHtmlEncodedData_NoEncodedText
+        {
+            get
+            {
+                var dataSet = new TheoryDataSet<string, bool>();
+                foreach (var stringSet in StringSets)
+                {
+                    dataSet.Add(stringSet.Text, false);
+                    dataSet.Add(stringSet.Text, true);
+                }
+
+                return dataSet;
             }
         }
 
@@ -114,6 +158,34 @@ namespace System.Web.Mvc.Html.Test
                 }
 
                 return result;
+            }
+        }
+
+        public static TheoryDataSet<string, string> HtmlEncodedData_NoHtmlEncode
+        {
+            get
+            {
+                var dataSet = new TheoryDataSet<string, string>();
+                foreach (var stringSet in StringSets)
+                {
+                    dataSet.Add(stringSet.Text, stringSet.HtmlEncodedText);
+                }
+
+                return dataSet;
+            }
+        }
+
+        public static TheoryDataSet<string> HtmlEncodedData_JustText
+        {
+            get
+            {
+                var dataSet = new TheoryDataSet<string>();
+                foreach (var stringSet in StringSets)
+                {
+                    dataSet.Add(stringSet.Text);
+                }
+
+                return dataSet;
             }
         }
 
@@ -134,6 +206,21 @@ namespace System.Web.Mvc.Html.Test
             }
         }
 
+        public static TheoryDataSet<string, string> IdEncodedData_NoHtmlEncode
+        {
+            get
+            {
+                var result = new TheoryDataSet<string, string>();
+                foreach (var encodedString in StringSets)
+                {
+                    // Add leading 'a' to avoid sanitizing to an empty string.
+                    result.Add("a" + encodedString.Text, "a" + encodedString.IdEncodedText);
+                }
+
+                return result;
+            }
+        }
+
         public static TheoryDataSet<string, bool, string> UrlEncodedData
         {
             get
@@ -144,6 +231,20 @@ namespace System.Web.Mvc.Html.Test
                     // Same results whether ModelMetadata.HtmlEncode is true or false.
                     result.Add(encodedString.Text, false, encodedString.UrlEncodedText);
                     result.Add(encodedString.Text, true, encodedString.UrlEncodedText);
+                }
+
+                return result;
+            }
+        }
+
+        public static TheoryDataSet<string, string> UrlEncodedData_NoHtmlEncode
+        {
+            get
+            {
+                var result = new TheoryDataSet<string, string>();
+                foreach (var encodedString in StringSets)
+                {
+                    result.Add(encodedString.Text, encodedString.UrlEncodedText);
                 }
 
                 return result;

--- a/test/System.Web.Mvc.Test/Html/Test/FormExtensionsTest.cs
+++ b/test/System.Web.Mvc.Test/Html/Test/FormExtensionsTest.cs
@@ -122,10 +122,9 @@ window.mvcClientValidationMetadata.push({""Fields"":[],""FormId"":""form_id"",""
         }
 
         [Theory]
-        [PropertyData("UrlEncodedData", PropertyType = typeof(EncodedDataSets))]
+        [PropertyData("UrlEncodedData_NoHtmlEncode", PropertyType = typeof(EncodedDataSets))]
         public void BeginFormWithActionController_UrlEncodesAction(
             string text,
-            bool htmlEncode,
             string expectedText)
         {
             BeginFormHelper(
@@ -134,10 +133,9 @@ window.mvcClientValidationMetadata.push({""Fields"":[],""FormId"":""form_id"",""
         }
 
         [Theory]
-        [PropertyData("UrlEncodedData", PropertyType = typeof(EncodedDataSets))]
+        [PropertyData("UrlEncodedData_NoHtmlEncode", PropertyType = typeof(EncodedDataSets))]
         public void BeginFormWithActionController_UrlEncodesController(
             string text,
-            bool htmlEncode,
             string expectedText)
         {
             BeginFormHelper(
@@ -162,10 +160,9 @@ window.mvcClientValidationMetadata.push({""Fields"":[],""FormId"":""form_id"",""
         }
 
         [Theory]
-        [PropertyData("AttributeEncodedData", PropertyType = typeof(EncodedDataSets))]
+        [PropertyData("AttributeEncodedData_NoHtmlEncode", PropertyType = typeof(EncodedDataSets))]
         public void BeginFormWithActionControllerFormMethodHtmlValues_AttributeEncodes_AddedHtmlAttributes(
             string text,
-            bool htmlEncode,
             string expectedText)
         {
             BeginFormHelper(
@@ -312,10 +309,9 @@ window.mvcClientValidationMetadata.push({""Fields"":[],""FormId"":""form_id"",""
         }
 
         [Theory]
-        [PropertyData("AttributeEncodedData", PropertyType = typeof(EncodedDataSets))]
+        [PropertyData("AttributeEncodedData_NoHtmlEncode", PropertyType = typeof(EncodedDataSets))]
         public void BeginRouteFormWithRouteNameFormMethodHtmlValues_AttributeEncodes_AddedHtmlAttributes(
             string text,
-            bool htmlEncode,
             string expectedText)
         {
             BeginFormHelper(

--- a/test/System.Web.Mvc.Test/Html/Test/LabelExtensionsTest.cs
+++ b/test/System.Web.Mvc.Test/Html/Test/LabelExtensionsTest.cs
@@ -123,11 +123,8 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("HtmlEncodedData", PropertyType = typeof(EncodedDataSets))]
-        public void Label_HtmlEncodes_LabelText(
-            string text,
-            bool htmlEncode,
-            string expectedText)
+        [PropertyData("HtmlEncodedData_NoHtmlEncode", PropertyType = typeof(EncodedDataSets))]
+        public void Label_HtmlEncodes_LabelText(string text, string expectedText)
         {
             // Arrange & Act
             var result =
@@ -199,11 +196,8 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("AttributeEncodedData", PropertyType = typeof(EncodedDataSets))]
-        public void LabelWithAnonymousValues_AttributeEncodes_AddedHtmlAttributes(
-            string text,
-            bool htmlEncode,
-            string expectedText)
+        [PropertyData("AttributeEncodedData_NoHtmlEncode", PropertyType = typeof(EncodedDataSets))]
+        public void LabelWithAnonymousValues_AttributeEncodes_AddedHtmlAttributes(string text, string expectedText)
         {
             // Arrange & Act
             var result = html.Label("PropertyName", "text", new { attribute = text }, metadataProvider.Object);
@@ -310,11 +304,8 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("HtmlEncodedData", PropertyType = typeof(EncodedDataSets))]
-        public void LabelFor_HtmlEncodes_LabelText(
-            string text,
-            bool htmlEncode,
-            string expectedText)
+        [PropertyData("HtmlEncodedData_NoHtmlEncode", PropertyType = typeof(EncodedDataSets))]
+        public void LabelFor_HtmlEncodes_LabelText(string text, string expectedText)
         {
             // Arrange
             var dummy = "this is a dummy parameter value";
@@ -369,11 +360,8 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("AttributeEncodedData", PropertyType = typeof(EncodedDataSets))]
-        public void LabeForlWithAnonymousValues_AttributeEncodes_AddedHtmlAttributes(
-            string text,
-            bool htmlEncode,
-            string expectedText)
+        [PropertyData("AttributeEncodedData_NoHtmlEncode", PropertyType = typeof(EncodedDataSets))]
+        public void LabeForlWithAnonymousValues_AttributeEncodes_AddedHtmlAttributes(string text, string expectedText)
         {
             // Arrange
             var dummy = "this is a dummy parameter value";

--- a/test/System.Web.Mvc.Test/Html/Test/LinkExtensionsTest.cs
+++ b/test/System.Web.Mvc.Test/Html/Test/LinkExtensionsTest.cs
@@ -25,11 +25,8 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("UrlEncodedData", PropertyType = typeof(EncodedDataSets))]
-        public void ActionLink_UrlEncodesAction(
-            string text,
-            bool htmlEncode,
-            string expectedText)
+        [PropertyData("UrlEncodedData_NoHtmlEncode", PropertyType = typeof(EncodedDataSets))]
+        public void ActionLink_UrlEncodesAction(string text, string expectedText)
         {
             // Arrange
             var helper = MvcHelper.GetHtmlHelper();
@@ -122,11 +119,8 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("UrlEncodedData", PropertyType = typeof(EncodedDataSets))]
-        public void ActionLinkWithControllerName_UrlEncodesController(
-            string text,
-            bool htmlEncode,
-            string expectedText)
+        [PropertyData("UrlEncodedData_NoHtmlEncode", PropertyType = typeof(EncodedDataSets))]
+        public void ActionLinkWithControllerName_UrlEncodesController(string text, string expectedText)
         {
             // Arrange
             var helper = MvcHelper.GetHtmlHelper();
@@ -167,10 +161,9 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("AttributeEncodedData", PropertyType = typeof(EncodedDataSets))]
+        [PropertyData("AttributeEncodedData_NoHtmlEncode", PropertyType = typeof(EncodedDataSets))]
         public void ActionLinkWithControllerNameAndObjectProperties_AttributeEncodes_AddedHtmlAttributes(
             string text,
-            bool htmlEncode,
             string expectedText)
         {
             // Arrange
@@ -559,10 +552,9 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("AttributeEncodedData", PropertyType = typeof(EncodedDataSets))]
+        [PropertyData("AttributeEncodedData_NoHtmlEncode", PropertyType = typeof(EncodedDataSets))]
         public void RouteLinkWithObjectProperties_AttributeEncodes_AddedHtmlAttributes(
             string text,
-            bool htmlEncode,
             string expectedText)
         {
             // Arrange
@@ -667,7 +659,7 @@ namespace System.Web.Mvc.Html.Test
             // Assert
             Assert.Equal(@"<a foo-baz=""baz"" href=""" + AppPathModifier + @"/app/named/home2/newaction/someid"">linktext</a>", html.ToHtmlString());
         }
-        
+
         // Class for the ActionLinkProducesLowercaseUrlsAfterRegisteringAnArea test
         private class MyAreaRegistration : AreaRegistration
         {

--- a/test/System.Web.Mvc.Test/Html/Test/NameExtensionsTest.cs
+++ b/test/System.Web.Mvc.Test/Html/Test/NameExtensionsTest.cs
@@ -72,7 +72,7 @@ namespace System.Web.Mvc.Html.Test
             Assert.Equal("prefix.IntValue", html.NameFor(m => m.IntValue).ToHtmlString());
             Assert.Equal("prefix.Inner.StringValue", html.NameFor(m => m.Inner.StringValue).ToHtmlString());
         }
-        
+
         // Regression test for codeplex #554 - editor templates for collections would add an extra dot to the
         // generated name.
         [Fact]
@@ -91,11 +91,8 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("IdEncodedData", PropertyType = typeof(EncodedDataSets))]
-        public void Id_IdEncodes_PropertyName(
-            string text,
-            bool htmlEncode,
-            string expectedText)
+        [PropertyData("IdEncodedData_NoHtmlEncode", PropertyType = typeof(EncodedDataSets))]
+        public void Id_IdEncodes_PropertyName(string text, string expectedText)
         {
             // Arrange
             var viewData = new ViewDataDictionary<string>(model: null);
@@ -109,11 +106,8 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("IdEncodedData", PropertyType = typeof(EncodedDataSets))]
-        public void IdHelpers_IdEncode_Prefix(
-            string text,
-            bool htmlEncode,
-            string expectedText)
+        [PropertyData("IdEncodedData_NoHtmlEncode", PropertyType = typeof(EncodedDataSets))]
+        public void IdHelpers_IdEncode_Prefix(string text, string expectedText)
         {
             // Arrange
             var viewData = new ViewDataDictionary<string>(model: null);
@@ -133,11 +127,8 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("AttributeEncodedData", PropertyType = typeof(EncodedDataSets))]
-        public void Name_AttributeEncodes_PropertyName(
-            string text,
-            bool htmlEncode,
-            string expectedText)
+        [PropertyData("AttributeEncodedData_NoHtmlEncode", PropertyType = typeof(EncodedDataSets))]
+        public void Name_AttributeEncodes_PropertyName(string text, string expectedText)
         {
             // Arrange
             var viewData = new ViewDataDictionary<string>(model: null);
@@ -151,11 +142,8 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("AttributeEncodedData", PropertyType = typeof(EncodedDataSets))]
-        public void NameHelpers_AttributeEncode_Prefix(
-            string text,
-            bool htmlEncode,
-            string expectedText)
+        [PropertyData("AttributeEncodedData_NoHtmlEncode", PropertyType = typeof(EncodedDataSets))]
+        public void NameHelpers_AttributeEncode_Prefix(string text, string expectedText)
         {
             // Arrange
             var viewData = new ViewDataDictionary<string>(model: null);

--- a/test/System.Web.Mvc.Test/Html/Test/SelectExtensionsTest.cs
+++ b/test/System.Web.Mvc.Test/Html/Test/SelectExtensionsTest.cs
@@ -781,11 +781,8 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("AttributeEncodedData", PropertyType = typeof(EncodedDataSets))]
-        public void DropDownList_AttributeEncodes_AddedHtmlAttributes(
-            string text,
-            bool htmlEncode,
-            string encodedText)
+        [PropertyData("AttributeEncodedData_NoHtmlEncode", PropertyType = typeof(EncodedDataSets))]
+        public void DropDownList_AttributeEncodes_AddedHtmlAttributes(string text, string encodedText)
         {
             // Arrange
             var selectList = new List<SelectListItem>
@@ -810,8 +807,8 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("AttributeEncodedData", PropertyType = typeof(EncodedDataSets))]
-        public void DropDownList_AttributeEncodes_Name(string text, bool htmlEncode, string encodedText)
+        [PropertyData("AttributeEncodedData_NoHtmlEncode", PropertyType = typeof(EncodedDataSets))]
+        public void DropDownList_AttributeEncodes_Name(string text, string encodedText)
         {
             // Arrange
             var selectList = new List<SelectListItem>
@@ -837,8 +834,8 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("AttributeEncodedData", PropertyType = typeof(EncodedDataSets))]
-        public void DropDownList_AttributeEncodes_OptGroupLabel(string text, bool htmlEncode, string encodedText)
+        [PropertyData("AttributeEncodedData_NoHtmlEncode", PropertyType = typeof(EncodedDataSets))]
+        public void DropDownList_AttributeEncodes_OptGroupLabel(string text, string encodedText)
         {
             // Arrange
             var selectList = new List<SelectListItem>
@@ -865,8 +862,8 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("HtmlEncodedData", PropertyType = typeof(EncodedDataSets))]
-        public void DropDownList_HtmlEncodes_OptionLabel(string text, bool htmlEncode, string encodedText)
+        [PropertyData("HtmlEncodedData_NoHtmlEncode", PropertyType = typeof(EncodedDataSets))]
+        public void DropDownList_HtmlEncodes_OptionLabel(string text, string encodedText)
         {
             // Arrange
             var selectList = new List<SelectListItem>
@@ -891,8 +888,8 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("AttributeEncodedData", PropertyType = typeof(EncodedDataSets))]
-        public void DropDownList_AttributeEncodes_Prefix(string text, bool htmlEncode, string encodedText)
+        [PropertyData("AttributeEncodedData_NoHtmlEncode", PropertyType = typeof(EncodedDataSets))]
+        public void DropDownList_AttributeEncodes_Prefix(string text, string encodedText)
         {
             // Arrange
             var selectList = new List<SelectListItem>
@@ -920,8 +917,8 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("HtmlEncodedData", PropertyType = typeof(EncodedDataSets))]
-        public void DropDownList_HtmlEncodes_Text(string text, bool htmlEncode, string encodedText)
+        [PropertyData("HtmlEncodedData_NoHtmlEncode", PropertyType = typeof(EncodedDataSets))]
+        public void DropDownList_HtmlEncodes_Text(string text, string encodedText)
         {
             // Arrange
             var selectList = new List<SelectListItem>
@@ -944,8 +941,8 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("AttributeEncodedData", PropertyType = typeof(EncodedDataSets))]
-        public void DropDownList_AttributeEncodes_Value(string text, bool htmlEncode, string encodedText)
+        [PropertyData("AttributeEncodedData_NoHtmlEncode", PropertyType = typeof(EncodedDataSets))]
+        public void DropDownList_AttributeEncodes_Value(string text, string encodedText)
         {
             // Arrange
             var selectList = new List<SelectListItem>

--- a/test/System.Web.Mvc.Test/Html/Test/TemplateHelpersTest.cs
+++ b/test/System.Web.Mvc.Test/Html/Test/TemplateHelpersTest.cs
@@ -971,7 +971,7 @@ namespace System.Web.Mvc.Html.Test
 
             // Assert
             Assert.NotNull(viewData);
-            Assert.True(viewData.TemplateInfo.VisitedObjects.Contains("Hello"));
+            Assert.Contains("Hello", viewData.TemplateInfo.VisitedObjects);
         }
 
         [Fact]
@@ -992,7 +992,7 @@ namespace System.Web.Mvc.Html.Test
 
             // Assert
             Assert.NotNull(viewData);
-            Assert.True(viewData.TemplateInfo.VisitedObjects.Contains(typeof(string)));
+            Assert.Contains(typeof(string), viewData.TemplateInfo.VisitedObjects);
         }
 
         [Fact]

--- a/test/System.Web.Mvc.Test/Html/Test/ValidationExtensionsTest.cs
+++ b/test/System.Web.Mvc.Test/Html/Test/ValidationExtensionsTest.cs
@@ -768,11 +768,8 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("AttributeEncodedData", PropertyType = typeof(EncodedDataSets))]
-        public void ValidationMessage_DoesNotEncode_Tag(
-            string text,
-            bool htmlEncode,
-            string unusedText)
+        [PropertyData("AttributeEncodedData_NoEncodedText", PropertyType = typeof(EncodedDataSets))]
+        public void ValidationMessage_DoesNotEncode_Tag(string text, bool htmlEncode)
         {
             // Arrange
             var viewData = new ViewDataDictionary<string>(model: null);
@@ -945,11 +942,8 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("AttributeEncodedData", PropertyType = typeof(EncodedDataSets))]
-        public void ValidationMessageNonUnobtrusive_DoesNotEncode_Tag(
-            string text,
-            bool htmlEncode,
-            string unusedText)
+        [PropertyData("AttributeEncodedData_NoEncodedText", PropertyType = typeof(EncodedDataSets))]
+        public void ValidationMessageNonUnobtrusive_DoesNotEncode_Tag(string text, bool htmlEncode)
         {
             // Arrange
             var viewData = new ViewDataDictionary<string>(model: null);
@@ -1375,11 +1369,8 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("AttributeEncodedData", PropertyType = typeof(EncodedDataSets))]
-        public void ValidationMessageFor_DoesNotEncode_Tag(
-            string text,
-            bool htmlEncode,
-            string unusedText)
+        [PropertyData("AttributeEncodedData_NoEncodedText", PropertyType = typeof(EncodedDataSets))]
+        public void ValidationMessageFor_DoesNotEncode_Tag(string text, bool htmlEncode)
         {
             // Arrange
             var viewData = new ViewDataDictionary<string>(model: null);
@@ -1540,11 +1531,8 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("AttributeEncodedData", PropertyType = typeof(EncodedDataSets))]
-        public void ValidationMessageForNonUnobtrusive_DoesNotEncode_Tag(
-            string text,
-            bool htmlEncode,
-            string unusedText)
+        [PropertyData("AttributeEncodedData_NoEncodedText", PropertyType = typeof(EncodedDataSets))]
+        public void ValidationMessageForNonUnobtrusive_DoesNotEncode_Tag(string text, bool htmlEncode)
         {
             // Arrange
             var viewData = new ViewDataDictionary<string>(model: null);
@@ -2015,11 +2003,8 @@ namespace System.Web.Mvc.Html.Test
         }
 
         [Theory]
-        [PropertyData("AttributeEncodedData", PropertyType = typeof(EncodedDataSets))]
-        public void ValidationSummary_DoesNotEncode_Tag(
-            string text,
-            bool htmlEncode,
-            string unusedText)
+        [PropertyData("AttributeEncodedData_NoEncodedText", PropertyType = typeof(EncodedDataSets))]
+        public void ValidationSummary_DoesNotEncode_Tag(string text, bool htmlEncode)
         {
             // Arrange
             var viewData = new ViewDataDictionary<string>(model: null);

--- a/test/System.Web.Mvc.Test/Razor/Test/MvcCSharpRazorCodeGeneratorTest.cs
+++ b/test/System.Web.Mvc.Test/Razor/Test/MvcCSharpRazorCodeGeneratorTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.CodeDom;
 using System.Collections.Generic;
 using System.Web.Razor;
 using Microsoft.TestCommon;
@@ -37,7 +38,7 @@ namespace System.Web.Mvc.Razor.Test
             var generator = new MvcCSharpRazorCodeGenerator("FooClass", "Root.Namespace", "SomeSourceFile.cshtml", mockHost.Object);
 
             // Assert
-            Assert.Equal(0, generator.Context.GeneratedClass.BaseTypes.Count);
+            Assert.Empty(generator.Context.GeneratedClass.BaseTypes);
         }
 
         [Fact]
@@ -51,7 +52,7 @@ namespace System.Web.Mvc.Razor.Test
             var generator = new MvcCSharpRazorCodeGenerator("FooClass", "Root.Namespace", "_viewStart.cshtml", mockHost.Object);
 
             // Assert
-            Assert.Equal(0, generator.Context.GeneratedClass.BaseTypes.Count);
+            Assert.Empty(generator.Context.GeneratedClass.BaseTypes);
         }
 
         [Fact]
@@ -65,8 +66,8 @@ namespace System.Web.Mvc.Razor.Test
             var generator = new MvcCSharpRazorCodeGenerator("FooClass", "Root.Namespace", "SomeSourceFile.cshtml", mockHost.Object);
 
             // Assert
-            Assert.Equal(1, generator.Context.GeneratedClass.BaseTypes.Count);
-            Assert.Equal("System.Web.Mvc.WebViewPage<dynamic>", generator.Context.GeneratedClass.BaseTypes[0].BaseType);
+            var baseType = Assert.IsType<CodeTypeReference>(Assert.Single(generator.Context.GeneratedClass.BaseTypes));
+            Assert.Equal("System.Web.Mvc.WebViewPage<dynamic>", baseType.BaseType);
         }
     }
 }

--- a/test/System.Web.Mvc.Test/Razor/Test/MvcVBRazorCodeParserTest.cs
+++ b/test/System.Web.Mvc.Test/Razor/Test/MvcVBRazorCodeParserTest.cs
@@ -165,7 +165,7 @@ namespace System.Web.Mvc.Razor.Test
                 factory.Markup("\r\n")
             };
             Assert.Equal(expectedSpans, spans.ToArray());
-            Assert.Equal(0, errors.Count);
+            Assert.Empty(errors);
         }
 
         [Fact]

--- a/test/System.Web.Mvc.Test/Routing/AttributeRoutingMapperTest.cs
+++ b/test/System.Web.Mvc.Test/Routing/AttributeRoutingMapperTest.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Linq;
-using System.Web.Mvc.Async;
 using System.Web.Routing;
 using Microsoft.TestCommon;
-using Moq;
 
 namespace System.Web.Mvc.Routing
 {
@@ -47,7 +44,7 @@ namespace System.Web.Mvc.Routing
             var entries = AttributeRoutingMapper.GetAttributeRoutes(controllerType);
 
             // Assert
-            var controllerEntry = Assert.Single(entries.Where(r => !r.Route.Defaults.ContainsKey("action")));
+            var controllerEntry = Assert.Single(entries, r => !r.Route.Defaults.ContainsKey("action"));
             Assert.Same(controllerType, controllerEntry.Route.GetTargetControllerDescriptor().ControllerType);
 
             var actionMethods = controllerEntry.Route.GetTargetActionDescriptors().ToArray();
@@ -79,14 +76,14 @@ namespace System.Web.Mvc.Routing
             var entries = AttributeRoutingMapper.GetAttributeRoutes(controllerType);
 
             // Assert
-            var controllerEntry = Assert.Single(entries.Where(r => !r.Route.Defaults.ContainsKey("action")));
+            var controllerEntry = Assert.Single(entries, r => !r.Route.Defaults.ContainsKey("action"));
             Assert.Same(controllerType, controllerEntry.Route.GetTargetControllerDescriptor().ControllerType);
 
             var actionMethods = controllerEntry.Route.GetTargetActionDescriptors().ToArray();
-            Assert.Equal(1, actionMethods.Length);
+            Assert.Single(actionMethods);
             Assert.Single(actionMethods, a => a.ActionName == "GoodAction");
 
-            var actionEntry = Assert.Single(entries.Where(r => r.Route.Defaults.ContainsKey("action")));
+            var actionEntry = Assert.Single(entries, r => r.Route.Defaults.ContainsKey("action"));
             Assert.Equal("DirectRouteAction", Assert.Single(actionEntry.Route.GetTargetActionDescriptors()).ActionName);
         }
 
@@ -100,10 +97,10 @@ namespace System.Web.Mvc.Routing
             var entries = AttributeRoutingMapper.GetAttributeRoutes(controllerType);
 
             // Assert
-            var controllerEntry = Assert.Single(entries.Where(r => !r.Route.Defaults.ContainsKey("action")));
+            var controllerEntry = Assert.Single(entries, r => !r.Route.Defaults.ContainsKey("action"));
             Assert.False(controllerEntry.Route.GetTargetIsAction());
 
-            var actionEntry = Assert.Single(entries.Where(r => r.Route.Defaults.ContainsKey("action")));
+            var actionEntry = Assert.Single(entries, r => r.Route.Defaults.ContainsKey("action"));
             Assert.True(actionEntry.Route.GetTargetIsAction());
         }
 

--- a/test/System.Web.Mvc.Test/Routing/DefaultDirectRouteProviderTest.cs
+++ b/test/System.Web.Mvc.Test/Routing/DefaultDirectRouteProviderTest.cs
@@ -69,7 +69,7 @@ namespace System.Web.Routing
             route.DataTokens.Add(RouteDataTokenKeys.Actions, new ActionDescriptor[0]);
             ActionDescriptor[] originalActions = route.GetTargetActionDescriptors();
             Assert.NotNull(originalActions); // Guard
-            Assert.Equal(0, originalActions.Length); // Guard
+            Assert.Empty(originalActions); // Guard
             RouteEntry entry = new RouteEntry(name: null, route: route);
             IDirectRouteFactory factory = CreateStubRouteFactory(entry);
             ControllerDescriptor controllerDescriptor = CreateStubControllerDescriptor("IgnoreController");

--- a/test/System.Web.Mvc.Test/Routing/RouteCollectionAttributeRoutingExtensionsTests.cs
+++ b/test/System.Web.Mvc.Test/Routing/RouteCollectionAttributeRoutingExtensionsTests.cs
@@ -113,7 +113,7 @@ namespace System.Web.Routing
 
             Assert.Equal(AttributeTargets.Class, usage.ValidOn);
             Assert.False(usage.AllowMultiple); // only 1 per class
-            Assert.False(usage.Inherited); // RoutePrefix is not inherited. 
+            Assert.False(usage.Inherited); // RoutePrefix is not inherited.
         }
 
         [Fact]
@@ -134,7 +134,7 @@ namespace System.Web.Routing
 
             Assert.Equal("puget-sound/getme", route.Url);
             Assert.Equal("PugetSound", route.DataTokens["area"]);
-            Assert.Equal(false, route.DataTokens["usenamespacefallback"]);
+            Assert.Equal((object)false, route.DataTokens["usenamespacefallback"]);
             Assert.Equal("GetMe", Assert.Single(route.GetTargetActionDescriptors()).ActionName);
             Assert.Equal(typeof(PugetSoundController).Namespace, ((string[])route.DataTokens["namespaces"])[0]);
         }
@@ -157,7 +157,7 @@ namespace System.Web.Routing
 
             Assert.Equal("puget-sound/prefpref/getme", route.Url);
             Assert.Equal("PugetSound", route.DataTokens["area"]);
-            Assert.Equal(false, route.DataTokens["usenamespacefallback"]);
+            Assert.Equal((object)false, route.DataTokens["usenamespacefallback"]);
             Assert.Equal("GetMe", Assert.Single(route.GetTargetActionDescriptors()).ActionName);
             Assert.Equal(typeof(PrefixedPugetSoundController).Namespace, ((string[])route.DataTokens["namespaces"])[0]);
         }

--- a/test/System.Web.Mvc.Test/System.Web.Mvc.Test.csproj
+++ b/test/System.Web.Mvc.Test/System.Web.Mvc.Test.csproj
@@ -414,6 +414,9 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/System.Web.Mvc.Test/Test/AreaRegistrationContextTest.cs
+++ b/test/System.Web.Mvc.Test/Test/AreaRegistrationContextTest.cs
@@ -65,7 +65,7 @@ namespace System.Web.Mvc.Test
             // Assert
             Assert.Equal(route, routes["the_name"]);
             Assert.Equal("the_area", route.DataTokens["area"]);
-            Assert.Equal(true, route.DataTokens["UseNamespaceFallback"]);
+            Assert.Equal((object)true, route.DataTokens["UseNamespaceFallback"]);
             Assert.Null(route.DataTokens["namespaces"]);
         }
 
@@ -86,7 +86,7 @@ namespace System.Web.Mvc.Test
             // Assert
             Assert.Equal(route, routes["the_name"]);
             Assert.Equal("the_area", route.DataTokens["area"]);
-            Assert.Equal(false, route.DataTokens["UseNamespaceFallback"]);
+            Assert.Equal((object)false, route.DataTokens["UseNamespaceFallback"]);
             Assert.Equal(explicitNamespaces, (string[])route.DataTokens["namespaces"]);
         }
 
@@ -107,7 +107,7 @@ namespace System.Web.Mvc.Test
             // Assert
             Assert.Equal(route, routes["the_name"]);
             Assert.Equal("the_area", route.DataTokens["area"]);
-            Assert.Equal(false, route.DataTokens["UseNamespaceFallback"]);
+            Assert.Equal((object)false, route.DataTokens["UseNamespaceFallback"]);
             Assert.Equal(implicitNamespaces, (string[])route.DataTokens["namespaces"]);
         }
 
@@ -125,7 +125,7 @@ namespace System.Web.Mvc.Test
             Assert.Equal(route, routes["the_name"]);
             Assert.Equal("the_area", route.DataTokens["area"]);
             Assert.Null(route.DataTokens["namespaces"]);
-            Assert.Equal(true, route.DataTokens["UseNamespaceFallback"]);
+            Assert.Equal((object)true, route.DataTokens["UseNamespaceFallback"]);
         }
 
         private static void ReplaceCollectionContents(ICollection<string> collectionToReplace, IEnumerable<string> newContents)

--- a/test/System.Web.Mvc.Test/Test/AssociatedMetadataProviderTest.cs
+++ b/test/System.Web.Mvc.Test/Test/AssociatedMetadataProviderTest.cs
@@ -24,7 +24,7 @@ namespace System.Web.Mvc.Test
 
             // Assert
             CreateMetadataParams parms = provider.CreateMetadataLog.Single();
-            Assert.False(parms.Attributes.Any(a => a is ReadOnlyAttribute));
+            Assert.DoesNotContain(parms.Attributes, a => a is ReadOnlyAttribute);
         }
 
         [Fact]
@@ -38,7 +38,7 @@ namespace System.Web.Mvc.Test
 
             // Assert
             CreateMetadataParams parms = provider.CreateMetadataLog.Single();
-            Assert.False(parms.Attributes.Any(a => a is ReadOnlyAttribute));
+            Assert.DoesNotContain(parms.Attributes, a => a is ReadOnlyAttribute);
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace System.Web.Mvc.Test
 
             // Assert
             CreateMetadataParams parms = provider.CreateMetadataLog.Single();
-            Assert.True(parms.Attributes.Any(a => a is ReadOnlyAttribute));
+            Assert.Contains(parms.Attributes, a => a is ReadOnlyAttribute);
         }
 
         // GetMetadataForProperties
@@ -85,22 +85,22 @@ namespace System.Web.Mvc.Test
                                                        m.PropertyName == "LocalAttributes");
             Assert.Equal(typeof(int), local.ModelType);
             Assert.Equal(42, local.Model);
-            Assert.True(local.Attributes.Any(a => a is RequiredAttribute));
+            Assert.Contains(local.Attributes, a => a is RequiredAttribute);
 
             CreateMetadataParams metadata =
                 provider.CreateMetadataLog.Single(m => m.ContainerType == typeof(PropertyModel) &&
                                                        m.PropertyName == "MetadataAttributes");
             Assert.Equal(typeof(string), metadata.ModelType);
             Assert.Equal("hello", metadata.Model);
-            Assert.True(metadata.Attributes.Any(a => a is RangeAttribute));
+            Assert.Contains(metadata.Attributes, a => a is RangeAttribute);
 
             CreateMetadataParams mixed =
                 provider.CreateMetadataLog.Single(m => m.ContainerType == typeof(PropertyModel) &&
                                                        m.PropertyName == "MixedAttributes");
             Assert.Equal(typeof(double), mixed.ModelType);
             Assert.Equal(21.12, mixed.Model);
-            Assert.True(mixed.Attributes.Any(a => a is RequiredAttribute));
-            Assert.True(mixed.Attributes.Any(a => a is RangeAttribute));
+            Assert.Contains(mixed.Attributes, a => a is RequiredAttribute);
+            Assert.Contains(mixed.Attributes, a => a is RangeAttribute);
         }
 
         [Fact]
@@ -191,7 +191,7 @@ namespace System.Web.Mvc.Test
 
             // Assert
             Assert.Same(metadata, result);
-            Assert.True(provider.CreateMetadataLog.Single().Attributes.Any(a => a is RequiredAttribute));
+            Assert.Contains(provider.CreateMetadataLog.Single().Attributes, a => a is RequiredAttribute);
         }
 
         [Fact]
@@ -208,7 +208,7 @@ namespace System.Web.Mvc.Test
             // Assert
             Assert.Same(metadata, result);
             CreateMetadataParams parms = provider.CreateMetadataLog.Single(p => p.PropertyName == "MetadataAttributes");
-            Assert.True(parms.Attributes.Any(a => a is RangeAttribute));
+            Assert.Contains(parms.Attributes, a => a is RangeAttribute);
         }
 
         [Fact]
@@ -225,8 +225,8 @@ namespace System.Web.Mvc.Test
             // Assert
             Assert.Same(metadata, result);
             CreateMetadataParams parms = provider.CreateMetadataLog.Single(p => p.PropertyName == "MixedAttributes");
-            Assert.True(parms.Attributes.Any(a => a is RequiredAttribute));
-            Assert.True(parms.Attributes.Any(a => a is RangeAttribute));
+            Assert.Contains(parms.Attributes, a => a is RequiredAttribute);
+            Assert.Contains(parms.Attributes, a => a is RangeAttribute);
         }
 
         // GetMetadataForType
@@ -256,7 +256,7 @@ namespace System.Web.Mvc.Test
             // Assert
             Assert.Same(metadata, result);
             CreateMetadataParams parms = provider.CreateMetadataLog.Single(p => p.ModelType == typeof(TypeModel));
-            Assert.True(parms.Attributes.Any(a => a is ReadOnlyAttribute));
+            Assert.Contains(parms.Attributes, a => a is ReadOnlyAttribute);
         }
 
         [AdditionalMetadata("ClassName", "ClassValue")]

--- a/test/System.Web.Mvc.Test/Test/AssociatedValidatorProviderTest.cs
+++ b/test/System.Web.Mvc.Test/Test/AssociatedValidatorProviderTest.cs
@@ -46,7 +46,7 @@ namespace System.Web.Mvc.Test
 
             // Assert
             provider.Verify();
-            Assert.True(callbackAttributes.Any(a => a is RequiredAttribute));
+            Assert.Contains(callbackAttributes, a => a is RequiredAttribute);
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace System.Web.Mvc.Test
 
             // Assert
             provider.Verify();
-            Assert.True(callbackAttributes.Any(a => a is RangeAttribute));
+            Assert.Contains(callbackAttributes, a => a is RangeAttribute);
         }
 
         [Fact]
@@ -88,8 +88,8 @@ namespace System.Web.Mvc.Test
 
             // Assert
             provider.Verify();
-            Assert.True(callbackAttributes.Any(a => a is RangeAttribute));
-            Assert.True(callbackAttributes.Any(a => a is RequiredAttribute));
+            Assert.Contains(callbackAttributes, a => a is RangeAttribute);
+            Assert.Contains(callbackAttributes, a => a is RequiredAttribute);
         }
 
         [MetadataType(typeof(Metadata))]

--- a/test/System.Web.Mvc.Test/Test/AuthorizeAttributeTest.cs
+++ b/test/System.Web.Mvc.Test/Test/AuthorizeAttributeTest.cs
@@ -43,8 +43,8 @@ namespace System.Web.Mvc.Test
 
             // Assert
             Assert.Equal(2, attributes.Count());
-            Assert.True(attributes.Any(a => a.Roles == "foo"));
-            Assert.True(attributes.Any(a => a.Roles == "bar"));
+            Assert.Contains(attributes, a => a.Roles == "foo");
+            Assert.Contains(attributes, a => a.Roles == "bar");
         }
 
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/CompareAttributeTest.cs
+++ b/test/System.Web.Mvc.Test/Test/CompareAttributeTest.cs
@@ -26,7 +26,7 @@ namespace System.Web.Mvc.Test
         public void FormatPropertyForClientValidationPrependsStarDot()
         {
             string prepended = CompareAttribute.FormatPropertyForClientValidation("test");
-            Assert.Equal(prepended, "*.test");
+            Assert.Equal("*.test", prepended);
         }
 
         [Fact]
@@ -110,9 +110,8 @@ namespace System.Web.Mvc.Test
             CompareAttribute attr = new CompareAttribute("CompareProperty");
             List<ModelClientValidationRule> ruleList = new List<ModelClientValidationRule>(attr.GetClientValidationRules(metadata.Object, null));
 
-            Assert.Equal(ruleList.Count, 1);
-
-            ModelClientValidationEqualToRule actualRule = ruleList[0] as ModelClientValidationEqualToRule;
+            ModelClientValidationRule rule = Assert.Single(ruleList);
+            ModelClientValidationEqualToRule actualRule = Assert.IsType<ModelClientValidationEqualToRule>(rule);
 
             Assert.Equal("'CurrentProperty' and 'CompareProperty' do not match.", actualRule.ErrorMessage);
             Assert.Equal("equalto", actualRule.ValidationType);
@@ -129,9 +128,8 @@ namespace System.Web.Mvc.Test
             CompareAttribute attr = new CompareAttribute("ComparePropertyWithDisplayName");
             List<ModelClientValidationRule> ruleList = new List<ModelClientValidationRule>(attr.GetClientValidationRules(metadata, null));
 
-            Assert.Equal(ruleList.Count, 1);
-
-            ModelClientValidationEqualToRule actualRule = ruleList[0] as ModelClientValidationEqualToRule;
+            ModelClientValidationRule rule = Assert.Single(ruleList);
+            ModelClientValidationEqualToRule actualRule = Assert.IsType<ModelClientValidationEqualToRule>(rule);
 
             Assert.Equal("'CurrentProperty' and 'DisplayName' do not match.", actualRule.ErrorMessage);
             Assert.Equal("equalto", actualRule.ValidationType);
@@ -149,8 +147,8 @@ namespace System.Web.Mvc.Test
             attr.OtherPropertyDisplayName = "SetDisplayName";
 
             List<ModelClientValidationRule> ruleList = new List<ModelClientValidationRule>(attr.GetClientValidationRules(metadata, null));
-            Assert.Equal(ruleList.Count, 1);
-            ModelClientValidationEqualToRule actualRule = ruleList[0] as ModelClientValidationEqualToRule;
+            ModelClientValidationRule rule = Assert.Single(ruleList);
+            ModelClientValidationEqualToRule actualRule = Assert.IsType<ModelClientValidationEqualToRule>(rule);
 
             Assert.Equal("'CurrentProperty' and 'SetDisplayName' do not match.", actualRule.ErrorMessage);
         }

--- a/test/System.Web.Mvc.Test/Test/ControllerActionInvokerTest.cs
+++ b/test/System.Web.Mvc.Test/Test/ControllerActionInvokerTest.cs
@@ -1485,8 +1485,8 @@ namespace System.Web.Mvc.Test
             // Assert
             Assert.Equal(ad, postContext.ActionDescriptor);
             Assert.Same(result, postContext.Result);
-            Assert.Single(callQueue);
-            Assert.Same(filter1, callQueue[0]);
+            AuthorizationFilterHelper resultFilter = Assert.Single(callQueue);
+            Assert.Same(filter1, resultFilter);
         }
 
         [Fact]
@@ -1543,8 +1543,8 @@ namespace System.Web.Mvc.Test
             // Assert
             Assert.Same(ad, postContext.ActionDescriptor);
             Assert.Same(controller, postContext.Controller);
-            Assert.Equal(1, callQueue.Count);
-            Assert.Same(filter, callQueue[0]);
+            AuthenticationFilterHelper actualHelper = Assert.Single(callQueue);
+            Assert.Same(filter, actualHelper);
             Assert.Same(principal, postContext.Principal);
         }
 
@@ -1574,8 +1574,8 @@ namespace System.Web.Mvc.Test
             Assert.Same(ad, postContext.ActionDescriptor);
             Assert.Same(controller, postContext.Controller);
             Assert.Same(result, postContext.Result);
-            Assert.Single(callQueue);
-            Assert.Same(filter1, callQueue[0]);
+            AuthenticationFilterHelper resultFilter = Assert.Single(callQueue);
+            Assert.Same(filter1, resultFilter);
         }
 
         [Fact]
@@ -1603,8 +1603,8 @@ namespace System.Web.Mvc.Test
             Assert.Same(ad, postContext.ActionDescriptor);
             Assert.Same(controller, postContext.Controller);
             Assert.Same(principal, postContext.HttpContext.User);
-            Assert.Single(callQueue);
-            Assert.Same(filter, callQueue[0]);
+            AuthenticationFilterHelper resultFilter = Assert.Single(callQueue);
+            Assert.Same(filter, resultFilter);
         }
 
         [Fact]
@@ -1630,8 +1630,8 @@ namespace System.Web.Mvc.Test
                 Assert.Same(ad, postContext.ActionDescriptor);
                 Assert.Same(controller, postContext.Controller);
                 Assert.Same(principal, Thread.CurrentPrincipal);
-                Assert.Single(callQueue);
-                Assert.Same(filter, callQueue[0]);
+                AuthenticationFilterHelper resultFilter = Assert.Single(callQueue);
+                Assert.Same(filter, resultFilter);
             }
         }
 
@@ -1660,8 +1660,8 @@ namespace System.Web.Mvc.Test
                 Assert.Same(ad, postContext.ActionDescriptor);
                 Assert.Same(controller, postContext.Controller);
                 Assert.NotSame(controllerContext.HttpContext.User, Thread.CurrentPrincipal);
-                Assert.Single(callQueue);
-                Assert.Same(filter, callQueue[0]);
+                AuthenticationFilterHelper resultFilter = Assert.Single(callQueue);
+                Assert.Same(filter, resultFilter);
             }
         }
 
@@ -2213,8 +2213,8 @@ namespace System.Web.Mvc.Test
             ResultExecutedContext result = helper.PublicInvokeActionResultWithFilters(context, filters, actionResult);
 
             // Assert
-            Assert.Equal(1, actions.Count);
-            Assert.Equal("OnResultExecuting1", actions[0]);
+            string action = Assert.Single(actions);
+            Assert.Equal("OnResultExecuting1", action);
             Assert.Null(result.Exception);
             Assert.True(result.Canceled);
             Assert.Same(actionResult, result.Result);

--- a/test/System.Web.Mvc.Test/Test/ControllerTest.cs
+++ b/test/System.Web.Mvc.Test/Test/ControllerTest.cs
@@ -1301,7 +1301,7 @@ namespace System.Web.Mvc.Test
             Assert.NotNull(mockContext.Object.Session[SessionStateTempDataProvider.TempDataSessionStateKey]);
             TempDataDictionary tempData = new TempDataDictionary();
             tempData.Load(controller.ControllerContext, controller.TempDataProvider);
-            Assert.Equal(tempData["Key1"], "Value1");
+            Assert.Equal("Value1", tempData["Key1"]);
         }
 
         [Fact]
@@ -2017,7 +2017,7 @@ namespace System.Web.Mvc.Test
 
             public override void Remove(string name)
             {
-                Assert.Equal<string>(SessionStateTempDataProvider.TempDataSessionStateKey, name);
+                Assert.Equal(SessionStateTempDataProvider.TempDataSessionStateKey, name);
                 _sessionData.Remove(name);
             }
 
@@ -2025,12 +2025,12 @@ namespace System.Web.Mvc.Test
             {
                 get
                 {
-                    Assert.Equal<string>(SessionStateTempDataProvider.TempDataSessionStateKey, name);
+                    Assert.Equal(SessionStateTempDataProvider.TempDataSessionStateKey, name);
                     return _sessionData[name];
                 }
                 set
                 {
-                    Assert.Equal<string>(SessionStateTempDataProvider.TempDataSessionStateKey, name);
+                    Assert.Equal(SessionStateTempDataProvider.TempDataSessionStateKey, name);
                     _sessionData[name] = value;
                 }
             }

--- a/test/System.Web.Mvc.Test/Test/DataAnnotationsModelMetadataProviderTestBase.cs
+++ b/test/System.Web.Mvc.Test/Test/DataAnnotationsModelMetadataProviderTestBase.cs
@@ -23,9 +23,9 @@ namespace System.Web.Mvc.Test
             IEnumerable<ModelMetadata> result = provider.GetMetadataForProperties("foo", typeof(string));
 
             // Assert
-            Assert.True(result.Any(m => m.ModelType == typeof(int)
+            Assert.Contains(result, m => m.ModelType == typeof(int)
                                         && m.PropertyName == "Length"
-                                        && (int)m.Model == 3));
+                                        && (int)m.Model == 3);
         }
 
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/DefaultModelBinderTest.cs
+++ b/test/System.Web.Mvc.Test/Test/DefaultModelBinderTest.cs
@@ -175,11 +175,11 @@ namespace System.Web.Mvc.Test
             Assert.Equal("Canada", modelAsDictionary["CA"].Name);
             Assert.Equal("United States", modelAsDictionary["US"].Name);
             Assert.Equal(2, modelAsDictionary["CA"].States.Count());
-            Assert.True(modelAsDictionary["CA"].States.Contains("Québec"));
-            Assert.True(modelAsDictionary["CA"].States.Contains("British Columbia"));
+            Assert.Contains("Québec", modelAsDictionary["CA"].States);
+            Assert.Contains("British Columbia", modelAsDictionary["CA"].States);
             Assert.Equal(2, modelAsDictionary["US"].States.Count());
-            Assert.True(modelAsDictionary["US"].States.Contains("Washington"));
-            Assert.True(modelAsDictionary["US"].States.Contains("Oregon"));
+            Assert.Contains("Washington", modelAsDictionary["US"].States);
+            Assert.Contains("Oregon", modelAsDictionary["US"].States);
         }
 
         [Fact]
@@ -215,11 +215,11 @@ namespace System.Web.Mvc.Test
             Assert.Equal("Canada", modelAsDictionary["CA"].Name);
             Assert.Equal("United States", modelAsDictionary["US"].Name);
             Assert.Equal(2, modelAsDictionary["CA"].States.Count());
-            Assert.True(modelAsDictionary["CA"].States.Contains("Québec"));
-            Assert.True(modelAsDictionary["CA"].States.Contains("British Columbia"));
+            Assert.Contains("Québec", modelAsDictionary["CA"].States);
+            Assert.Contains("British Columbia", modelAsDictionary["CA"].States);
             Assert.Equal(2, modelAsDictionary["US"].States.Count());
-            Assert.True(modelAsDictionary["US"].States.Contains("Washington"));
-            Assert.True(modelAsDictionary["US"].States.Contains("Oregon"));
+            Assert.Contains("Washington", modelAsDictionary["US"].States);
+            Assert.Contains("Oregon", modelAsDictionary["US"].States);
         }
 
         [Fact]
@@ -254,14 +254,14 @@ namespace System.Web.Mvc.Test
             Assert.Equal(2, modelAsDictionary.Count);
             Assert.Equal("Canada", modelAsDictionary["CA"].Name);
             Assert.Equal("United States", modelAsDictionary["US"].Name);
-            Assert.Equal(1, modelAsDictionary["CA"].States.Count());
-            Assert.True(modelAsDictionary["CA"].States.Contains("Québec"));
+            string state = Assert.Single(modelAsDictionary["CA"].States);
+            Assert.Contains("Québec", state);
 
             // We do not accept double notation for a same entry, so we can't find that state.
-            Assert.False(modelAsDictionary["CA"].States.Contains("British Columbia"));
+            Assert.DoesNotContain("British Columbia", state);
             Assert.Equal(2, modelAsDictionary["US"].States.Count());
-            Assert.True(modelAsDictionary["US"].States.Contains("Washington"));
-            Assert.True(modelAsDictionary["US"].States.Contains("Oregon"));
+            Assert.Contains("Washington", modelAsDictionary["US"].States);
+            Assert.Contains("Oregon", modelAsDictionary["US"].States);
         }
 
         [Fact]
@@ -733,8 +733,8 @@ namespace System.Web.Mvc.Test
             // Assert
             ModelState modelState = bindingContext.ModelState["IntReadWrite"];
             Assert.NotNull(modelState);
-            Assert.Single(modelState.Errors);
-            Assert.Equal("The value 'foo' is not valid for IntReadWrite.", modelState.Errors[0].ErrorMessage);
+            ModelError error = Assert.Single(modelState.Errors);
+            Assert.Equal("The value 'foo' is not valid for IntReadWrite.", error.ErrorMessage);
         }
 
         [Fact]
@@ -1050,7 +1050,7 @@ namespace System.Web.Mvc.Test
             helper.PublicBindProperty(new ControllerContext(), bindingContext, pd);
 
             // Assert
-            Assert.Equal(false, bindingContext.ModelState.IsValidField("IntReadWriteNonNegative"));
+            Assert.False(bindingContext.ModelState.IsValidField("IntReadWriteNonNegative"));
             var error = Assert.Single(bindingContext.ModelState["IntReadWriteNonNegative"].Errors);
             Assert.Equal("Some error text.", error.ErrorMessage);
             Assert.Equal(4, model.IntReadWriteNonNegative);
@@ -1212,8 +1212,8 @@ namespace System.Web.Mvc.Test
 
             // Assert
             var returnedValueAsIntArray = Assert.IsType<int[]>(returnedValue);
-            Assert.Single(returnedValueAsIntArray);
-            Assert.Equal(42, returnedValueAsIntArray[0]);
+            var returnedInt = Assert.Single(returnedValueAsIntArray);
+            Assert.Equal(42, returnedInt);
         }
 
         [Fact]
@@ -1318,8 +1318,8 @@ namespace System.Web.Mvc.Test
 
             // Assert
             Assert.False(bindingContext.ModelState.IsValidField("foo"));
-            Assert.IsType<InvalidOperationException>(bindingContext.ModelState["foo"].Errors[0].Exception);
-            Assert.Equal("The parameter conversion from type 'System.String' to type 'System.Int32' failed. See the inner exception for more information.", bindingContext.ModelState["foo"].Errors[0].Exception.Message);
+            InvalidOperationException exception = Assert.IsType<InvalidOperationException>(bindingContext.ModelState["foo"].Errors[0].Exception);
+            Assert.Equal("The parameter conversion from type 'System.String' to type 'System.Int32' failed. See the inner exception for more information.", exception.Message);
             Assert.Null(returnedValue);
         }
 
@@ -1791,7 +1791,7 @@ namespace System.Web.Mvc.Test
 
             // Assert
             Assert.Equal(3, model.Count);
-            Assert.Equal(false, bindingContext.ModelState.IsValidField("foo[1]"));
+            Assert.False(bindingContext.ModelState.IsValidField("foo[1]"));
             Assert.Equal("A value is required.", bindingContext.ModelState["foo[1]"].Errors[0].ErrorMessage);
             Assert.Equal(0, model[0]);
             Assert.Equal(0, model[1]);
@@ -2505,7 +2505,7 @@ namespace System.Web.Mvc.Test
                 .Single();
 
             // Assert
-            Assert.True(property.Attributes.Cast<Attribute>().Any(a => a is RequiredAttribute));
+            Assert.Contains(property.Attributes.Cast<Attribute>(), a => a is RequiredAttribute);
         }
 
         [Fact]
@@ -2521,7 +2521,7 @@ namespace System.Web.Mvc.Test
                 .Single();
 
             // Assert
-            Assert.True(property.Attributes.Cast<Attribute>().Any(a => a is RangeAttribute));
+            Assert.Contains(property.Attributes.Cast<Attribute>(), a => a is RangeAttribute);
         }
 
         [Fact]
@@ -2537,8 +2537,8 @@ namespace System.Web.Mvc.Test
                 .Single();
 
             // Assert
-            Assert.True(property.Attributes.Cast<Attribute>().Any(a => a is RequiredAttribute));
-            Assert.True(property.Attributes.Cast<Attribute>().Any(a => a is RangeAttribute));
+            Assert.Contains(property.Attributes.Cast<Attribute>(), a => a is RequiredAttribute);
+            Assert.Contains(property.Attributes.Cast<Attribute>(), a => a is RangeAttribute);
         }
 
         // GetPropertyValue tests
@@ -2666,7 +2666,8 @@ namespace System.Web.Mvc.Test
             Assert.Single(modelBinder.ModelState);
             ModelState stateModel = modelBinder.ModelState[BASE_MODEL_NAME];
             Assert.NotNull(stateModel);
-            Assert.Equal("Minimum must be less than or equal to Maximum", stateModel.Errors.Single().ErrorMessage);
+            ModelError error = Assert.Single(stateModel.Errors);
+            Assert.Equal("Minimum must be less than or equal to Maximum", error.ErrorMessage);
         }
 
         [Fact]
@@ -2719,7 +2720,8 @@ namespace System.Web.Mvc.Test
             Assert.Single(modelBinder.ModelState);
             ModelState stateModel = modelBinder.ModelState[BASE_MODEL_NAME];
             Assert.NotNull(stateModel);
-            Assert.Equal("The object just isn't right", stateModel.Errors.Single().ErrorMessage);
+            ModelError error = Assert.Single(stateModel.Errors);
+            Assert.Equal("The object just isn't right", error.ErrorMessage);
         }
 
         [AlwaysInvalid]
@@ -2741,7 +2743,8 @@ namespace System.Web.Mvc.Test
             Assert.Single(modelBinder.ModelState);
             ModelState stateModel = modelBinder.ModelState[BASE_MODEL_NAME];
             Assert.NotNull(stateModel);
-            Assert.Equal("The field OnModelUpdatedModelNoValidationResult is invalid.", stateModel.Errors.Single().ErrorMessage);
+            ModelError error = Assert.Single(stateModel.Errors);
+            Assert.Equal("The field OnModelUpdatedModelNoValidationResult is invalid.", error.ErrorMessage);
         }
 
         [Fact]
@@ -2875,8 +2878,8 @@ namespace System.Web.Mvc.Test
 
             // Assert
             ModelState modelState = binder.Context.ModelState[BASE_MODEL_NAME + ".NonNullableString"];
-            Assert.Single(modelState.Errors);
-            Assert.IsType<ArgumentNullException>(modelState.Errors[0].Exception);
+            ModelError error = Assert.Single(modelState.Errors);
+            Assert.IsType<ArgumentNullException>(error.Exception);
         }
 
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/HandleErrorAttributeTest.cs
+++ b/test/System.Web.Mvc.Test/Test/HandleErrorAttributeTest.cs
@@ -41,8 +41,8 @@ namespace System.Web.Mvc.Test
 
             // Assert
             Assert.Equal(2, attributes.Count());
-            Assert.True(attributes.Any(a => a.View == "foo"));
-            Assert.True(attributes.Any(a => a.View == "bar"));
+            Assert.Contains(attributes, a => a.View == "foo");
+            Assert.Contains(attributes, a => a.View == "bar");
         }
 
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/HtmlHelperOfTModelTest.cs
+++ b/test/System.Web.Mvc.Test/Test/HtmlHelperOfTModelTest.cs
@@ -24,9 +24,10 @@ namespace System.Web.Mvc.Test
             // Assert
 
             // Original ViewData should not be modified by redfined ViewData and ViewBag
-            Assert.Single((htmlHelper as HtmlHelper).ViewData.Keys);
-            Assert.Equal(1, (htmlHelper as HtmlHelper).ViewData["A"]);
-            Assert.Equal(1, (htmlHelper as HtmlHelper).ViewBag.A);
+            HtmlHelper baseHelper = (HtmlHelper)htmlHelper;
+            Assert.Single(baseHelper.ViewData.Keys);
+            Assert.Equal(1, baseHelper.ViewData["A"]);
+            Assert.Equal(1, baseHelper.ViewBag.A);
 
             // Redefined ViewData and ViewBag should be in sync
             Assert.Equal(3, htmlHelper.ViewData.Keys.Count);

--- a/test/System.Web.Mvc.Test/Test/HtmlHelperTest.cs
+++ b/test/System.Web.Mvc.Test/Test/HtmlHelperTest.cs
@@ -108,7 +108,7 @@ namespace System.Web.Mvc.Test
             string encodedHtml = htmlHelper.AttributeEncode((object)@"<"">");
 
             // Assert
-            Assert.Equal(encodedHtml, "&lt;&quot;>");
+            Assert.Equal("&lt;&quot;>", encodedHtml);
         }
 
         [Fact]
@@ -134,7 +134,7 @@ namespace System.Web.Mvc.Test
             string encodedHtml = htmlHelper.AttributeEncode(@"<"">");
 
             // Assert
-            Assert.Equal(encodedHtml, "&lt;&quot;>");
+            Assert.Equal("&lt;&quot;>", encodedHtml);
         }
 
         [Fact]
@@ -196,7 +196,7 @@ namespace System.Web.Mvc.Test
             string encodedHtml = htmlHelper.Encode((object)"<br />");
 
             // Assert
-            Assert.Equal(encodedHtml, "&lt;br /&gt;");
+            Assert.Equal("&lt;br /&gt;", encodedHtml);
         }
 
         [Fact]
@@ -222,7 +222,7 @@ namespace System.Web.Mvc.Test
             string encodedHtml = htmlHelper.Encode("<br />");
 
             // Assert
-            Assert.Equal(encodedHtml, "&lt;br /&gt;");
+            Assert.Equal("&lt;br /&gt;", encodedHtml);
         }
 
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/ModelStateDictionaryTest.cs
+++ b/test/System.Web.Mvc.Test/Test/ModelStateDictionaryTest.cs
@@ -138,10 +138,10 @@ namespace System.Web.Mvc.Test
             Assert.Equal(3, deserializedDict.Count);
 
             ModelState foo = deserializedDict["FOO"];
-            Assert.IsType<InvalidOperationException>(foo.Errors[0].Exception);
-            Assert.Equal("Some invalid operation.", foo.Errors[0].Exception.Message);
-            Assert.IsType<InvalidOperationException>(foo.Errors[1].Exception);
-            Assert.Equal("Some other invalid operation.", foo.Errors[1].Exception.Message);
+            InvalidOperationException exception0 = Assert.IsType<InvalidOperationException>(foo.Errors[0].Exception);
+            Assert.Equal("Some invalid operation.", exception0.Message);
+            InvalidOperationException exception1 = Assert.IsType<InvalidOperationException>(foo.Errors[1].Exception);
+            Assert.Equal("Some other invalid operation.", exception1.Message);
 
             ModelState bar = deserializedDict["BAR"];
             Assert.Equal("Some exception text.", bar.Errors[0].ErrorMessage);
@@ -317,8 +317,8 @@ namespace System.Web.Mvc.Test
             Assert.Single(dictionary);
             ModelState modelState = dictionary["some key"];
 
-            Assert.Single(modelState.Errors);
-            Assert.Equal("some error", modelState.Errors[0].ErrorMessage);
+            ModelError error = Assert.Single(modelState.Errors);
+            Assert.Equal("some error", error.ErrorMessage);
             Assert.Equal("some value", modelState.Value.ConvertTo(typeof(string)));
         }
     }

--- a/test/System.Web.Mvc.Test/Test/NameValueCollectionExtensionsTest.cs
+++ b/test/System.Web.Mvc.Test/Test/NameValueCollectionExtensionsTest.cs
@@ -27,6 +27,7 @@ namespace System.Web.Mvc.Test
             Assert.Equal("BazCollection", dictionary["baz"]);
         }
 
+        [Fact]
         public void CopyToReplaceExisting()
         {
             // Arrange

--- a/test/System.Web.Mvc.Test/Test/OutputCacheAttributeTest.cs
+++ b/test/System.Web.Mvc.Test/Test/OutputCacheAttributeTest.cs
@@ -47,7 +47,7 @@ namespace System.Web.Mvc.Test
             Assert.Equal("SomeProfile", cacheSettings.CacheProfile);
             Assert.Equal(50, cacheSettings.Duration);
             Assert.Equal(OutputCacheLocation.Downstream, cacheSettings.Location);
-            Assert.Equal(true, cacheSettings.NoStore);
+            Assert.True(cacheSettings.NoStore);
             Assert.Equal("SomeSqlDependency", cacheSettings.SqlDependency);
             Assert.Equal("SomeContentEncoding", cacheSettings.VaryByContentEncoding);
             Assert.Equal("SomeCustom", cacheSettings.VaryByCustom);

--- a/test/System.Web.Mvc.Test/Test/OverrideFiltersAttributeTests.cs
+++ b/test/System.Web.Mvc.Test/Test/OverrideFiltersAttributeTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Web.Mvc.Filters;
 using Microsoft.TestCommon;
 using Moq;
@@ -38,8 +37,8 @@ namespace System.Web.Mvc.Test
             // Assert
             Assert.NotNull(usage);
             Assert.Equal(AttributeTargets.Class | AttributeTargets.Method, usage.ValidOn);
-            Assert.Equal(true, usage.Inherited);
-            Assert.Equal(false, usage.AllowMultiple);
+            Assert.True(usage.Inherited);
+            Assert.False(usage.AllowMultiple);
         }
 
         [Fact]
@@ -56,8 +55,7 @@ namespace System.Web.Mvc.Test
 
             // Assert
             Assert.NotNull(filters);
-            Assert.Equal(1, filters.Count());
-            Filter filter = filters.Single();
+            Filter filter = Assert.Single(filters);
             Assert.NotNull(filter);
             Assert.Same(expected, filter.Instance);
         }

--- a/test/System.Web.Mvc.Test/Test/ReflectedControllerDescriptorTest.cs
+++ b/test/System.Web.Mvc.Test/Test/ReflectedControllerDescriptorTest.cs
@@ -44,8 +44,8 @@ namespace System.Web.Mvc.Test
 
             // Assert
             Assert.Equal("NewName", ad.ActionName);
-            Assert.IsType<ReflectedActionDescriptor>(ad);
-            Assert.Same(targetMethod, ((ReflectedActionDescriptor)ad).MethodInfo);
+            ReflectedActionDescriptor actionDescriptor = Assert.IsType<ReflectedActionDescriptor>(ad);
+            Assert.Same(targetMethod, actionDescriptor.MethodInfo);
             Assert.Same(cd, ad.ControllerDescriptor);
         }
 

--- a/test/System.Web.Mvc.Test/Test/RouteCollectionExtensionsTest.cs
+++ b/test/System.Web.Mvc.Test/Test/RouteCollectionExtensionsTest.cs
@@ -156,7 +156,7 @@ namespace System.Web.Mvc.Test
             Assert.NotNull(route.DataTokens);
             Assert.NotNull(route.DataTokens["Namespaces"]);
             string[] routeNameSpaces = route.DataTokens["Namespaces"] as string[];
-            Assert.Equal(routeNameSpaces.Length, 2);
+            Assert.Equal(2, routeNameSpaces.Length);
             Assert.Same(route, routes["RouteName"]);
             Assert.Same(routeNameSpaces, _nameSpaces);
             Assert.Equal("SomeUrl", route.Url);
@@ -222,7 +222,7 @@ namespace System.Web.Mvc.Test
             Assert.NotNull(route.DataTokens);
             Assert.NotNull(route.DataTokens["Namespaces"]);
             string[] routeNameSpaces = route.DataTokens["Namespaces"] as string[];
-            Assert.Equal(routeNameSpaces.Length, 2);
+            Assert.Equal(2, routeNameSpaces.Length);
             Assert.Same(route, routes["RouteName"]);
             Assert.Same(routeNameSpaces, _nameSpaces);
             Assert.Equal("SomeUrl", route.Url);

--- a/test/System.Web.Mvc.Test/Test/SelectListTest.cs
+++ b/test/System.Web.Mvc.Test/Test/SelectListTest.cs
@@ -43,8 +43,8 @@ namespace System.Web.Mvc.Test
             Assert.Null(selectList.DataValueField);
             Assert.Null(selectList.DataTextField);
             Assert.Same(selectedValue, selectList.SelectedValue);
-            Assert.Single(selectedValues);
-            Assert.Same(selectedValue, selectedValues[0]);
+            object resultValue = Assert.Single(selectedValues);
+            Assert.Same(selectedValue, resultValue);
         }
 
         [Fact]
@@ -99,8 +99,8 @@ namespace System.Web.Mvc.Test
             Assert.Equal("SomeValueField", selectList.DataValueField);
             Assert.Equal("SomeTextField", selectList.DataTextField);
             Assert.Same(selectedValue, selectList.SelectedValue);
-            Assert.Single(selectedValues);
-            Assert.Same(selectedValue, selectedValues[0]);
+            object resultValue = Assert.Single(selectedValues);
+            Assert.Same(selectedValue, resultValue);
         }
 
         [Fact]
@@ -129,8 +129,8 @@ namespace System.Web.Mvc.Test
             Assert.Equal("Value", selectList.DataValueField);
             Assert.Equal("Text", selectList.DataTextField);
             Assert.Same(selectedValue, selectList.SelectedValue);
-            Assert.Single(selectedValues);
-            Assert.Same(selectedValue, selectedValues[0]);
+            object resultValue = Assert.Single(selectedValues);
+            Assert.Same(selectedValue, resultValue);
             Assert.Same(disabledValues, selectList.DisabledValues);
             Assert.Equal(disabledValues, selectList.DisabledValues);
             Assert.Null(selectList.DataGroupField);
@@ -162,8 +162,8 @@ namespace System.Web.Mvc.Test
             Assert.Equal("Value", selectList.DataValueField);
             Assert.Equal("Text", selectList.DataTextField);
             Assert.Same(selectedValue, selectList.SelectedValue);
-            Assert.Single(selectedValues);
-            Assert.Same(selectedValue, selectedValues[0]);
+            object resultValue = Assert.Single(selectedValues);
+            Assert.Same(selectedValue, resultValue);
             Assert.Equal("Group", selectList.DataGroupField);
         }
 
@@ -195,8 +195,8 @@ namespace System.Web.Mvc.Test
             Assert.Equal("Value", selectList.DataValueField);
             Assert.Equal("Text", selectList.DataTextField);
             Assert.Same(selectedValue, selectList.SelectedValue);
-            Assert.Single(selectedValues);
-            Assert.Same(selectedValue, selectedValues[0]);
+            object resultValue = Assert.Single(selectedValues);
+            Assert.Same(selectedValue, resultValue);
             Assert.Equal("Group", selectList.DataGroupField);
             Assert.Equal(disabledGroups, selectList.DisabledGroups);
         }
@@ -228,8 +228,8 @@ namespace System.Web.Mvc.Test
             Assert.Equal("Value", selectList.DataValueField);
             Assert.Equal("Text", selectList.DataTextField);
             Assert.Same(selectedValue, selectList.SelectedValue);
-            Assert.Single(selectedValues);
-            Assert.Same(selectedValue, selectedValues[0]);
+            object resultValue = Assert.Single(selectedValues);
+            Assert.Same(selectedValue, resultValue);
             Assert.Equal("Group", selectList.DataGroupField);
             Assert.Same(disabledValues, selectList.DisabledValues);
         }

--- a/test/System.Web.Mvc.Test/Test/TypeCacheUtilTest.cs
+++ b/test/System.Web.Mvc.Test/Test/TypeCacheUtilTest.cs
@@ -31,7 +31,7 @@ namespace System.Web.Mvc.Test
 
             MemoryStream cachedStream = buildManager.CachedFileStore[cacheName] as MemoryStream;
             Assert.NotNull(cachedStream);
-            Assert.NotEqual(0, cachedStream.ToArray().Length);
+            Assert.NotEmpty(cachedStream.ToArray());
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace System.Web.Mvc.Test
             Assert.NotNull(writeStream);
 
             byte[] streamContents = writeStream.ToArray();
-            Assert.NotEqual(0, streamContents.Length);
+            Assert.NotEmpty(streamContents);
 
             // READING
 
@@ -97,7 +97,7 @@ namespace System.Web.Mvc.Test
             Assert.NotNull(writeStream);
 
             byte[] streamContents = writeStream.ToArray();
-            Assert.NotEqual(0, streamContents.Length);
+            Assert.NotEmpty(streamContents);
 
             // READING
 

--- a/test/System.Web.Mvc.Test/Test/UrlHelperTest.cs
+++ b/test/System.Web.Mvc.Test/Test/UrlHelperTest.cs
@@ -394,7 +394,7 @@ namespace System.Web.Mvc.Test
             string encodedUrl = urlHelper.Encode(@"SomeUrl /+\");
 
             // Assert
-            Assert.Equal(encodedUrl, "SomeUrl+%2f%2b%5c");
+            Assert.Equal("SomeUrl+%2f%2b%5c", encodedUrl);
         }
 
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/ValueProviderDictionaryTest.cs
+++ b/test/System.Web.Mvc.Test/Test/ValueProviderDictionaryTest.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Specialized;
 using System.Globalization;
-using System.Threading;
 using System.Web.Routing;
 using System.Web.TestUtil;
 using Microsoft.TestCommon;
@@ -110,9 +109,9 @@ namespace System.Web.Mvc.Test
             // Assert
             Assert.NotNull(result);
             Assert.Equal("fooFromForm", result.AttemptedValue);
-            string[] stringValue = Assert.IsType<string[]>(result.RawValue);
-            Assert.Single(stringValue);
-            Assert.Equal("fooFromForm", stringValue[0]);
+            string[] stringValues = Assert.IsType<string[]>(result.RawValue);
+            string stringValue = Assert.Single(stringValues);
+            Assert.Equal("fooFromForm", stringValue);
             Assert.Equal(CultureInfo.GetCultureInfo("fr-FR"), result.Culture);
         }
 
@@ -132,12 +131,13 @@ namespace System.Web.Mvc.Test
             // Assert
             Assert.NotNull(result);
             Assert.Equal("bazFromQueryString", result.AttemptedValue);
-            string[] stringValue = Assert.IsType<string[]>(result.RawValue);
-            Assert.Single(stringValue);
-            Assert.Equal("bazFromQueryString", stringValue[0]);
+            string[] stringValues = Assert.IsType<string[]>(result.RawValue);
+            string stringValue = Assert.Single(stringValues);
+            Assert.Equal("bazFromQueryString", stringValue);
             Assert.Equal(CultureInfo.InvariantCulture, result.Culture);
         }
 
+        [Fact]
         public void ValueFromRoute()
         {
             // Arrange

--- a/test/System.Web.Mvc.Test/Test/ValueProviderFactoryCollectionTest.cs
+++ b/test/System.Web.Mvc.Test/Test/ValueProviderFactoryCollectionTest.cs
@@ -61,9 +61,9 @@ namespace System.Web.Mvc.Test
         public void ValueProviderFactoryCollectionCombinedItemsCaches()
         {
             // Arrange
-            var factories = new ValueProviderFactory[] 
+            var factories = new ValueProviderFactory[]
             {
-                new Mock<ValueProviderFactory>(MockBehavior.Strict).Object, 
+                new Mock<ValueProviderFactory>(MockBehavior.Strict).Object,
                 new Mock<ValueProviderFactory>(MockBehavior.Strict).Object
             };
             var collection = new ValueProviderFactoryCollection(factories);
@@ -104,9 +104,9 @@ namespace System.Web.Mvc.Test
         private static void TestCacheReset(Action<ValueProviderFactoryCollection> mutatingAction)
         {
             // Arrange
-            var providers = new List<ValueProviderFactory>() 
+            var providers = new List<ValueProviderFactory>()
             {
-                new Mock<ValueProviderFactory>(MockBehavior.Strict).Object, 
+                new Mock<ValueProviderFactory>(MockBehavior.Strict).Object,
                 new Mock<ValueProviderFactory>(MockBehavior.Strict).Object
             };
             var collection = new ValueProviderFactoryCollection(providers);
@@ -212,8 +212,8 @@ namespace System.Web.Mvc.Test
             collection[0] = newFactory;
 
             // Assert
-            Assert.Single(collection);
-            Assert.Equal(newFactory, collection[0]);
+            ValueProviderFactory factory = Assert.Single(collection);
+            Assert.Equal(newFactory, factory);
         }
 
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/ValueProviderResultTest.cs
+++ b/test/System.Web.Mvc.Test/Test/ValueProviderResultTest.cs
@@ -67,8 +67,8 @@ namespace System.Web.Mvc.Test
 
             // Assert
             Assert.NotNull(converted);
-            Assert.Single(converted);
-            Assert.Equal("42", converted[0]);
+            string value = Assert.Single(converted);
+            Assert.Equal("42", value);
         }
 
         [Fact]
@@ -96,7 +96,7 @@ namespace System.Web.Mvc.Test
             DefaultModelBinderTest.StringContainer returned = (DefaultModelBinderTest.StringContainer)vpr.ConvertTo(typeof(DefaultModelBinderTest.StringContainer));
 
             // Assert
-            Assert.Equal(returned.Value, "someValue (fr-FR)");
+            Assert.Equal("someValue (fr-FR)", returned.Value);
         }
 
         [Fact]
@@ -138,7 +138,7 @@ namespace System.Web.Mvc.Test
             string returned = (string)vpr.ConvertTo(typeof(string));
 
             // Assert
-            Assert.Equal(returned, "someValue (en-US)");
+            Assert.Equal("someValue (en-US)", returned);
         }
 
         [Fact]
@@ -216,7 +216,7 @@ namespace System.Web.Mvc.Test
             object outValue = vpr.ConvertTo(typeof(MyEnum));
 
             // Assert
-            Assert.Equal(outValue, MyEnum.Value1);
+            Assert.Equal(MyEnum.Value1, outValue);
         }
 
         [Fact]
@@ -229,7 +229,7 @@ namespace System.Web.Mvc.Test
             object outValue = vpr.ConvertTo(typeof(MyEnum));
 
             // Assert
-            Assert.Equal(outValue, MyEnum.Value1);
+            Assert.Equal(MyEnum.Value1, outValue);
         }
 
         [Fact]
@@ -242,7 +242,7 @@ namespace System.Web.Mvc.Test
             object outValue = vpr.ConvertTo(typeof(MyEnum));
 
             // Assert
-            Assert.Equal(outValue, MyEnum.Value1);
+            Assert.Equal(MyEnum.Value1, outValue);
         }
 
         [Fact]
@@ -403,7 +403,7 @@ namespace System.Web.Mvc.Test
             DefaultModelBinderTest.StringContainer returned = (DefaultModelBinderTest.StringContainer)vpr.ConvertTo(typeof(DefaultModelBinderTest.StringContainer), gbCulture);
 
             // Assert
-            Assert.Equal(returned.Value, "someValue (en-GB)");
+            Assert.Equal("someValue (en-GB)", returned.Value);
         }
 
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/ViewContextTest.cs
+++ b/test/System.Web.Mvc.Test/Test/ViewContextTest.cs
@@ -110,10 +110,10 @@ namespace System.Web.Mvc.Test
             Assert.False(viewContext.ClientValidationEnabled);
             viewContext.ClientValidationEnabled = true;
             Assert.True(viewContext.ClientValidationEnabled);
-            Assert.Equal(true, scope[ViewContext.ClientValidationKeyName]);
+            Assert.Equal((object)true, scope[ViewContext.ClientValidationKeyName]);
             viewContext.ClientValidationEnabled = false;
             Assert.False(viewContext.ClientValidationEnabled);
-            Assert.Equal(false, scope[ViewContext.ClientValidationKeyName]);
+            Assert.Equal((object)false, scope[ViewContext.ClientValidationKeyName]);
         }
 
         [Fact]
@@ -129,10 +129,10 @@ namespace System.Web.Mvc.Test
             Assert.False(viewContext.UnobtrusiveJavaScriptEnabled);
             viewContext.UnobtrusiveJavaScriptEnabled = true;
             Assert.True(viewContext.UnobtrusiveJavaScriptEnabled);
-            Assert.Equal(true, scope[ViewContext.UnobtrusiveJavaScriptKeyName]);
+            Assert.Equal((object)true, scope[ViewContext.UnobtrusiveJavaScriptKeyName]);
             viewContext.UnobtrusiveJavaScriptEnabled = false;
             Assert.False(viewContext.UnobtrusiveJavaScriptEnabled);
-            Assert.Equal(false, scope[ViewContext.UnobtrusiveJavaScriptKeyName]);
+            Assert.Equal((object)false, scope[ViewContext.UnobtrusiveJavaScriptKeyName]);
         }
 
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/ViewEngineCollectionTest.cs
+++ b/test/System.Web.Mvc.Test/Test/ViewEngineCollectionTest.cs
@@ -176,10 +176,10 @@ namespace System.Web.Mvc.Test
             // Assert
             Assert.Null(result.View);
             Assert.Equal(4, result.SearchedLocations.Count());
-            Assert.True(result.SearchedLocations.Contains("location1"));
-            Assert.True(result.SearchedLocations.Contains("location2"));
-            Assert.True(result.SearchedLocations.Contains("location3"));
-            Assert.True(result.SearchedLocations.Contains("location4"));
+            Assert.Contains("location1", result.SearchedLocations);
+            Assert.Contains("location2", result.SearchedLocations);
+            Assert.Contains("location3", result.SearchedLocations);
+            Assert.Contains("location4", result.SearchedLocations);
         }
 
         [Fact]
@@ -199,8 +199,8 @@ namespace System.Web.Mvc.Test
             // Assert
             Assert.Null(result.View);
             Assert.Equal(2, result.SearchedLocations.Count());
-            Assert.True(result.SearchedLocations.Contains("location1"));
-            Assert.True(result.SearchedLocations.Contains("location2"));
+            Assert.Contains("location1", result.SearchedLocations);
+            Assert.Contains("location2", result.SearchedLocations);
         }
 
         [Fact]
@@ -433,10 +433,10 @@ namespace System.Web.Mvc.Test
             // Assert
             Assert.Null(result.View);
             Assert.Equal(4, result.SearchedLocations.Count());
-            Assert.True(result.SearchedLocations.Contains("location1"));
-            Assert.True(result.SearchedLocations.Contains("location2"));
-            Assert.True(result.SearchedLocations.Contains("location3"));
-            Assert.True(result.SearchedLocations.Contains("location4"));
+            Assert.Contains("location1", result.SearchedLocations);
+            Assert.Contains("location2", result.SearchedLocations);
+            Assert.Contains("location3", result.SearchedLocations);
+            Assert.Contains("location4", result.SearchedLocations);
         }
 
         [Fact]
@@ -456,8 +456,8 @@ namespace System.Web.Mvc.Test
             // Assert
             Assert.Null(result.View);
             Assert.Equal(2, result.SearchedLocations.Count());
-            Assert.True(result.SearchedLocations.Contains("location1"));
-            Assert.True(result.SearchedLocations.Contains("location2"));
+            Assert.Contains("location1", result.SearchedLocations);
+            Assert.Contains("location2", result.SearchedLocations);
         }
 
         [Fact]

--- a/test/System.Web.Mvc.Test/Test/VirtualPathProviderViewEngineTest.cs
+++ b/test/System.Web.Mvc.Test/Test/VirtualPathProviderViewEngineTest.cs
@@ -233,8 +233,8 @@ namespace System.Web.Mvc.Test
             // Assert
             Assert.Null(result.View);
             Assert.Equal(2, result.SearchedLocations.Count()); // Both view and master locations
-            Assert.True(result.SearchedLocations.Contains("~/vpath/controllerName/viewName.view"));
-            Assert.True(result.SearchedLocations.Contains("~/vpath/controllerName/masterName.master"));
+            Assert.Contains("~/vpath/controllerName/viewName.view", result.SearchedLocations);
+            Assert.Contains("~/vpath/controllerName/masterName.master", result.SearchedLocations);
         }
 
         [Fact]
@@ -278,8 +278,8 @@ namespace System.Web.Mvc.Test
             // Assert
             Assert.Null(result.View);
             Assert.Equal(2, result.SearchedLocations.Count()); // View was found, not included in 'searched locations'
-            Assert.True(result.SearchedLocations.Contains("~/vpath/areaName/controllerName/masterName.master"));
-            Assert.True(result.SearchedLocations.Contains("~/vpath/controllerName/masterName.master"));
+            Assert.Contains("~/vpath/areaName/controllerName/masterName.master", result.SearchedLocations);
+            Assert.Contains("~/vpath/controllerName/masterName.master", result.SearchedLocations);
         }
 
         [Fact]

--- a/test/System.Web.Mvc.Test/packages.config
+++ b/test/System.Web.Mvc.Test/packages.config
@@ -3,7 +3,9 @@
   <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />


### PR DESCRIPTION
- part of #65

Few manual changes:
- use `Assert.IsAssignableFrom<T>(...)`, `Assert.IsType<T>(...)` and `Assert.Single(...)` return values
- fix xUnit1026, "`[Theory]` method doesn't use all parameters" issues
  - turn `[Theory]` that used no parameters into a `[Fact]`
  - add new dataset properties; see `EncodedDataSets` in particular
- `Assert.Equal<T>(...)` -> `Assert.Equal(...)`
- avoid Linq's `.Where` inside `Assert.Contains(...)` and similar