### PR TITLE
Fixed ASP.NET Web API version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@ ASP.NET MVC, Web API, Web Pages, and Razor
 
 AppVeyor: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/aspnet/aspnetwebstack?branch=master&svg=true)](https://ci.appveyor.com/project/aspnetci/aspnetwebstack/branch/master)
 
-## Note: This repo is for ASP.NET MVC 5.x, Web API 5.x, and Web Pages 3.x. For ASP.NET Core MVC, check the [MVC repo](https://github.com/aspnet/Mvc).
+## Note: This repo is for ASP.NET MVC 5.x, Web API 2.x, and Web Pages 3.x. For ASP.NET Core MVC, check the [MVC repo](https://github.com/aspnet/Mvc).
 
 ASP.NET MVC is a web framework that gives you a powerful, patterns-based way to build dynamic websites and Web APIs. ASP.NET MVC enables a clean separation of concerns and gives you full control over markup.
 
 This repo includes:
 
 * ASP.NET MVC 5.x
-* ASP.NET Web API 5.x
+* ASP.NET Web API 2.x
 * ASP.NET Web Pages 3.x
 * ASP.NET Razor 3.x
 


### PR DESCRIPTION
Fixed ASP.NET Web API version in `README.md`, to make it be same as the Repository Description.