### PR TITLE
Restore `HttpRequestContext.Principal` after executing inner message handlers

### DIFF
--- a/src/System.Web.Http/Hosting/SuppressHostPrincipalMessageHandler.cs
+++ b/src/System.Web.Http/Hosting/SuppressHostPrincipalMessageHandler.cs
@@ -25,7 +25,7 @@ namespace System.Web.Http.Hosting
             () => new ClaimsPrincipal(new ClaimsIdentity()), isThreadSafe: true);
 
         /// <inheritdoc />
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
             if (request == null)
@@ -33,23 +33,31 @@ namespace System.Web.Http.Hosting
                 throw new ArgumentNullException("request");
             }
 
-            SetCurrentPrincipalToAnonymous(request);
-
-            return base.SendAsync(request, cancellationToken);
+            var previousPrincipal = SetCurrentPrincipal(request, _anonymousPrincipal.Value);
+            try
+            {
+                return await base.SendAsync(request, cancellationToken);
+            }
+            finally
+            {
+                SetCurrentPrincipal(request, previousPrincipal);
+            }
         }
 
-        private static void SetCurrentPrincipalToAnonymous(HttpRequestMessage request)
+        private static IPrincipal SetCurrentPrincipal(HttpRequestMessage request, IPrincipal principal)
         {
             Contract.Assert(request != null);
 
             HttpRequestContext requestContext = request.GetRequestContext();
-
             if (requestContext == null)
             {
                 throw new ArgumentException(SRResources.Request_RequestContextMustNotBeNull, "request");
             }
 
-            requestContext.Principal = _anonymousPrincipal.Value;
+            var previousPrincipal = requestContext.Principal;
+            requestContext.Principal = principal;
+
+            return previousPrincipal;
         }
     }
 }


### PR DESCRIPTION
- #119

nits: use `var` more in affected tests