### PR TITLE
Move to 5.2.6 / 3.2.6 Preview1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@ ASP.NET MVC, Web API, Web Pages, and Razor
 
 AppVeyor: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/aspnet/aspnetwebstack?branch=master&svg=true)](https://ci.appveyor.com/project/aspnetci/aspnetwebstack/branch/master)
 
-## Note: This repo is for ASP.NET MVC 5.x, Web API 2.x, and Web Pages 3.x. For ASP.NET Core MVC, check the [MVC repo](https://github.com/aspnet/Mvc).
+## Note: This repo is for ASP.NET MVC 5.x, Web API 5.x, and Web Pages 3.x. For ASP.NET Core MVC, check the [MVC repo](https://github.com/aspnet/Mvc).
 
 ASP.NET MVC is a web framework that gives you a powerful, patterns-based way to build dynamic websites and Web APIs. ASP.NET MVC enables a clean separation of concerns and gives you full control over markup.
 
 This repo includes:
 
 * ASP.NET MVC 5.x
-* ASP.NET Web API 2.x
+* ASP.NET Web API 5.x
 * ASP.NET Web Pages 3.x
 * ASP.NET Razor 3.x
 
@@ -26,5 +26,5 @@ Git tag|Git branch|Other products|MVC package versions|Web API package (product)
 [v2.1](https://github.com/aspnet/AspNetWebStack/tree/v2.1)||ASP.NET and Web Tools 2012.2, VS 2012 Update 2 (not on http://nuget.org)|v4 2012.2 Update RTM|v1 2012.2 Update RTM|v2 2012.2 Update RTM
 [v3.0.2](https://github.com/aspnet/AspNetWebStack/tree/v3.0.2)|[v3-rtm](https://github.com/aspnet/AspNetWebStack/tree/v3-rtm)||5.0.2|5.0.1 (2.0.1)|3.0.1
 [v3.1.3](https://github.com/aspnet/AspNetWebStack/tree/v3.1.3)|[v3.1-rtm](https://github.com/aspnet/AspNetWebStack/tree/v3.1-rtm)||5.1.3|5.1.2 (2.1.2)|3.1.2
-[v3.2.4](https://github.com/aspnet/AspNetWebStack/tree/v3.2.4)||In https://dotnet.myget.org/gallery/aspnetwebstack-dev feed; not on https://nuget.org yet|5.2.4|5.2.4 (2.2.4)|3.2.4
-||[master](https://github.com/aspnet/AspNetWebStack/tree/master)|New work e.g. Web API 2.2.5-preview1|||
+[v3.2.5](https://github.com/aspnet/AspNetWebStack/tree/v3.2.5)|||5.2.5|5.2.5|3.2.5
+||[master](https://github.com/aspnet/AspNetWebStack/tree/master)|New work e.g. MVC 5.2.6-preview1|||

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -28,8 +28,8 @@ using System.Runtime.InteropServices;
 #error Runtime projects cannot define more than one of ASPNETMVC, ASPNETWEBPAGES or ASPNETFACEBOOK
 #elif ASPNETMVC
 #if !BUILD_GENERATED_VERSION
-[assembly: AssemblyVersion("5.2.5.0")] // ASPNETMVC
-[assembly: AssemblyFileVersion("5.2.5.0")] // ASPNETMVC
+[assembly: AssemblyVersion("5.2.6.0")] // ASPNETMVC
+[assembly: AssemblyFileVersion("5.2.6.0")] // ASPNETMVC
 #endif
 [assembly: AssemblyProduct("Microsoft ASP.NET MVC")]
 #elif ASPNETWEBPAGES

--- a/src/CommonAssemblyInfo.vb
+++ b/src/CommonAssemblyInfo.vb
@@ -20,6 +20,6 @@ Imports System.Runtime.InteropServices
 ' Version numbers are automatically generated based on regular expressions.
 ' ===========================================================================
 
-<Assembly: AssemblyVersion("5.2.5.0")>   'ASPNETMVC
-<Assembly: AssemblyFileVersion("5.2.5.0")>   'ASPNETMVC
+<Assembly: AssemblyVersion("5.2.6.0")>   'ASPNETMVC
+<Assembly: AssemblyFileVersion("5.2.6.0")>   'ASPNETMVC
 <Assembly: AssemblyProduct("Microsoft ASP.NET MVC")>

--- a/src/WebApiHelpPage/Areas/HelpPage/Views/Web.config
+++ b/src/WebApiHelpPage/Areas/HelpPage/Views/Web.config
@@ -9,7 +9,7 @@
   </configSections>
 
   <system.web.webPages.razor>
-    <host factoryType="System.Web.Mvc.MvcWebRazorHostFactory, System.Web.Mvc, Version=5.2.5.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
+    <host factoryType="System.Web.Mvc.MvcWebRazorHostFactory, System.Web.Mvc, Version=5.2.6.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
     <pages pageBaseType="System.Web.Mvc.WebViewPage">
       <namespaces>
         <add namespace="System.Web.Mvc" />

--- a/src/WebApiHelpPage/VB/Areas/HelpPage/Views/Web.config
+++ b/src/WebApiHelpPage/VB/Areas/HelpPage/Views/Web.config
@@ -9,7 +9,7 @@
   </configSections>
 
   <system.web.webPages.razor>
-    <host factoryType="System.Web.Mvc.MvcWebRazorHostFactory, System.Web.Mvc, Version=5.2.5.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
+    <host factoryType="System.Web.Mvc.MvcWebRazorHostFactory, System.Web.Mvc, Version=5.2.6.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
     <pages pageBaseType="System.Web.Mvc.WebViewPage">
       <namespaces>
         <add namespace="System.Web.Mvc" />

--- a/test/Microsoft.Web.Mvc.Test/Test/VersionTest.cs
+++ b/test/Microsoft.Web.Mvc.Test/Test/VersionTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Web.Test
         public void VerifyMVCVersionChangesAreIntentional()
         {
             Version mvcVersion = VersionTestHelper.GetVersionFromAssembly("System.Web.Mvc", typeof(Controller));
-            Assert.Equal(new Version(5, 2, 5, 0), mvcVersion);
+            Assert.Equal(new Version(5, 2, 6, 0), mvcVersion);
         }
     }
 }

--- a/test/System.Web.WebPages.Test/App.config
+++ b/test/System.Web.WebPages.Test/App.config
@@ -11,7 +11,7 @@
       <dependentAssembly>
         <!-- Need this because the BinarySerializer uses the TypeForwardedFrom attribute and deserializes to the original assembly (MVC 2.0) for the HttpAntiForgeryException test -->
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-5.2.5.0" newVersion="5.2.5.0" />
+        <bindingRedirect oldVersion="1.0.0.0-5.2.6.0" newVersion="5.2.6.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
- match combination of eb1bfe51a1 and 986889d81c i.e. the upgrade to 5.2.5 / 3.2.5 Preview1
- also change README.md to use "Web API 5.x" instead of "Web API 2.x"