### PR TITLE
Fix build on internal CI

### DIFF
--- a/test/Microsoft.TestCommon/Microsoft.TestCommon.csproj
+++ b/test/Microsoft.TestCommon/Microsoft.TestCommon.csproj
@@ -9,6 +9,10 @@
     <AssemblyName>Microsoft.TestCommon</AssemblyName>
     <IsTestProject>false</IsTestProject>
     <OutputPath>..\..\bin\$(Configuration)\Test\</OutputPath>
+    <CodeSignEnabled>false</CodeSignEnabled>
+    <EnableGetGitHeadSHA1>false</EnableGetGitHeadSHA1>
+    <ValidateBuildParamsDisabled>true</ValidateBuildParamsDisabled>
+    <VersionFileGenerationEnabled>false</VersionFileGenerationEnabled>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
- some properties with defaults based on `$(IsTestProject)` were set incorrectly
  - Microsoft.TestCommon project is not really a test project
- follow-up to 4b309584ad