### PR TITLE
Update SelectExtensions to handle nested expressions where no name is parsed

### DIFF
--- a/src/System.Web.Mvc/Html/SelectExtensions.cs
+++ b/src/System.Web.Mvc/Html/SelectExtensions.cs
@@ -285,7 +285,7 @@ namespace System.Web.Mvc.Html
         private static IEnumerable<SelectListItem> GetSelectData(this HtmlHelper htmlHelper, string name)
         {
             object o = null;
-            if (htmlHelper.ViewData != null)
+            if (htmlHelper.ViewData != null && !String.IsNullOrEmpty(name))
             {
                 o = htmlHelper.ViewData.Eval(name);
             }
@@ -396,9 +396,9 @@ namespace System.Web.Mvc.Html
 
             // If we haven't already used ViewData to get the entire list of items then we need to
             // use the ViewData-supplied value before using the parameter-supplied value.
-            if (defaultValue == null && !String.IsNullOrEmpty(name))
+            if (defaultValue == null)
             {
-                if (!usedViewData)
+                if (!usedViewData && !String.IsNullOrEmpty(name))
                 {
                     defaultValue = htmlHelper.ViewData.Eval(name);
                 }

--- a/test/System.Web.Mvc.Test/Util/MvcHelper.cs
+++ b/test/System.Web.Mvc.Test/Util/MvcHelper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.IO;
+using System.Linq.Expressions;
 using System.Web;
 using System.Web.Mvc;
 using System.Web.Routing;
@@ -150,6 +151,25 @@ namespace Microsoft.Web.UnitTestUtil
         public static HttpContextBase GetHttpContext(string appPath, string requestPath, string httpMethod)
         {
             return GetHttpContext(appPath, requestPath, httpMethod, Uri.UriSchemeHttp.ToString(), -1);
+        }
+
+        public static ViewDataDictionary<TValue> GetNestedViewData<TModel, TValue>(ViewDataDictionary<TModel> viewData, Expression<Func<TModel, TValue>> expression)
+        {
+            var metadata = ModelMetadata.FromLambdaExpression(expression, viewData);
+            var htmlFieldName = ExpressionHelper.GetExpressionText(expression);
+
+
+            ViewDataDictionary nestedViewData = new ViewDataDictionary(viewData)
+            {
+                Model = metadata.Model,
+                ModelMetadata = metadata,
+                TemplateInfo = new TemplateInfo
+                {
+                    HtmlFieldPrefix = viewData.TemplateInfo.GetFullHtmlFieldName(htmlFieldName),
+                }
+            };
+
+            return new ViewDataDictionary<TValue>(nestedViewData);
         }
 
         public static ViewContext GetViewContextWithPath(string appPath, ViewDataDictionary viewData)


### PR DESCRIPTION
Similar to #165.

When calling `Html.DropDownListFor(m => m, selectList)`, the default value from the model is not marked as selected in the provided select list because it is being guarded by a `!String.IsNullOrEmpty(name)` condition unnecessarily.

Test "DropDownListForUsesLambdaDefaultValueWhenNested" exercises the new functionality allowed. 
 The other tests added ensure no change for similar use-cases that currently work to ensure those are not broken.