### PR TITLE
Include 5.2.4 in 'Tags and releases' list

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,6 @@ Git tag|Git branch|Other products|MVC package versions|Web API package (product)
 [v2.1](https://github.com/aspnet/AspNetWebStack/tree/v2.1)||ASP.NET and Web Tools 2012.2, VS 2012 Update 2 (not on http://nuget.org)|v4 2012.2 Update RTM|v1 2012.2 Update RTM|v2 2012.2 Update RTM
 [v3.0.2](https://github.com/aspnet/AspNetWebStack/tree/v3.0.2)|[v3-rtm](https://github.com/aspnet/AspNetWebStack/tree/v3-rtm)||5.0.2|5.0.1 (2.0.1)|3.0.1
 [v3.1.3](https://github.com/aspnet/AspNetWebStack/tree/v3.1.3)|[v3.1-rtm](https://github.com/aspnet/AspNetWebStack/tree/v3.1-rtm)||5.1.3|5.1.2 (2.1.2)|3.1.2
+[v3.2.4](https://github.com/aspnet/AspNetWebStack/tree/v3.2.4)|||5.2.4|5.2.4 (2.2.4)|3.2.4
 [v3.2.6](https://github.com/aspnet/AspNetWebStack/tree/v3.2.6)|||5.2.6|5.2.6|3.2.6
 ||[master](https://github.com/aspnet/AspNetWebStack/tree/master)|New work e.g. MVC 5.2.7-preview1|||


### PR DESCRIPTION
5.2.4 was a widely announced release (https://blogs.msdn.microsoft.com/webdev/2018/02/12/announcing-asp-net-mvc-5-2-4-web-api-5-2-4-and-web-pages-3-2-4). Can it be included in this list to make it easier to get to the proper source code tag?