### PR TITLE
Give `ValidationContext.MemberName` a distinct value from `DisplayName`

### DIFF
--- a/src/System.Web.Http/System.Web.Http.csproj
+++ b/src/System.Web.Http/System.Web.Http.csproj
@@ -21,6 +21,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.Linq" />
     <Reference Include="System.Net.Http" />

--- a/src/System.Web.Http/Validation/Validators/DataAnnotationsModelValidator.cs
+++ b/src/System.Web.Http/Validation/Validators/DataAnnotationsModelValidator.cs
@@ -33,11 +33,11 @@ namespace System.Web.Http.Validation.Validators
             // Per the WCF RIA Services team, instance can never be null (if you have
             // no parent, you pass yourself for the "instance" parameter).
             
-            string memberName = metadata.GetDisplayName();
+            var memberName = metadata.PropertyName;
             ValidationContext context = new ValidationContext(container ?? metadata.Model)
             {
-                DisplayName = memberName,
-                MemberName = memberName
+                DisplayName = metadata.GetDisplayName(),
+                MemberName = memberName,
             };
 
             ValidationResult result = Attribute.GetValidationResult(metadata.Model, context);

--- a/src/System.Web.Http/Validation/Validators/DataAnnotationsModelValidator.cs
+++ b/src/System.Web.Http/Validation/Validators/DataAnnotationsModelValidator.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.ComponentModel.DataAnnotations;
+using System.Configuration;
 using System.Linq;
 using System.Web.Http.Metadata;
 
@@ -10,7 +12,13 @@ namespace System.Web.Http.Validation.Validators
 {
     public class DataAnnotationsModelValidator : ModelValidator
     {
-        public DataAnnotationsModelValidator(IEnumerable<ModelValidatorProvider> validatorProviders, ValidationAttribute attribute)
+        internal static readonly string UseLegacyValidationMemberNameKey = "webapi:UseLegacyValidationMemberName";
+        private static bool _useLegacyValidationMemberName =
+            GetUseLegacyValidationMemberName(ConfigurationManager.AppSettings);
+
+        public DataAnnotationsModelValidator(
+            IEnumerable<ModelValidatorProvider> validatorProviders,
+            ValidationAttribute attribute)
             : base(validatorProviders)
         {
             if (attribute == null)
@@ -19,6 +27,13 @@ namespace System.Web.Http.Validation.Validators
             }
 
             Attribute = attribute;
+        }
+
+        // Internal for testing
+        internal static bool UseLegacyValidationMemberName
+        {
+            get { return _useLegacyValidationMemberName; }
+            set { _useLegacyValidationMemberName = value; }
         }
 
         protected internal ValidationAttribute Attribute { get; private set; }
@@ -30,11 +45,25 @@ namespace System.Web.Http.Validation.Validators
 
         public override IEnumerable<ModelValidationResult> Validate(ModelMetadata metadata, object container)
         {
+            string memberName;
+            if (_useLegacyValidationMemberName)
+            {
+                // Using member name from a Display or DisplayFormat attribute is generally incorrect. This
+                // (configuration-controlled) override is provided only for corner cases where strict
+                // back-compatibility is required.
+                memberName = metadata.GetDisplayName();
+            }
+            else
+            {
+                // MemberName expression matches GetDisplayName() except it ignores Display and DisplayName
+                // attributes. ModelType fallback isn't great and can separate errors and attempted values in the
+                // ModelState. But, expression matches MVC, avoids a null MemberName, and is mostly back-compatible.
+                memberName = metadata.PropertyName ?? metadata.ModelType.Name;
+            }
+
             // Per the WCF RIA Services team, instance can never be null (if you have
             // no parent, you pass yourself for the "instance" parameter).
-
-            var memberName = metadata.PropertyName;
-            ValidationContext context = new ValidationContext(container ?? metadata.Model)
+            ValidationContext context = new ValidationContext(instance: container ?? metadata.Model)
             {
                 DisplayName = metadata.GetDisplayName(),
                 MemberName = memberName,
@@ -68,6 +97,24 @@ namespace System.Web.Http.Validation.Validators
             }
 
             return Enumerable.Empty<ModelValidationResult>();
+        }
+
+        // Internal for testing
+        internal static bool GetUseLegacyValidationMemberName(NameValueCollection appSettings)
+        {
+            var useLegacyMemberNameArray = appSettings.GetValues(UseLegacyValidationMemberNameKey);
+            if (useLegacyMemberNameArray != null &&
+                useLegacyMemberNameArray.Length > 0)
+            {
+                bool useLegacyMemberName;
+                if (bool.TryParse(useLegacyMemberNameArray[0], out useLegacyMemberName) &&
+                    useLegacyMemberName)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/System.Web.Http/Validation/Validators/DataAnnotationsModelValidator.cs
+++ b/src/System.Web.Http/Validation/Validators/DataAnnotationsModelValidator.cs
@@ -32,7 +32,7 @@ namespace System.Web.Http.Validation.Validators
         {
             // Per the WCF RIA Services team, instance can never be null (if you have
             // no parent, you pass yourself for the "instance" parameter).
-            
+
             var memberName = metadata.PropertyName;
             ValidationContext context = new ValidationContext(container ?? metadata.Model)
             {
@@ -44,11 +44,11 @@ namespace System.Web.Http.Validation.Validators
 
             if (result != ValidationResult.Success)
             {
-                // ModelValidationResult.MemberName is used by invoking validators (such as ModelValidationNode) to 
-                // construct the ModelKey for ModelStateDictionary. When validating at type level we want to append the 
-                // returned MemberNames if specified (e.g. person.Address.FirstName). For property validation, the 
-                // ModelKey can be constructed using the ModelMetadata and we should ignore MemberName (we don't want 
-                // (person.Name.Name). However the invoking validator does not have a way to distinguish between these two 
+                // ModelValidationResult.MemberName is used by invoking validators (such as ModelValidationNode) to
+                // construct the ModelKey for ModelStateDictionary. When validating at type level we want to append the
+                // returned MemberNames if specified (e.g. person.Address.FirstName). For property validation, the
+                // ModelKey can be constructed using the ModelMetadata and we should ignore MemberName (we don't want
+                // (person.Name.Name). However the invoking validator does not have a way to distinguish between these two
                 // cases. Consequently we'll only set MemberName if this validation returns a MemberName that is different
                 // from the property being validated.
 
@@ -63,7 +63,7 @@ namespace System.Web.Http.Validation.Validators
                     Message = result.ErrorMessage,
                     MemberName = errorMemberName
                 };
-                
+
                 return new ModelValidationResult[] { validationResult };
             }
 

--- a/test/System.Web.Http.Test/Validation/Validators/DataAnnotationsModelValidatorTest.cs
+++ b/test/System.Web.Http.Test/Validation/Validators/DataAnnotationsModelValidatorTest.cs
@@ -2,10 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Web.Http.Metadata;
 using System.Web.Http.Metadata.Providers;
+using System.Web.WebPages.TestUtils;
 using Microsoft.TestCommon;
 using Moq;
 using Moq.Protected;
@@ -47,6 +49,90 @@ namespace System.Web.Http.Validation.Validators
             Assert.Same(attribute, validator.Attribute);
         }
 
+        public static TheoryDataSet<NameValueCollection> FalseAppSettingsData
+        {
+            get
+            {
+                return new TheoryDataSet<NameValueCollection>
+                {
+                    new NameValueCollection(),
+                    new NameValueCollection
+                    {
+                        { DataAnnotationsModelValidator.UseLegacyValidationMemberNameKey, "false" },
+                    },
+                    new NameValueCollection
+                    {
+                        { DataAnnotationsModelValidator.UseLegacyValidationMemberNameKey, "False" },
+                    },
+                    new NameValueCollection
+                    {
+                        { DataAnnotationsModelValidator.UseLegacyValidationMemberNameKey, "false" },
+                        { DataAnnotationsModelValidator.UseLegacyValidationMemberNameKey, "true" },
+                    },
+                    new NameValueCollection
+                    {
+                        { DataAnnotationsModelValidator.UseLegacyValidationMemberNameKey, "garbage" },
+                    },
+                };
+            }
+        }
+
+        [Theory]
+        [PropertyData("FalseAppSettingsData")]
+        public void GetUseLegacyValidationMemberName_ReturnsFalse(NameValueCollection appSettings)
+        {
+            // Arrange & Act
+            var result = DataAnnotationsModelValidator.GetUseLegacyValidationMemberName(appSettings);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        public static TheoryDataSet<NameValueCollection> TrueAppSettingsData
+        {
+            get
+            {
+                return new TheoryDataSet<NameValueCollection>
+                {
+                    new NameValueCollection
+                    {
+                        { DataAnnotationsModelValidator.UseLegacyValidationMemberNameKey, "true" },
+                    },
+                    new NameValueCollection
+                    {
+                        { DataAnnotationsModelValidator.UseLegacyValidationMemberNameKey, "True" },
+                    },
+                    new NameValueCollection
+                    {
+                        { DataAnnotationsModelValidator.UseLegacyValidationMemberNameKey, "true" },
+                        { DataAnnotationsModelValidator.UseLegacyValidationMemberNameKey, "false" },
+                    },
+                    new NameValueCollection
+                    {
+                        { DataAnnotationsModelValidator.UseLegacyValidationMemberNameKey, "true" },
+                        { DataAnnotationsModelValidator.UseLegacyValidationMemberNameKey, "false" },
+                        { DataAnnotationsModelValidator.UseLegacyValidationMemberNameKey, "garbage" },
+                    },
+                    new NameValueCollection
+                    {
+                        { DataAnnotationsModelValidator.UseLegacyValidationMemberNameKey, "True" },
+                        { DataAnnotationsModelValidator.UseLegacyValidationMemberNameKey, "garbage" },
+                    },
+                };
+            }
+        }
+
+        [Theory]
+        [PropertyData("TrueAppSettingsData")]
+        public void GetUseLegacyValidationMemberName_ReturnsTrue(NameValueCollection appSettings)
+        {
+            // Arrange & Act
+            var result = DataAnnotationsModelValidator.GetUseLegacyValidationMemberName(appSettings);
+
+            // Assert
+            Assert.True(result);
+        }
+
         public static TheoryDataSet<ModelMetadata, string> ValidateSetsMemberNamePropertyDataSet
         {
             get
@@ -63,7 +149,7 @@ namespace System.Web.Http.Validation.Validators
                     },
                     {
                         _metadataProvider.GetMetadataForType(() => new object(), typeof(SampleModel)),
-                        null
+                        "SampleModel"
                     },
                 };
             }
@@ -87,6 +173,71 @@ namespace System.Web.Http.Validation.Validators
 
             // Act
             IEnumerable<ModelValidationResult> results = validator.Validate(metadata, container: null);
+
+            // Assert
+            Assert.Empty(results);
+            attribute.VerifyAll();
+        }
+
+        [Fact]
+        public void ValidateSetsMemberNameProperty_UsingDisplayName()
+        {
+            AppDomainUtils.RunInSeparateAppDomain(ValidateSetsMemberNameProperty_UsingDisplayName_Inner);
+        }
+
+        private static void ValidateSetsMemberNameProperty_UsingDisplayName_Inner()
+        {
+            // Arrange
+            DataAnnotationsModelValidator.UseLegacyValidationMemberName = true;
+            var expectedMemberName = "Annotated Name";
+            var attribute = new Mock<ValidationAttribute> { CallBase = true };
+            attribute
+                .Protected()
+                .Setup<ValidationResult>("IsValid", ItExpr.IsAny<object>(), ItExpr.IsAny<ValidationContext>())
+                .Callback((object o, ValidationContext context) =>
+                {
+                    Assert.Equal(expectedMemberName, context.MemberName);
+                })
+                .Returns(ValidationResult.Success)
+                .Verifiable();
+            var validator = new DataAnnotationsModelValidator(_noValidatorProviders, attribute.Object);
+            var metadata = _metadataProvider.GetMetadataForProperty(() => string.Empty, typeof(AnnotatedModel), "Name");
+
+            // Act
+            var results = validator.Validate(metadata, container: null);
+
+            // Assert
+            Assert.Empty(results);
+            attribute.VerifyAll();
+        }
+
+        // Confirm explicit false setting does not change Validate(...)'s behavior from its default.
+        [Fact]
+        public void ValidateSetsMemberNameProperty_NotUsingDisplayName()
+        {
+            AppDomainUtils.RunInSeparateAppDomain(ValidateSetsMemberNameProperty_NotUsingDisplayName_Inner);
+        }
+
+        private static void ValidateSetsMemberNameProperty_NotUsingDisplayName_Inner()
+        {
+            // Arrange
+            DataAnnotationsModelValidator.UseLegacyValidationMemberName = false;
+            var expectedMemberName = "Name";
+            var attribute = new Mock<ValidationAttribute> { CallBase = true };
+            attribute
+                .Protected()
+                .Setup<ValidationResult>("IsValid", ItExpr.IsAny<object>(), ItExpr.IsAny<ValidationContext>())
+                .Callback((object o, ValidationContext context) =>
+                {
+                    Assert.Equal(expectedMemberName, context.MemberName);
+                })
+                .Returns(ValidationResult.Success)
+                .Verifiable();
+            var validator = new DataAnnotationsModelValidator(_noValidatorProviders, attribute.Object);
+            var metadata = _metadataProvider.GetMetadataForProperty(() => string.Empty, typeof(AnnotatedModel), "Name");
+
+            // Act
+            var results = validator.Validate(metadata, container: null);
 
             // Assert
             Assert.Empty(results);

--- a/test/System.Web.Http.Test/Validation/Validators/DataAnnotationsModelValidatorTest.cs
+++ b/test/System.Web.Http.Test/Validation/Validators/DataAnnotationsModelValidatorTest.cs
@@ -59,7 +59,7 @@ namespace System.Web.Http.Validation.Validators
                     },
                     {
                         _metadataProvider.GetMetadataForType(() => new object(), typeof(SampleModel)),
-                        "SampleModel"
+                        null
                     }
                 };
             }


### PR DESCRIPTION
- #120

No longer true:
~~`ValidationAttribute` classes that (incorrectly) expected `MemberName` to always be set or that
instantiate `ValidationResult`s using the `DisplayName` may be negatively impacted. For exmaple,
`MemberName` will be `null` when binding parameters and items in a collection.~~