### PR TITLE
Add xUnit analyzers and take xUnit fixer suggestions (5 of 5): System.Web.Razor.Test to end

### DIFF
--- a/src/System.Web.Http/Validation/BodyModelValidatorContext.cs
+++ b/src/System.Web.Http/Validation/BodyModelValidatorContext.cs
@@ -13,6 +13,18 @@ namespace System.Web.Http.Validation
     /// </summary>
     public class BodyModelValidatorContext
     {
+        public BodyModelValidatorContext(ModelStateDictionary modelState)
+        {
+            if (modelState == null)
+            {
+                throw new ArgumentNullException("modelState");
+            }
+
+            KeyBuilders = new Stack<IBodyModelValidatorKeyBuilder>();
+            ModelState = modelState;
+            Visited = new HashSet<object>(ReferenceEqualityComparer.Instance);
+        }
+
         /// <summary>
         /// Gets or sets the <see cref="ModelMetadataProvider"/> used to provide the model metadata.
         /// </summary>
@@ -29,21 +41,21 @@ namespace System.Web.Http.Validation
         public IModelValidatorCache ValidatorCache { get; set; }
 
         /// <summary>
-        /// Gets or sets the current <see cref="ModelStateDictionary"/>.
+        /// Gets the current <see cref="ModelStateDictionary"/>.
         /// </summary>
-        public ModelStateDictionary ModelState { get; set; }
+        public ModelStateDictionary ModelState { get; private set; }
 
         /// <summary>
-        /// Gets or sets the set of model objects visited in this validation. Includes the model being validated in the
+        /// Gets the set of model objects visited in this validation. Includes the model being validated in the
         /// current scope.
         /// </summary>
-        public HashSet<object> Visited { get; set; }
+        public HashSet<object> Visited { get; private set; }
 
         /// <summary>
-        /// Gets or sets the stack of <see cref="IBodyModelValidatorKeyBuilder"/>s used in this validation. Includes
+        /// Gets the stack of <see cref="IBodyModelValidatorKeyBuilder"/>s used in this validation. Includes
         /// the <see cref="IBodyModelValidatorKeyBuilder"/> to generate model state keys for the current scope.
         /// </summary>
-        public Stack<IBodyModelValidatorKeyBuilder> KeyBuilders { get; set; }
+        public Stack<IBodyModelValidatorKeyBuilder> KeyBuilders { get; private set; }
 
         /// <summary>
         /// Gets or sets the model state prefix for the root scope of this validation.

--- a/src/System.Web.Http/Validation/DefaultBodyModelValidator.cs
+++ b/src/System.Web.Http/Validation/DefaultBodyModelValidator.cs
@@ -59,14 +59,11 @@ namespace System.Web.Http.Validation
             }
 
             ModelMetadata metadata = metadataProvider.GetMetadataForType(() => model, type);
-            BodyModelValidatorContext validationContext = new BodyModelValidatorContext
+            BodyModelValidatorContext validationContext = new BodyModelValidatorContext(actionContext.ModelState)
             {
                 MetadataProvider = metadataProvider,
                 ActionContext = actionContext,
                 ValidatorCache = actionContext.GetValidatorCache(),
-                ModelState = actionContext.ModelState,
-                Visited = new HashSet<object>(ReferenceEqualityComparer.Instance),
-                KeyBuilders = new Stack<IBodyModelValidatorKeyBuilder>(),
                 RootPrefix = keyPrefix
             };
             return ValidateNodeAndChildren(metadata, validationContext, container: null, validators: null);

--- a/test/System.Web.Razor.Test/Parser/ParserContextTest.cs
+++ b/test/System.Web.Razor.Test/Parser/ParserContextTest.cs
@@ -133,8 +133,8 @@ namespace System.Web.Razor.Test.Parser
             context.StartBlock(BlockType.Expression);
 
             // Assert
-            Assert.Equal(1, context.BlockStack.Count);
-            Assert.Equal(BlockType.Expression, context.BlockStack.Peek().Type);
+            BlockBuilder blockBuilder = Assert.Single(context.BlockStack);
+            Assert.Equal(BlockType.Expression, blockBuilder.Type);
         }
 
         [Fact]
@@ -150,10 +150,10 @@ namespace System.Web.Razor.Test.Parser
             context.EndBlock();
 
             // Assert
-            Assert.Equal(1, context.BlockStack.Count);
-            Assert.Equal(BlockType.Expression, context.BlockStack.Peek().Type);
-            Assert.Equal(1, context.BlockStack.Peek().Children.Count);
-            Assert.Equal(BlockType.Statement, ((Block)context.BlockStack.Peek().Children[0]).Type);
+            BlockBuilder blockBuilder = Assert.Single(context.BlockStack);
+            Assert.Equal(BlockType.Expression, blockBuilder.Type);
+            SyntaxTreeNode node = Assert.Single(blockBuilder.Children);
+            Assert.Equal(BlockType.Statement, Assert.IsType<Block>(node).Type);
         }
 
         [Fact]

--- a/test/System.Web.Razor.Test/RazorDirectiveAttributeTest.cs
+++ b/test/System.Web.Razor.Test/RazorDirectiveAttributeTest.cs
@@ -25,7 +25,7 @@ namespace System.Web.Razor.Test
 
             // Assert
             Assert.True(attribute.AllowMultiple);
-            Assert.True(attribute.ValidOn == AttributeTargets.Class);
+            Assert.Equal(AttributeTargets.Class, attribute.ValidOn);
             Assert.True(attribute.Inherited);
         }
 

--- a/test/System.Web.Razor.Test/System.Web.Razor.Test.csproj
+++ b/test/System.Web.Razor.Test/System.Web.Razor.Test.csproj
@@ -475,9 +475,6 @@
   <ItemGroup>
     <EmbeddedResource Include="TestFiles\CodeGenerator\VB\Output\FunctionsBlock.DesignTime.Tabs.vb" />
   </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
-  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/System.Web.Razor.Test/System.Web.Razor.Test.csproj
+++ b/test/System.Web.Razor.Test/System.Web.Razor.Test.csproj
@@ -475,6 +475,9 @@
   <ItemGroup>
     <EmbeddedResource Include="TestFiles\CodeGenerator\VB\Output\FunctionsBlock.DesignTime.Tabs.vb" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/System.Web.Razor.Test/Text/LookaheadTextReaderTestBase.cs
+++ b/test/System.Web.Razor.Test/Text/LookaheadTextReaderTestBase.cs
@@ -159,9 +159,7 @@ namespace System.Web.Razor.Test.Text
             Assert.Equal(expectedRaw, actualLocation.AbsoluteIndex);
             Assert.Equal(expectedChar, actualLocation.CharacterIndex);
             Assert.Equal(expectedLine, actualLocation.LineIndex);
-
-            // Workaround xunit/xunit#1502
-            Assert.Equal('b' - '\0', reader.Peek());
+            Assert.Equal('b', reader.Peek());
             Assert.Equal(read, readMethod(reader));
         }
 
@@ -190,9 +188,7 @@ namespace System.Web.Razor.Test.Text
             Assert.Equal(0, actualLocation.LineIndex);
             Assert.Equal(1, reader.CurrentLocation.CharacterIndex);
             Assert.Equal(0, reader.CurrentLocation.LineIndex);
-
-            // Workaround xunit/xunit#1502
-            Assert.Equal('b' - '\0', reader.Peek());
+            Assert.Equal('b', reader.Peek());
         }
 
         private static void RunAll(Action<StringBuilder, LookaheadTextReader>[] readerCommands, StringBuilder builder, LookaheadTextReader reader)

--- a/test/System.Web.Razor.Test/Text/LookaheadTextReaderTestBase.cs
+++ b/test/System.Web.Razor.Test/Text/LookaheadTextReaderTestBase.cs
@@ -159,7 +159,9 @@ namespace System.Web.Razor.Test.Text
             Assert.Equal(expectedRaw, actualLocation.AbsoluteIndex);
             Assert.Equal(expectedChar, actualLocation.CharacterIndex);
             Assert.Equal(expectedLine, actualLocation.LineIndex);
-            Assert.Equal('b', reader.Peek());
+
+            // Workaround xunit/xunit#1502
+            Assert.Equal('b' - '\0', reader.Peek());
             Assert.Equal(read, readMethod(reader));
         }
 
@@ -188,7 +190,9 @@ namespace System.Web.Razor.Test.Text
             Assert.Equal(0, actualLocation.LineIndex);
             Assert.Equal(1, reader.CurrentLocation.CharacterIndex);
             Assert.Equal(0, reader.CurrentLocation.LineIndex);
-            Assert.Equal('b', reader.Peek());
+
+            // Workaround xunit/xunit#1502
+            Assert.Equal('b' - '\0', reader.Peek());
         }
 
         private static void RunAll(Action<StringBuilder, LookaheadTextReader>[] readerCommands, StringBuilder builder, LookaheadTextReader reader)

--- a/test/System.Web.Razor.Test/Utils/MiscAssert.cs
+++ b/test/System.Web.Razor.Test/Utils/MiscAssert.cs
@@ -9,6 +9,7 @@ namespace System.Web.Razor.Test.Utils
     public static class MiscAssert
     {
         public static void AssertBothNullOrPropertyEqual<T>(T expected, T actual, Expression<Func<T, object>> propertyExpr, string objectName)
+            where T : class
         {
             // Unpack convert expressions
             Expression expr = propertyExpr.Body;

--- a/test/System.Web.Razor.Test/packages.config
+++ b/test/System.Web.Razor.Test/packages.config
@@ -2,7 +2,9 @@
 <packages>
   <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
+  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />

--- a/test/System.Web.Razor.Test/packages.config
+++ b/test/System.Web.Razor.Test/packages.config
@@ -2,9 +2,7 @@
 <packages>
   <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
-  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
-  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />

--- a/test/System.Web.WebPages.Administration.Test/PackageManagerModuleTest.cs
+++ b/test/System.Web.WebPages.Administration.Test/PackageManagerModuleTest.cs
@@ -22,7 +22,7 @@ namespace System.Web.WebPages.Administration.Test
             sourceFile.Setup(c => c.ReadSources()).Callback(() => sourceFileCalled = true);
             ISet<WebPackageSource> set = new HashSet<WebPackageSource>();
 
-            // Act 
+            // Act
             PackageManagerModule.InitPackageSourceFile(sourceFile.Object, ref set);
 
             // Assert
@@ -42,9 +42,9 @@ namespace System.Web.WebPages.Administration.Test
             PackageManagerModule.InitPackageSourceFile(sourceFile.Object, ref set);
 
             Assert.NotNull(set);
-            Assert.Equal(set.Count(), 2);
-            Assert.Equal(set.First().Source, "http://go.microsoft.com/fwlink/?LinkID=226946");
-            Assert.Equal(set.Last().Source, "http://go.microsoft.com/fwlink/?LinkID=226948");
+            Assert.Equal(2, set.Count());
+            Assert.Equal("http://go.microsoft.com/fwlink/?LinkID=226946", set.First().Source);
+            Assert.Equal("http://go.microsoft.com/fwlink/?LinkID=226948", set.Last().Source);
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace System.Web.WebPages.Administration.Test
 
             // Assert
             Assert.NotNull(set);
-            Assert.Equal(set.Count(), 2);
+            Assert.Equal(2, set.Count());
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace System.Web.WebPages.Administration.Test
             bool returnValue = PackageManagerModule.AddPackageSource(sourceFile.Object, set, new WebPackageSource(source: "http://www.microsoft.com/feed3", name: "Feed3"));
 
             // Assert
-            Assert.Equal(set.Count(), 3);
+            Assert.Equal(3, set.Count());
             Assert.True(writeCalled);
             Assert.True(returnValue);
         }
@@ -94,7 +94,7 @@ namespace System.Web.WebPages.Administration.Test
             bool returnValue = PackageManagerModule.AddPackageSource(sourceFile.Object, set, new WebPackageSource(source: "http://www.microsoft.com/feed1", name: "Feed1"));
 
             // Assert
-            Assert.Equal(set.Count(), 2);
+            Assert.Equal(2, set.Count());
             Assert.False(writeCalled);
             Assert.False(returnValue);
         }
@@ -112,8 +112,8 @@ namespace System.Web.WebPages.Administration.Test
             PackageManagerModule.RemovePackageSource(sourceFile.Object, set, "feed1");
 
             // Assert
-            Assert.Equal(set.Count(), 1);
-            Assert.False(set.Any(s => s.Name == "Feed1"));
+            Assert.Single(set);
+            Assert.DoesNotContain(set, s => s.Name == "Feed1");
             Assert.True(writeCalled);
         }
 
@@ -130,7 +130,7 @@ namespace System.Web.WebPages.Administration.Test
             PackageManagerModule.RemovePackageSource(sourceFile.Object, set, "feed3");
 
             // Assert
-            Assert.Equal(set.Count(), 2);
+            Assert.Equal(2, set.Count());
             Assert.False(writeCalled);
         }
 

--- a/test/System.Web.WebPages.Administration.Test/PackagesSourceFileTest.cs
+++ b/test/System.Web.WebPages.Administration.Test/PackagesSourceFileTest.cs
@@ -129,20 +129,20 @@ namespace System.Web.WebPages.Administration.Test
 
             // Assert
             var document = XDocument.Parse(result);
-            Assert.Equal(document.Root.Name, "sources");
-            Assert.Equal(document.Root.Elements().Count(), 2);
+            Assert.Equal("sources", document.Root.Name);
+            Assert.Equal(2, document.Root.Elements().Count());
 
             var firstFeed = document.Root.Elements().First();
-            Assert.Equal(firstFeed.Name, "source");
-            Assert.Equal(firstFeed.Attribute("displayname").Value, "Feed1");
-            Assert.Equal(firstFeed.Attribute("url").Value, "http://www.microsoft.com/Feed1");
-            Assert.Equal(firstFeed.Attribute("filterpreferred").Value, "false");
+            Assert.Equal("source", firstFeed.Name);
+            Assert.Equal("Feed1", firstFeed.Attribute("displayname").Value);
+            Assert.Equal("http://www.microsoft.com/Feed1", firstFeed.Attribute("url").Value);
+            Assert.Equal("false", firstFeed.Attribute("filterpreferred").Value);
 
             var secondFeed = document.Root.Elements().Last();
-            Assert.Equal(secondFeed.Name, "source");
-            Assert.Equal(secondFeed.Attribute("displayname").Value, "Feed2");
-            Assert.Equal(secondFeed.Attribute("url").Value, "http://www.microsoft.com/Feed2");
-            Assert.Equal(secondFeed.Attribute("filterpreferred").Value, "true");
+            Assert.Equal("source", secondFeed.Name);
+            Assert.Equal("Feed2", secondFeed.Attribute("displayname").Value);
+            Assert.Equal("http://www.microsoft.com/Feed2", secondFeed.Attribute("url").Value);
+            Assert.Equal("true", secondFeed.Attribute("filterpreferred").Value);
         }
     }
 }

--- a/test/System.Web.WebPages.Administration.Test/PageUtilsTest.cs
+++ b/test/System.Web.WebPages.Administration.Test/PageUtilsTest.cs
@@ -99,7 +99,7 @@ namespace System.Web.WebPages.Administration.Test
             PageUtils.PersistFilter(response.Object, "my-cookie", new Dictionary<string, string>());
 
             // Assert
-            Assert.Equal(1, cookies.Count);
+            Assert.Single(cookies);
         }
 
         [Fact]
@@ -115,8 +115,8 @@ namespace System.Web.WebPages.Administration.Test
 
             // Assert
             var cookie = cookies["my-cookie"];
-            Assert.Equal(cookie["a"], "b");
-            Assert.Equal(cookie["x"], "y");
+            Assert.Equal("b", cookie["a"]);
+            Assert.Equal("y", cookie["x"]);
         }
 
         [Fact]

--- a/test/System.Web.WebPages.Administration.Test/PreApplicationStartCodeTest.cs
+++ b/test/System.Web.WebPages.Administration.Test/PreApplicationStartCodeTest.cs
@@ -22,8 +22,8 @@ namespace System.Web.WebPages.Administration.Test
 
                 // TODO: Need a way to see if the module was actually registered
                 var registeredAssemblies = ApplicationPart.GetRegisteredParts().ToList();
-                Assert.Equal(1, registeredAssemblies.Count);
-                registeredAssemblies.First().Assembly.Equals(adminPackageAssembly);
+                ApplicationPart part = Assert.Single(registeredAssemblies);
+                part.Assembly.Equals(adminPackageAssembly);
             });
         }
 

--- a/test/System.Web.WebPages.Administration.Test/System.Web.WebPages.Administration.Test.csproj
+++ b/test/System.Web.WebPages.Administration.Test/System.Web.WebPages.Administration.Test.csproj
@@ -91,6 +91,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/System.Web.WebPages.Administration.Test/WebProjectManagerTest.cs
+++ b/test/System.Web.WebPages.Administration.Test/WebProjectManagerTest.cs
@@ -67,7 +67,7 @@ namespace System.Web.WebPages.Administration.Test
             // Act
             var repositoryFolder = WebProjectManager.GetWebRepositoryDirectory(siteRoot);
 
-            Assert.Equal(repositoryFolder, @"my-site\App_Data\packages");
+            Assert.Equal(@"my-site\App_Data\packages", repositoryFolder);
         }
 
         [Fact]
@@ -95,7 +95,7 @@ namespace System.Web.WebPages.Administration.Test
 
             // Assert
             Assert.NotNull(package);
-            Assert.Equal(package.Id, "A");
+            Assert.Equal("A", package.Id);
         }
 
         [Fact]
@@ -111,8 +111,8 @@ namespace System.Web.WebPages.Administration.Test
 
             // Assert
             Assert.Equal(2, result.Count());
-            Assert.True(result.Any(c => c.Id == "C"));
-            Assert.True(result.Any(c => c.Id == "B"));
+            Assert.Contains(result, c => c.Id == "C");
+            Assert.Contains(result, c => c.Id == "B");
         }
 
         [Fact]

--- a/test/System.Web.WebPages.Administration.Test/WebProjectSystemTest.cs
+++ b/test/System.Web.WebPages.Administration.Test/WebProjectSystemTest.cs
@@ -80,7 +80,7 @@ namespace System.Web.WebPages.Administration.Test
             XDocument document = XDocument.Load(memoryStream);
 
             var element = document.Root;
-            Assert.Equal(element.Name, "configuration");
+            Assert.Equal("configuration", element.Name);
 
             // Use SingleOrDefault to ensure there's exactly one element with that name
             var assemblies = document.Root
@@ -126,7 +126,7 @@ namespace System.Web.WebPages.Administration.Test
             XDocument document = XDocument.Load(memoryStream);
 
             var element = document.Root;
-            Assert.Equal(element.Name, "configuration");
+            Assert.Equal("configuration", element.Name);
 
             // Use SingleOrDefault to ensure there's exactly one element with that name
             var assemblies = document.Root
@@ -187,7 +187,7 @@ namespace System.Web.WebPages.Administration.Test
             XDocument document = XDocument.Load(memoryStream);
 
             var element = document.Root;
-            Assert.Equal(element.Name, "configuration");
+            Assert.Equal("configuration", element.Name);
 
             // Use SingleOrDefault to ensure there's exactly one element with that name
             var assemblies = document.Root

--- a/test/System.Web.WebPages.Administration.Test/packages.config
+++ b/test/System.Web.WebPages.Administration.Test/packages.config
@@ -3,7 +3,9 @@
   <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
   <package id="Nuget.Core" version="1.6.2" targetFramework="net452" />
+  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />

--- a/test/System.Web.WebPages.Deployment.Test/PreApplicationStartCodeTest.cs
+++ b/test/System.Web.WebPages.Deployment.Test/PreApplicationStartCodeTest.cs
@@ -342,7 +342,7 @@ In order to use this site, specify a version in the site’s web.config file. Fo
 
             // Assert
             Assert.Equal("Changes were detected in the Web Pages runtime version that require your application to be recompiled. Refresh your browser window to continue.", ex.Message);
-            Assert.Equal(ex.Data["WebPages.VersionChange"], true);
+            Assert.Equal((object)true, ex.Data["WebPages.VersionChange"]);
             Assert.False(registeredForChangeNotification);
             VerifyVersionFile(buildManager, new Version(LatestVersion));
             Assert.True(fileSystem.FileExists(@"site\bin\WebPagesRecompilation.deleteme"));

--- a/test/System.Web.WebPages.Deployment.Test/System.Web.WebPages.Deployment.Test.csproj
+++ b/test/System.Web.WebPages.Deployment.Test/System.Web.WebPages.Deployment.Test.csproj
@@ -83,6 +83,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/System.Web.WebPages.Deployment.Test/packages.config
+++ b/test/System.Web.WebPages.Deployment.Test/packages.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />

--- a/test/System.Web.WebPages.Razor.Test/System.Web.WebPages.Razor.Test.csproj
+++ b/test/System.Web.WebPages.Razor.Test/System.Web.WebPages.Razor.Test.csproj
@@ -79,6 +79,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/System.Web.WebPages.Razor.Test/WebCodeRazorEngineHostTest.cs
+++ b/test/System.Web.WebPages.Razor.Test/WebCodeRazorEngineHostTest.cs
@@ -80,7 +80,7 @@ namespace System.Web.WebPages.Razor.Test
             host.PostProcessGeneratedCode(context);
 
             // Assert
-            Assert.Equal(0, context.GeneratedClass.Members.OfType<CodeMemberMethod>().Count());
+            Assert.Empty(context.GeneratedClass.Members.OfType<CodeMemberMethod>());
         }
 
         [Fact]

--- a/test/System.Web.WebPages.Razor.Test/WebPageRazorEngineHostTest.cs
+++ b/test/System.Web.WebPages.Razor.Test/WebPageRazorEngineHostTest.cs
@@ -55,7 +55,7 @@ namespace System.Web.WebPages.Razor.Test
             host.PostProcessGeneratedCode(context);
 
             // Assert
-            Assert.True(context.Namespace.Imports.OfType<CodeNamespaceImport>().Any(import => String.Equals("Foo.Bar", import.Namespace)));
+            Assert.Contains(context.Namespace.Imports.OfType<CodeNamespaceImport>(), import => String.Equals("Foo.Bar", import.Namespace));
         }
 
         [Fact]

--- a/test/System.Web.WebPages.Razor.Test/WebRazorHostFactoryTest.cs
+++ b/test/System.Web.WebPages.Razor.Test/WebRazorHostFactoryTest.cs
@@ -339,8 +339,8 @@ namespace System.Web.WebPages.Razor.Test
 
             // Assert
             Assert.NotNull(pages);
-            Assert.Equal(1, pages.Namespaces.Count);
-            Assert.Equal("System.Text.RegularExpressions", pages.Namespaces[0].Namespace);
+            NamespaceInfo namespaceInfo = Assert.IsType<NamespaceInfo>(Assert.Single(pages.Namespaces));
+            Assert.Equal("System.Text.RegularExpressions", namespaceInfo.Namespace);
         }
 
         [Fact]

--- a/test/System.Web.WebPages.Razor.Test/packages.config
+++ b/test/System.Web.WebPages.Razor.Test/packages.config
@@ -2,7 +2,9 @@
 <packages>
   <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
+  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />

--- a/test/System.Web.WebPages.Test/ApplicationParts/ApplicationPartRegistryTest.cs
+++ b/test/System.Web.WebPages.Test/ApplicationParts/ApplicationPartRegistryTest.cs
@@ -18,7 +18,7 @@ namespace System.Web.WebPages.Test.ApplicationModule
             var root1 = "~/myappmodule";
             var root2 = "~/myappmodule2/";
 
-            // Act 
+            // Act
             var actualPath11 = ApplicationPartRegistry.GetRootRelativeVirtualPath(root1, path1);
             var actualPath12 = ApplicationPartRegistry.GetRootRelativeVirtualPath(root1, path2);
             var actualPath21 = ApplicationPartRegistry.GetRootRelativeVirtualPath(root2, path1);
@@ -114,7 +114,7 @@ namespace System.Web.WebPages.Test.ApplicationModule
 
             // Assert
             Assert.True(dictionary.Exists("~/mymodule/Page1"));
-            Assert.Equal(dictionary.CreateInstance("~/mymodule/Page1"), "foo");
+            Assert.Equal("foo", dictionary.CreateInstance("~/mymodule/Page1"));
             Assert.False(dictionary.Exists("~/mymodule/Page2"));
             Assert.False(dictionary.Exists("~/mymodule/Page3"));
         }

--- a/test/System.Web.WebPages.Test/ApplicationParts/ApplicationPartTest.cs
+++ b/test/System.Web.WebPages.Test/ApplicationParts/ApplicationPartTest.cs
@@ -30,7 +30,7 @@ namespace System.Web.WebPages.Test
             var virtualPath = ApplicationPart.ResolveVirtualPath(appPartRoot, basePath, path);
 
             // Assert
-            Assert.Equal(virtualPath, "~/base/somefile");
+            Assert.Equal("~/base/somefile", virtualPath);
         }
 
         [Fact]
@@ -45,7 +45,7 @@ namespace System.Web.WebPages.Test
             var virtualPath = ApplicationPart.ResolveVirtualPath(appPartRoot, basePath, path);
 
             // Assert
-            Assert.Equal(virtualPath, "~/app/somefile");
+            Assert.Equal("~/app/somefile", virtualPath);
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace System.Web.WebPages.Test
             var virtualPath = ApplicationPart.ResolveVirtualPath(appPartRoot, basePath, path);
 
             // Assert
-            Assert.Equal(virtualPath, "~/somefile");
+            Assert.Equal("~/somefile", virtualPath);
         }
 
         [Fact]
@@ -88,7 +88,7 @@ namespace System.Web.WebPages.Test
             var name = ApplicationPart.GetResourceNameFromVirtualPath(moduleName, path);
 
             // Assert
-            Assert.Equal(name, "my-module.bar.foo");
+            Assert.Equal("my-module.bar.foo", name);
         }
 
         [Fact]
@@ -102,7 +102,7 @@ namespace System.Web.WebPages.Test
             var name = ApplicationPart.GetResourceNameFromVirtualPath(moduleName, path);
 
             // Assert
-            Assert.Equal(name, "my-module.program_files.data_files.my file .foo");
+            Assert.Equal("my-module.program_files.data_files.my file .foo", name);
         }
 
         [Fact]

--- a/test/System.Web.WebPages.Test/Extensions/HttpResponseExtensionsTest.cs
+++ b/test/System.Web.WebPages.Test/Extensions/HttpResponseExtensionsTest.cs
@@ -121,11 +121,11 @@ namespace Microsoft.WebPages.Test.Helpers
                                            new[] { "baz", "baz2" }, HttpCacheability.Public);
 
             // Assert
-            Assert.Equal(varyByParams["foo"], true);
-            Assert.Equal(varyByHeader["bar"], true);
-            Assert.Equal(varyByHeader["bar2"], true);
-            Assert.Equal(varyByContentEncoding["baz"], true);
-            Assert.Equal(varyByContentEncoding["baz2"], true);
+            Assert.True(varyByParams["foo"]);
+            Assert.True(varyByHeader["bar"]);
+            Assert.True(varyByHeader["bar2"]);
+            Assert.True(varyByContentEncoding["baz"]);
+            Assert.True(varyByContentEncoding["baz2"]);
         }
     }
 }

--- a/test/System.Web.WebPages.Test/Extensions/StringExtensionsTest.cs
+++ b/test/System.Web.WebPages.Test/Extensions/StringExtensionsTest.cs
@@ -85,14 +85,14 @@ namespace System.Web.WebPages.Test
             decimal value = 12345.00M;
             using (new CultureReplacer("ar-DZ"))
             {
-                Assert.Equal(value.ToString(CultureInfo.CurrentCulture), "12345.00");
-                Assert.Equal(value.ToString(), "12345.00");
+                Assert.Equal("12345.00", value.ToString(CultureInfo.CurrentCulture));
+                Assert.Equal("12345.00", value.ToString());
             }
 
             using (new CultureReplacer("bg-BG"))
             {
-                Assert.Equal(value.ToString(CultureInfo.CurrentCulture), "12345,00");
-                Assert.Equal(value.ToString(), "12345,00");
+                Assert.Equal("12345,00", value.ToString(CultureInfo.CurrentCulture));
+                Assert.Equal("12345,00", value.ToString());
             }
         }
 

--- a/test/System.Web.WebPages.Test/Helpers/AntiXsrf/AntiForgeryTokenStoreTest.cs
+++ b/test/System.Web.WebPages.Test/Helpers/AntiXsrf/AntiForgeryTokenStoreTest.cs
@@ -223,7 +223,7 @@ namespace System.Web.Helpers.AntiXsrf.Test
             tokenStore.SaveCookieToken(mockHttpContext.Object, token);
 
             // Assert
-            Assert.Equal(1, cookies.Count);
+            Assert.Single(cookies);
             HttpCookie cookie = cookies["cookie-name"];
 
             Assert.NotNull(cookie);

--- a/test/System.Web.WebPages.Test/Html/HtmlHelperTest.cs
+++ b/test/System.Web.WebPages.Test/Html/HtmlHelperTest.cs
@@ -35,7 +35,7 @@ namespace System.Web.WebPages.Test
             string encodedHtml = htmlHelper.Encode(text);
 
             // Assert
-            Assert.Equal(encodedHtml, "&lt;br /&gt;");
+            Assert.Equal("&lt;br /&gt;", encodedHtml);
         }
 
         [Fact]
@@ -63,7 +63,7 @@ namespace System.Web.WebPages.Test
             string encodedHtml = htmlHelper.Encode(text);
 
             // Assert
-            Assert.Equal(encodedHtml, "&lt;br /&gt;");
+            Assert.Equal("&lt;br /&gt;", encodedHtml);
         }
 
         [Fact]
@@ -195,6 +195,7 @@ namespace System.Web.WebPages.Test
                        };
         }
 
+#pragma warning disable xUnit1013 // Public method should be marked as test
         /// <summary>
         /// Will invoke a helper with overload that accepts custom attribute with a name containing
         /// and underscore as an anonymous object, and will then assert that the resulted html
@@ -202,6 +203,7 @@ namespace System.Web.WebPages.Test
         /// </summary>
         /// <param name="helperInvocation"></param>
         public static void AssertHelperTransformsAttributesUnderscoresToDashs(Func<HtmlHelper, object, IHtmlString> helperInvocation)
+#pragma warning restore xUnit1013 // Public method should be marked as test
         {
             // Arrange
             HtmlHelper helper = HtmlHelperFactory.Create();

--- a/test/System.Web.WebPages.Test/Html/HtmlHelperTest.cs
+++ b/test/System.Web.WebPages.Test/Html/HtmlHelperTest.cs
@@ -195,15 +195,13 @@ namespace System.Web.WebPages.Test
                        };
         }
 
-#pragma warning disable xUnit1013 // Public method should be marked as test
         /// <summary>
         /// Will invoke a helper with overload that accepts custom attribute with a name containing
         /// and underscore as an anonymous object, and will then assert that the resulted html
         /// has the attribute name underscore correctly transformed to a dash
         /// </summary>
         /// <param name="helperInvocation"></param>
-        public static void AssertHelperTransformsAttributesUnderscoresToDashs(Func<HtmlHelper, object, IHtmlString> helperInvocation)
-#pragma warning restore xUnit1013 // Public method should be marked as test
+        internal static void AssertHelperTransformsAttributesUnderscoresToDashs(Func<HtmlHelper, object, IHtmlString> helperInvocation)
         {
             // Arrange
             HtmlHelper helper = HtmlHelperFactory.Create();

--- a/test/System.Web.WebPages.Test/ScopeStorage/ScopeStorageDictionaryTest.cs
+++ b/test/System.Web.WebPages.Test/ScopeStorage/ScopeStorageDictionaryTest.cs
@@ -16,7 +16,7 @@ namespace System.Web.WebPages.Test
             var stateStorage = GetChainedStorageStateDictionary();
 
             // Act and Assert
-            Assert.Equal(stateStorage["f"], "f2");
+            Assert.Equal("f2", stateStorage["f"]);
         }
 
         [Fact]
@@ -26,8 +26,8 @@ namespace System.Web.WebPages.Test
             var stateStorage = GetChainedStorageStateDictionary();
 
             // Act and Assert
-            Assert.Equal(stateStorage["a"], "a2");
-            Assert.Equal(stateStorage["d"], "d2");
+            Assert.Equal("a2", stateStorage["a"]);
+            Assert.Equal("d2", stateStorage["d"]);
         }
 
         [Fact]
@@ -37,8 +37,8 @@ namespace System.Web.WebPages.Test
             var stateStorage = GetChainedStorageStateDictionary();
 
             // Act and Assert
-            Assert.Equal(stateStorage["c"], "c0");
-            Assert.Equal(stateStorage["b"], "b1");
+            Assert.Equal("c0", stateStorage["c"]);
+            Assert.Equal("b1", stateStorage["b"]);
         }
 
         [Fact]
@@ -99,12 +99,12 @@ namespace System.Web.WebPages.Test
             var scopeStorage = GetChainedStorageStateDictionary();
 
             // Act and Assert
-            Assert.Equal(scopeStorage["a"], "a2");
-            Assert.Equal(scopeStorage["b"], "b1");
-            Assert.Equal(scopeStorage["c"], "c0");
-            Assert.Equal(scopeStorage["d"], "d2");
-            Assert.Equal(scopeStorage["e"], "e1");
-            Assert.Equal(scopeStorage["f"], "f2");
+            Assert.Equal("a2", scopeStorage["a"]);
+            Assert.Equal("b1", scopeStorage["b"]);
+            Assert.Equal("c0", scopeStorage["c"]);
+            Assert.Equal("d2", scopeStorage["d"]);
+            Assert.Equal("e1", scopeStorage["e"]);
+            Assert.Equal("f2", scopeStorage["f"]);
         }
 
         [Fact]
@@ -117,7 +117,7 @@ namespace System.Web.WebPages.Test
             dictionary.Clear();
 
             // Assert
-            Assert.Equal(0, dictionary.Count);
+            Assert.Empty(dictionary);
         }
 
         [Fact]
@@ -137,16 +137,16 @@ namespace System.Web.WebPages.Test
             var dictionary = GetChainedStorageStateDictionary();
             var array = new KeyValuePair<object, object>[8];
 
-            // Act 
+            // Act
             dictionary.CopyTo(array, 2);
 
             // Assert
-            Assert.Equal(array[2].Key, "a");
-            Assert.Equal(array[2].Value, "a2");
-            Assert.Equal(array[4].Key, "f");
-            Assert.Equal(array[4].Value, "f2");
-            Assert.Equal(array[7].Key, "c");
-            Assert.Equal(array[7].Value, "c0");
+            Assert.Equal("a", array[2].Key);
+            Assert.Equal("a2", array[2].Value);
+            Assert.Equal("f", array[4].Key);
+            Assert.Equal("f2", array[4].Value);
+            Assert.Equal("c", array[7].Key);
+            Assert.Equal("c0", array[7].Value);
         }
 
         private ScopeStorageDictionary GetChainedStorageStateDictionary()

--- a/test/System.Web.WebPages.Test/ScopeStorage/ScopeStorageKeyComparerTest.cs
+++ b/test/System.Web.WebPages.Test/ScopeStorage/ScopeStorageKeyComparerTest.cs
@@ -16,7 +16,7 @@ namespace System.Web.WebPages.Test
             var dictionary = new Dictionary<object, object>(ScopeStorageComparer.Instance) { { "foo", "bar" } };
 
             // Act and Assert
-            Assert.Equal(dictionary["foo"], "bar");
+            Assert.Equal("bar", dictionary["foo"]);
             Assert.Equal(dictionary["foo"], dictionary["FOo"]);
         }
 
@@ -27,9 +27,9 @@ namespace System.Web.WebPages.Test
             var stateStorage = new Dictionary<object, object> { { 4, "4-value" }, { new Person { ID = 10 }, "person-value" } };
 
             // Act and Assert
-            Assert.Equal(stateStorage[4], "4-value");
+            Assert.Equal("4-value", stateStorage[4]);
             Assert.Equal(stateStorage[(int)8 / 2], stateStorage[4]);
-            Assert.Equal(stateStorage[new Person { ID = 10 }], "person-value");
+            Assert.Equal("person-value", stateStorage[new Person { ID = 10 }]);
         }
 
         private class Person

--- a/test/System.Web.WebPages.Test/ScopeStorage/WebConfigScopeStorageTest.cs
+++ b/test/System.Web.WebPages.Test/ScopeStorage/WebConfigScopeStorageTest.cs
@@ -20,8 +20,8 @@ namespace System.Web.WebPages.Test
             var stateStorage = GetWebConfigScopeStorage();
 
             // Assert
-            Assert.Equal(stateStorage["foo1"], "bar1");
-            Assert.Equal(stateStorage["foo2"], "bar2");
+            Assert.Equal("bar1", stateStorage["foo1"]);
+            Assert.Equal("bar2", stateStorage["foo2"]);
         }
 
         [Fact]
@@ -31,8 +31,8 @@ namespace System.Web.WebPages.Test
             var stateStorage = GetWebConfigScopeStorage();
 
             // Assert
-            Assert.Equal(stateStorage["FOO1"], "bar1");
-            Assert.Equal(stateStorage["FoO2"], "bar2");
+            Assert.Equal("bar1", stateStorage["FOO1"]);
+            Assert.Equal("bar2", stateStorage["FoO2"]);
         }
 
         [Fact]

--- a/test/System.Web.WebPages.Test/System.Web.WebPages.Test.csproj
+++ b/test/System.Web.WebPages.Test/System.Web.WebPages.Test.csproj
@@ -182,6 +182,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/System.Web.WebPages.Test/Utils/HtmlAttributePropertyHelperTest.cs
+++ b/test/System.Web.WebPages.Test/Utils/HtmlAttributePropertyHelperTest.cs
@@ -80,7 +80,7 @@ namespace System.Web.WebPages.Test
             PropertyHelper[] helpers2 = HtmlAttributePropertyHelper.GetProperties(anonymous);
 
             // Assert
-            Assert.Equal(1, helpers1.Length);
+            Assert.Single(helpers1);
             Assert.ReferenceEquals(helpers1, helpers2);
             Assert.ReferenceEquals(helpers1[0], helpers2[0]);
         }
@@ -96,17 +96,17 @@ namespace System.Web.WebPages.Test
             PropertyHelper[] helpers2 = PropertyHelper.GetProperties(anonymous);
 
             // Assert
-            Assert.Equal(1, helpers1.Length);
-            Assert.Equal(1, helpers2.Length);
+            PropertyHelper helper1 = Assert.Single(helpers1);
+            PropertyHelper helper2 = Assert.Single(helpers2);
 
-            Assert.NotEqual<PropertyHelper[]>(helpers1, helpers2);
-            Assert.NotEqual<PropertyHelper>(helpers1[0], helpers2[0]);
+            Assert.NotEqual(helpers1, helpers2);
+            Assert.NotEqual(helper1, helper2);
 
-            Assert.IsType<HtmlAttributePropertyHelper>(helpers1[0]);
-            Assert.IsNotType<HtmlAttributePropertyHelper>(helpers2[0]);
+            Assert.IsType<HtmlAttributePropertyHelper>(helper1);
+            Assert.IsNotType<HtmlAttributePropertyHelper>(helper2);
 
-            Assert.Equal("bar-baz1", helpers1[0].Name);
-            Assert.Equal("bar_baz1", helpers2[0].Name);
+            Assert.Equal("bar-baz1", helper1.Name);
+            Assert.Equal("bar_baz1", helper2.Name);
         }
     }
 }

--- a/test/System.Web.WebPages.Test/Utils/PathUtilTest.cs
+++ b/test/System.Web.WebPages.Test/Utils/PathUtilTest.cs
@@ -57,7 +57,7 @@ namespace System.Web.WebPages.Test
             var extensions = paths.Select(PathUtil.GetExtension);
 
             // Assert
-            Assert.True(extensions.All(ext => ext.Length == 0));
+            Assert.All(extensions, ext => Assert.Empty(ext));
         }
 
         [Fact]
@@ -70,7 +70,7 @@ namespace System.Web.WebPages.Test
             var extensions = paths.Select(PathUtil.GetExtension);
 
             // Assert
-            Assert.True(extensions.All(ext => ext.Length == 0));
+            Assert.All(extensions, ext => Assert.Empty(ext));
         }
 
         [Fact]
@@ -83,7 +83,7 @@ namespace System.Web.WebPages.Test
             var extensions = paths.Select(PathUtil.GetExtension);
 
             // Assert
-            Assert.True(extensions.All(ext => ext.Length == 0));
+            Assert.All(extensions, ext => Assert.Empty(ext));
         }
 
         [Fact]
@@ -98,8 +98,8 @@ namespace System.Web.WebPages.Test
             string ext2 = PathUtil.GetExtension(path2);
 
             // Assert
-            Assert.Equal(ext1, ".cshtml");
-            Assert.Equal(ext2, ".txt");
+            Assert.Equal(".cshtml", ext1);
+            Assert.Equal(".txt", ext2);
         }
 
         [Fact]

--- a/test/System.Web.WebPages.Test/Utils/PropertyHelperTest.cs
+++ b/test/System.Web.WebPages.Test/Utils/PropertyHelperTest.cs
@@ -65,7 +65,7 @@ namespace System.Web.WebPages.Test
             PropertyHelper[] helpers2 = PropertyHelper.GetProperties(anonymous);
 
             // Assert
-            Assert.Equal(1, helpers1.Length);
+            Assert.Single(helpers1);
             Assert.ReferenceEquals(helpers1, helpers2);
             Assert.ReferenceEquals(helpers1[0], helpers2[0]);
         }
@@ -149,8 +149,8 @@ namespace System.Web.WebPages.Test
             anonymous.StringProp = "Five";
 
             // Act + Assert
-            PropertyHelper helper1 = Assert.Single(PropertyHelper.GetProperties(anonymous).Where(prop => prop.Name == "IntProp"));
-            PropertyHelper helper2 = Assert.Single(PropertyHelper.GetProperties(anonymous).Where(prop => prop.Name == "StringProp"));
+            PropertyHelper helper1 = Assert.Single(PropertyHelper.GetProperties(anonymous), prop => prop.Name == "IntProp");
+            PropertyHelper helper2 = Assert.Single(PropertyHelper.GetProperties(anonymous), prop => prop.Name == "StringProp");
             Assert.Equal(3, helper1.GetValue(anonymous));
             Assert.Equal("Five", helper2.GetValue(anonymous));
         }
@@ -196,8 +196,8 @@ namespace System.Web.WebPages.Test
             Assert.NotNull(helpers);
             Assert.Equal(2, helpers.Length);
 
-            PropertyHelper propAHelper = Assert.Single(helpers.Where(h => h.Name == "PropA"));
-            PropertyHelper propBHelper = Assert.Single(helpers.Where(h => h.Name == "PropB"));
+            PropertyHelper propAHelper = Assert.Single(helpers, h => h.Name == "PropA");
+            PropertyHelper propBHelper = Assert.Single(helpers, h => h.Name == "PropB");
 
             Assert.Equal("propAValue", propAHelper.GetValue(derived));
             Assert.Equal("propBValue", propBHelper.GetValue(derived));
@@ -216,8 +216,8 @@ namespace System.Web.WebPages.Test
             Assert.NotNull(helpers);
             Assert.Equal(2, helpers.Length);
 
-            PropertyHelper propAHelper = Assert.Single(helpers.Where(h => h.Name == "PropA"));
-            PropertyHelper propBHelper = Assert.Single(helpers.Where(h => h.Name == "PropB"));
+            PropertyHelper propAHelper = Assert.Single(helpers, h => h.Name == "PropA");
+            PropertyHelper propBHelper = Assert.Single(helpers, h => h.Name == "PropB");
 
             Assert.Equal("propAValue", propAHelper.GetValue(derived));
             Assert.Equal("Newed", propBHelper.GetValue(derived));
@@ -236,8 +236,8 @@ namespace System.Web.WebPages.Test
             Assert.NotNull(helpers);
             Assert.Equal(2, helpers.Length);
 
-            PropertyHelper propAHelper = Assert.Single(helpers.Where(h => h.Name == "PropA"));
-            PropertyHelper propBHelper = Assert.Single(helpers.Where(h => h.Name == "PropB"));
+            PropertyHelper propAHelper = Assert.Single(helpers, h => h.Name == "PropA");
+            PropertyHelper propBHelper = Assert.Single(helpers, h => h.Name == "PropB");
 
             Assert.Equal("Overriden", propAHelper.GetValue(derived));
             Assert.Equal("propBValue", propBHelper.GetValue(derived));

--- a/test/System.Web.WebPages.Test/Validation/ValidationHelperTest.cs
+++ b/test/System.Web.WebPages.Test/Validation/ValidationHelperTest.cs
@@ -75,8 +75,8 @@ namespace System.Web.WebPages.Validation.Test
             var results = validationHelper.Validate();
 
             // Assert
-            Assert.Equal(1, results.Count());
-            Assert.Equal(message, results.First().ErrorMessage);
+            ValidationResult result = Assert.Single(results);
+            Assert.Equal(message, result.ErrorMessage);
         }
 
         [Fact]
@@ -92,8 +92,8 @@ namespace System.Web.WebPages.Validation.Test
             var results = validationHelper.Validate();
 
             // Assert
-            Assert.Equal(1, results.Count());
-            Assert.Equal(message, results.First().ErrorMessage);
+            ValidationResult result = Assert.Single(results);
+            Assert.Equal(message, result.ErrorMessage);
         }
 
         [Fact]
@@ -109,7 +109,7 @@ namespace System.Web.WebPages.Validation.Test
             var results = validationHelper.Validate();
 
             // Assert
-            Assert.Equal(0, results.Count());
+            Assert.Empty(results);
         }
 
         [Fact]
@@ -124,8 +124,8 @@ namespace System.Web.WebPages.Validation.Test
             var results = validationHelper.Validate();
 
             // Assert
-            Assert.Equal(1, results.Count());
-            Assert.Equal("This field is required.", results.First().ErrorMessage);
+            ValidationResult result = Assert.Single(results);
+            Assert.Equal("This field is required.", result.ErrorMessage);
         }
 
         [Fact]
@@ -416,8 +416,7 @@ namespace System.Web.WebPages.Validation.Test
             var oddValidator = new Mock<IValidator>();
             oddValidator.Setup(c => c.Validate(It.IsAny<ValidationContext>())).Returns<ValidationContext>(v =>
             {
-                Assert.IsAssignableFrom<HttpContextBase>(v.ObjectInstance);
-                var context = (HttpContextBase)v.ObjectInstance;
+                var context = Assert.IsAssignableFrom<HttpContextBase>(v.ObjectInstance);
                 var value = Int32.Parse(context.Request.Form["foo"]);
 
                 if (value % 2 != 0)
@@ -430,11 +429,11 @@ namespace System.Web.WebPages.Validation.Test
 
             // Act
             validationHelper.Add("foo", oddValidator.Object);
-            var result = validationHelper.Validate();
+            var results = validationHelper.Validate();
 
             // Assert
-            Assert.Equal(1, result.Count());
-            Assert.Equal(message, result.First().ErrorMessage);
+            ValidationResult result = Assert.Single(results);
+            Assert.Equal(message, result.ErrorMessage);
             oddValidator.Verify();
         }
 
@@ -447,8 +446,7 @@ namespace System.Web.WebPages.Validation.Test
             var oddValidator = new Mock<IValidator>();
             oddValidator.Setup(c => c.Validate(It.IsAny<ValidationContext>())).Returns<ValidationContext>(v =>
             {
-                Assert.IsAssignableFrom<HttpContextBase>(v.ObjectInstance);
-                var context = (HttpContextBase)v.ObjectInstance;
+                var context = Assert.IsAssignableFrom<HttpContextBase>(v.ObjectInstance);
                 if (context.Request.Form["foo"].IsEmpty())
                 {
                     return ValidationResult.Success;
@@ -465,11 +463,11 @@ namespace System.Web.WebPages.Validation.Test
             // Act
             validationHelper.Add(new[] { "foo", "bar" }, oddValidator.Object);
             validationHelper.RequireField("foo");
-            var result = validationHelper.Validate("foo");
+            var results = validationHelper.Validate("foo");
 
             // Assert
-            Assert.Equal(1, result.Count());
-            Assert.Equal("This field is required.", result.First().ErrorMessage);
+            ValidationResult result = Assert.Single(results);
+            Assert.Equal("This field is required.", result.ErrorMessage);
         }
 
         [Fact]
@@ -481,8 +479,7 @@ namespace System.Web.WebPages.Validation.Test
             var oddValidator = new Mock<IValidator>();
             oddValidator.Setup(c => c.Validate(It.IsAny<ValidationContext>())).Returns<ValidationContext>(v =>
             {
-                Assert.IsAssignableFrom<HttpContextBase>(v.ObjectInstance);
-                var context = (HttpContextBase)v.ObjectInstance;
+                var context = Assert.IsAssignableFrom<HttpContextBase>(v.ObjectInstance);
                 if (context.Request.Form["foo"].IsEmpty())
                 {
                     return ValidationResult.Success;
@@ -516,8 +513,7 @@ namespace System.Web.WebPages.Validation.Test
             var oddValidator = new Mock<IValidator>();
             oddValidator.Setup(c => c.Validate(It.IsAny<ValidationContext>())).Returns<ValidationContext>(v =>
             {
-                Assert.IsAssignableFrom<HttpContextBase>(v.ObjectInstance);
-                var context = (HttpContextBase)v.ObjectInstance;
+                var context = Assert.IsAssignableFrom<HttpContextBase>(v.ObjectInstance);
                 if (context.Request.Form["foo"].IsEmpty())
                 {
                     return ValidationResult.Success;
@@ -549,8 +545,7 @@ namespace System.Web.WebPages.Validation.Test
             var oddValidator = new Mock<IValidator>();
             oddValidator.Setup(c => c.Validate(It.IsAny<ValidationContext>())).Returns<ValidationContext>(v =>
             {
-                Assert.IsAssignableFrom<HttpContextBase>(v.ObjectInstance);
-                var context = (HttpContextBase)v.ObjectInstance;
+                var context = Assert.IsAssignableFrom<HttpContextBase>(v.ObjectInstance);
                 int value;
                 if (!Int32.TryParse(context.Request.Form["foo"], out value))
                 {

--- a/test/System.Web.WebPages.Test/Validation/ValidatorTest.cs
+++ b/test/System.Web.WebPages.Test/Validation/ValidatorTest.cs
@@ -339,10 +339,10 @@ namespace System.Web.WebPages.Validation.Test
             var result = validator.ClientValidationRule;
 
             // Assert
-            Assert.Equal(result.ValidationType, "length");
-            Assert.Equal(result.ErrorMessage, "String must be between 4 and 6 characters.");
-            Assert.Equal(result.ValidationParameters["min"], 4);
-            Assert.Equal(result.ValidationParameters["max"], 6);
+            Assert.Equal("length", result.ValidationType);
+            Assert.Equal("String must be between 4 and 6 characters.", result.ErrorMessage);
+            Assert.Equal(4, result.ValidationParameters["min"]);
+            Assert.Equal(6, result.ValidationParameters["max"]);
         }
 
         [Fact]
@@ -356,9 +356,9 @@ namespace System.Web.WebPages.Validation.Test
             var result = validator.ClientValidationRule;
 
             // Assert
-            Assert.Equal(result.ValidationType, "length");
-            Assert.Equal(result.ErrorMessage, "Must be at least 6 letters.");
-            Assert.Equal(result.ValidationParameters["max"], 6);
+            Assert.Equal("length", result.ValidationType);
+            Assert.Equal("Must be at least 6 letters.", result.ErrorMessage);
+            Assert.Equal(6, result.ValidationParameters["max"]);
         }
 
         [Fact]

--- a/test/System.Web.WebPages.Test/WebPage/DisplayInfoTest.cs
+++ b/test/System.Web.WebPages.Test/WebPage/DisplayInfoTest.cs
@@ -16,6 +16,7 @@ namespace System.Web.WebPages.Test
             Assert.ThrowsArgumentNull(() => new DisplayInfo("testPath", displayMode: null), "displayMode");
         }
 
+        [Fact]
         public void ConstructorSetsDisplayInfoProperties()
         {
             // Arrange
@@ -30,6 +31,7 @@ namespace System.Web.WebPages.Test
             Assert.Equal(displayMode, info.DisplayMode);
         }
 
+        [Fact]
         public void ConstructorSetsEmptyFilePath()
         {
             // Act & Assert

--- a/test/System.Web.WebPages.Test/WebPage/DisplayModeProviderTest.cs
+++ b/test/System.Web.WebPages.Test/WebPage/DisplayModeProviderTest.cs
@@ -169,8 +169,8 @@ namespace System.Web.WebPages.Test
             var availableDisplayModes = displayModeProvider.GetAvailableDisplayModesForContext(httpContext.Object, displayMode2.Object, requireConsistentDisplayMode: true).ToList();
 
             // Assert
-            Assert.Equal(1, availableDisplayModes.Count);
-            Assert.Equal(displayMode3.Object, availableDisplayModes[0]);
+            var availableDisplayMode = Assert.Single(availableDisplayModes);
+            Assert.Equal(displayMode3.Object, availableDisplayMode);
         }
 
         [Fact]
@@ -225,8 +225,8 @@ namespace System.Web.WebPages.Test
             var availableDisplayModes = displayModeProvider.GetAvailableDisplayModesForContext(httpContext.Object, displayMode1.Object, requireConsistentDisplayMode: false).ToList();
 
             // Assert
-            Assert.Equal(1, availableDisplayModes.Count);
-            Assert.Equal(displayMode2.Object, availableDisplayModes[0]);
+            IDisplayMode availableDisplayMode = Assert.Single(availableDisplayModes);
+            Assert.Equal(displayMode2.Object, availableDisplayMode);
         }
     }
 }

--- a/test/System.Web.WebPages.Test/WebPage/DynamicPageDataDictionaryTest.cs
+++ b/test/System.Web.WebPages.Test/WebPage/DynamicPageDataDictionaryTest.cs
@@ -162,7 +162,7 @@ namespace System.Web.WebPages.Test
             dynamic dyn = d;
             Assert.IsType<int>(dyn.Count);
             d.Add("x", 1);
-            Assert.Equal(1, d.Count);
+            Assert.Single(d);
             d.Add("y", 2);
             Assert.Equal(2, d.Count);
             dyn.Count = "foo";

--- a/test/System.Web.WebPages.Test/WebPage/LayoutTest.cs
+++ b/test/System.Web.WebPages.Test/WebPage/LayoutTest.cs
@@ -65,8 +65,8 @@ namespace System.Web.WebPages.Test
 
             var result = Utils.RenderWebPage(page, request: request.Object);
             Assert.Equal(2, page.PageContext.SourceFiles.Count);
-            Assert.True(page.PageContext.SourceFiles.Contains("~/MyApp/index.cshtml"));
-            Assert.True(page.PageContext.SourceFiles.Contains("~/MyFiles/Layout.cshtml"));
+            Assert.Contains("~/MyApp/index.cshtml", page.PageContext.SourceFiles);
+            Assert.Contains("~/MyFiles/Layout.cshtml", page.PageContext.SourceFiles);
         }
 
         private static void LayoutBasicTestInternal(string layoutPath, string pagePath = "~/index.cshtml", string layoutPage = "Layout.cshtml")
@@ -75,7 +75,7 @@ namespace System.Web.WebPages.Test
             // PageData["Title"] = "MyPage";
             // Layout = "Layout.cshtml";
             // WriteLiteral("hello world");
-            // 
+            //
             // The layout page ~/Layout.cshtml does the following:
             // WriteLiteral(Title);
             // RenderBody();
@@ -109,7 +109,7 @@ namespace System.Web.WebPages.Test
             // PageData["Title"] = "MyPage";
             // Layout = "Layout1.cshtml";
             // WriteLiteral("hello world");
-            // 
+            //
             // The first layout page ~/Layout1.cshtml does the following:
             // Layout = "Layout2.cshtml";
             // WriteLiteral("<layout1>");
@@ -291,7 +291,7 @@ namespace System.Web.WebPages.Test
             // The page ~/layout1.cshtml does the following:
             // Layout = "Layout2.cshtml";
             // @section body {
-            //     body in layout1 
+            //     body in layout1
             //     @RenderSection("body")
             // }
             //

--- a/test/System.Web.WebPages.Test/WebPage/PageDataDictionaryTest.cs
+++ b/test/System.Web.WebPages.Test/WebPage/PageDataDictionaryTest.cs
@@ -54,9 +54,9 @@ namespace System.Web.WebPages.Test
             var d = new PageDataDictionary<dynamic>();
             var item = new KeyValuePair<object, object>("x", 1);
             d.Add(item);
-            Assert.True(d.Contains(item));
+            Assert.Contains(item, d);
             var item2 = new KeyValuePair<object, object>("y", 2);
-            Assert.False(d.Contains(item2));
+            Assert.DoesNotContain(item2, d);
         }
 
         [Fact]
@@ -106,9 +106,9 @@ namespace System.Web.WebPages.Test
             var d = new PageDataDictionary<dynamic>();
             var item = new KeyValuePair<object, object>("x", 2);
             d.Add(item);
-            Assert.True(d.Contains(item));
+            Assert.Contains(item, d);
             d.Remove(item);
-            Assert.False(d.Contains(item));
+            Assert.DoesNotContain(item, d);
         }
 
         [Fact]
@@ -137,7 +137,7 @@ namespace System.Web.WebPages.Test
         {
             var d = new PageDataDictionary<dynamic>();
             d.Add("x", 1);
-            Assert.Equal(1, d.Count);
+            Assert.Single(d);
             d.Add("y", 2);
             Assert.Equal(2, d.Count);
         }

--- a/test/System.Web.WebPages.Test/WebPage/UrlDataTest.cs
+++ b/test/System.Web.WebPages.Test/WebPage/UrlDataTest.cs
@@ -36,8 +36,8 @@ namespace System.Web.WebPages.Test
             var item = "!!@#$#$";
             var item2 = "13l53125";
             var d = new UrlDataList(item + "/" + item2);
-            Assert.True(d.IndexOf(item) == 0);
-            Assert.True(d.IndexOf(item2) == 1);
+            Assert.Equal(0, d.IndexOf(item));
+            Assert.Equal(1, d.IndexOf(item2));
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace System.Web.WebPages.Test
         {
             var item = "!!@#$#$";
             var d = new UrlDataList(item);
-            Assert.True(d.Contains(item));
+            Assert.Contains(item, d);
         }
 
         [Fact]
@@ -92,14 +92,14 @@ namespace System.Web.WebPages.Test
         public void CountTest()
         {
             var d = new UrlDataList("x");
-            Assert.Equal(1, d.Count);
+            Assert.Single(d);
         }
 
         [Fact]
         public void IsReadOnlyTest()
         {
             var d = new UrlDataList(null);
-            Assert.Equal(true, d.IsReadOnly);
+            Assert.True(d.IsReadOnly);
         }
 
         [Fact]

--- a/test/System.Web.WebPages.Test/WebPage/WebPageHttpHandlerTest.cs
+++ b/test/System.Web.WebPages.Test/WebPage/WebPageHttpHandlerTest.cs
@@ -52,14 +52,14 @@ namespace System.Web.WebPages.Test
             Mock<HttpContextBase> context = Utils.CreateTestContext(httpRequest.Object, httpResponse.Object);
             var page = Utils.CreatePage(p => p.Write(contents));
 
-            // Act 
+            // Act
             var webPageHttpHandler = new WebPageHttpHandler(page);
             webPageHttpHandler.ProcessRequestInternal(context.Object);
 
             // Assert
             Assert.Equal(contents, writer.ToString());
-            Assert.Equal(1, page.PageContext.SourceFiles.Count);
-            Assert.True(page.PageContext.SourceFiles.Contains("~/index.cshtml"));
+            Assert.Single(page.PageContext.SourceFiles);
+            Assert.Contains("~/index.cshtml", page.PageContext.SourceFiles);
         }
 
         [Fact]
@@ -87,8 +87,8 @@ namespace System.Web.WebPages.Test
             WebPageHttpHandler.GenerateSourceFilesHeader(webPageContext);
 
             // Assert
-            Assert.Equal(headerKey, "X-SourceFiles");
-            Assert.Equal(headerValue, "=?UTF-8?B?Zm9vfGJhcnzOuw==?=");
+            Assert.Equal("X-SourceFiles", headerKey);
+            Assert.Equal("=?UTF-8?B?Zm9vfGJhcnzOuw==?=", headerValue);
         }
 
         [Fact]
@@ -166,8 +166,7 @@ namespace System.Web.WebPages.Test
 
             // Act
             IHttpHandler handler = WebPageHttpHandler.CreateFromVirtualPath(virtualPath, new VirtualPathFactoryManager(mockBuildManager.Object));
-            Assert.IsType<WebPageHttpHandler>(handler);
-            WebPageHttpHandler webPageHttpHandler = (WebPageHttpHandler)handler;
+            WebPageHttpHandler webPageHttpHandler = Assert.IsType<WebPageHttpHandler>(handler);
             webPageHttpHandler.ProcessRequestInternal(httpContext.Object);
 
             // Assert

--- a/test/System.Web.WebPages.Test/WebPage/WebPageTest.cs
+++ b/test/System.Web.WebPages.Test/WebPage/WebPageTest.cs
@@ -172,14 +172,18 @@ namespace System.Web.WebPages.Test
         public void SessionPropertyTest()
         {
             var page = CreateMockPageWithPostContext().Object;
+#pragma warning disable xUnit2013 // Do not use equality check to check for collection size.
             Assert.Equal(0, page.Session.Count);
+#pragma warning restore xUnit2013 // Do not use equality check to check for collection size.
         }
 
         [Fact]
         public void AppStatePropertyTest()
         {
             var page = CreateMockPageWithPostContext().Object;
+#pragma warning disable xUnit2013 // Do not use equality check to check for collection size.
             Assert.Equal(0, page.AppState.Count);
+#pragma warning restore xUnit2013 // Do not use equality check to check for collection size.
         }
 
         [Fact]

--- a/test/System.Web.WebPages.Test/packages.config
+++ b/test/System.Web.WebPages.Test/packages.config
@@ -2,7 +2,9 @@
 <packages>
   <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
+  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />

--- a/test/WebApiHelpPage.Test/WebApiHelpPage.Test.csproj
+++ b/test/WebApiHelpPage.Test/WebApiHelpPage.Test.csproj
@@ -136,6 +136,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/WebApiHelpPage.Test/packages.config
+++ b/test/WebApiHelpPage.Test/packages.config
@@ -4,7 +4,9 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />

--- a/test/WebApiHelpPage.VB.Test/WebApiHelpPage.VB.Test.csproj
+++ b/test/WebApiHelpPage.VB.Test/WebApiHelpPage.VB.Test.csproj
@@ -170,6 +170,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/WebMatrix.Data.Test/WebMatrix.Data.Test.csproj
+++ b/test/WebMatrix.Data.Test/WebMatrix.Data.Test.csproj
@@ -77,6 +77,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/WebMatrix.Data.Test/packages.config
+++ b/test/WebMatrix.Data.Test/packages.config
@@ -2,7 +2,9 @@
 <packages>
   <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
+  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />

--- a/test/WebMatrix.WebData.Test/PreApplicationStartCodeTest.cs
+++ b/test/WebMatrix.WebData.Test/PreApplicationStartCodeTest.cs
@@ -25,8 +25,8 @@ namespace WebMatrix.WebData.Test
 
                 // Verify namespaces
                 var imports = WebPageRazorHost.GetGlobalImports();
-                Assert.True(imports.Any(ns => ns.Equals("WebMatrix.Data")));
-                Assert.True(imports.Any(ns => ns.Equals("WebMatrix.WebData")));
+                Assert.Contains(imports, ns => ns.Equals("WebMatrix.Data"));
+                Assert.Contains(imports, ns => ns.Equals("WebMatrix.WebData"));
             });
         }
 

--- a/test/WebMatrix.WebData.Test/SimpleMembershipProviderTest.cs
+++ b/test/WebMatrix.WebData.Test/SimpleMembershipProviderTest.cs
@@ -198,7 +198,7 @@ namespace WebMatrix.WebData.Test
                 "zeke");
 
             // Assert
-            Assert.Equal<int>(999, result);
+            Assert.Equal(999, result);
         }
 
         [Fact]
@@ -219,7 +219,7 @@ namespace WebMatrix.WebData.Test
                 "zeke");
 
             // Assert
-            Assert.Equal<int>(999, result);
+            Assert.Equal(999, result);
         }
 
         [Theory]

--- a/test/WebMatrix.WebData.Test/WebMatrix.WebData.Test.csproj
+++ b/test/WebMatrix.WebData.Test/WebMatrix.WebData.Test.csproj
@@ -80,6 +80,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\xunit.analyzers.0.7.0\analyzers\dotnet\cs\xunit.analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/WebMatrix.WebData.Test/packages.config
+++ b/test/WebMatrix.WebData.Test/packages.config
@@ -2,7 +2,9 @@
 <packages>
   <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
+  <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.3.0" targetFramework="net452" />
   <package id="xunit.core" version="2.3.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.3.0" targetFramework="net452" />


### PR DESCRIPTION
- part of #65

Few manual changes:
- work around xunit/xunit#1502
- use `Assert.IsAssignableFrom<T>(...)`, `Assert.IsType<T>(...)` and `Assert.Single(...)` return values
- suppress xUnit1013, Public method should be marked as test
  - helper method is called from multiple test classes; none inherit from defining class
- fix xUnit1026, `[Theory]` method doesn't use all parameters
  - add new data set properties
- suppress xUnit2013, Do not use equality check to check for collection size.
  - calls `Count` because the `Mock<T>` does not set up `GetEnumerable()`
- `Assert.Equal<T>(...)` -> `Assert.Equal(...)`
- avoid Linq's `.Where` inside `Assert.Contains(...)` and similar