### PR TITLE
Do not include compiler-generated names in expression names

### DIFF
--- a/src/System.Web.Mvc/ExpressionHelper.cs
+++ b/src/System.Web.Mvc/ExpressionHelper.cs
@@ -35,6 +35,7 @@ namespace System.Web.Mvc
 
                     if (!IsSingleArgumentIndexer(methodExpression))
                     {
+                        // Unsupported
                         break;
                     }
 
@@ -59,7 +60,18 @@ namespace System.Web.Mvc
                 else if (part.NodeType == ExpressionType.MemberAccess)
                 {
                     MemberExpression memberExpressionPart = (MemberExpression)part;
-                    nameParts.Push("." + memberExpressionPart.Member.Name);
+                    var name = memberExpressionPart.Member.Name;
+
+                    // If identifier contains "__", it is "reserved for use by the implementation" and likely compiler-
+                    // or Razor-generated e.g. the name of a field in a delegate's generated class.
+                    if (name.Contains("__"))
+                    {
+                        // Exit loop. Should have the entire name because previous MemberAccess has same name as the
+                        // leftmost expression node (a variable).
+                        break;
+                    }
+
+                    nameParts.Push("." + name);
                     part = memberExpressionPart.Expression;
                 }
                 else if (part.NodeType == ExpressionType.Parameter)
@@ -69,15 +81,19 @@ namespace System.Web.Mvc
                     // string onto the stack and stop evaluating. The extra empty string makes sure that
                     // we don't accidentally cut off too much of m => m.Model.
                     nameParts.Push(String.Empty);
-                    part = null;
+
+                    // Exit loop. Have the entire name because the parameter cannot be used as an indexer; always the
+                    // leftmost expression node.
+                    break;
                 }
                 else
                 {
+                    // Unsupported
                     break;
                 }
             }
 
-            // If it starts with "model", then strip that away
+            // If parts start with "model", then strip that part away.
             if (nameParts.Count > 0 && String.Equals(nameParts.Peek(), ".model", StringComparison.OrdinalIgnoreCase))
             {
                 nameParts.Pop();


### PR DESCRIPTION
- #117
- see also aspnet/Mvc@a045324d3a and PR aspnet/Mvc#3027, the fix for aspnet/Mvc#2890

nits: copy some improved comments from aspnet/Mvc@a045324d3a