### PR TITLE
Avoid odd test failures

### DIFF
--- a/test/System.Net.Http.Formatting.Test/Formatting/DataContractJsonMediaTypeFormatterTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/DataContractJsonMediaTypeFormatterTests.cs
@@ -157,6 +157,7 @@ namespace System.Net.Http.Formatting
             }
         }
 
+#if !NETCOREAPP2_0 // DBNull not serializable on .NET Core 2.0.
         // Test alternate null value
         [Fact]
         public async Task ReadFromStreamAsync_RoundTripsWriteToStreamAsync_DBNull()
@@ -187,6 +188,7 @@ namespace System.Net.Http.Formatting
             // Lower levels convert DBNull.Value to empty string on read
             Assert.Equal(String.Empty, readObj);
         }
+#endif
 
         [Fact]
         public async Task UseDataContractJsonSerializer_Default()

--- a/test/System.Net.Http.Formatting.Test/Formatting/XmlMediaTypeFormatterTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/XmlMediaTypeFormatterTests.cs
@@ -23,8 +23,23 @@ namespace System.Net.Http.Formatting
         // sample only; avoids types DataContractJsonSerializer fails to round trip (e.g. Guid, Uint16).  May require
         // known types or similar (de)serializer configuration.
         public static readonly RefTypeTestData<object> BunchOfTypedObjectsTestData = new RefTypeTestData<object>(
-            () => new List<object> { null, String.Empty, "This is a string", false, true, Double.MinValue,
-                Double.MaxValue, Int32.MinValue, Int32.MaxValue, Int64.MinValue, Int64.MaxValue, DBNull.Value, });
+            () => new List<object>
+            {
+                null,
+                String.Empty,
+                "This is a string",
+                false,
+                true,
+                Double.MinValue,
+                Double.MaxValue,
+                Int32.MinValue,
+                Int32.MaxValue,
+                Int64.MinValue,
+                Int64.MaxValue,
+#if !NETCOREAPP2_0 // DBNull not serializable on .NET Core 2.0.
+                DBNull.Value,
+#endif
+            });
 
         public static IEnumerable<TestData> BunchOfTypedObjectsTestDataCollection
         {


### PR DESCRIPTION
- XML serializers handle `DBNull` on some machines but not others
- possible an underlying problem was fixed recently, in .NET Core SDK 2.0.3
- but, better to make builds work almost everywhere and wait for .NET Core SDK 2.1.x (where `DBNull` is seralizable)