### PR TITLE
Make `OwinHttpRequestContext.VirtualPathRoot` unescaped

### DIFF
--- a/src/System.Web.Http.Owin/OwinHttpRequestContext.cs
+++ b/src/System.Web.Http.Owin/OwinHttpRequestContext.cs
@@ -182,7 +182,7 @@ namespace System.Web.Http.Owin
                 {
                     // Set the virtual path root for link resolution and link generation to work
                     // OWIN spec requires request path base to be either the empty string or start with "/"
-                    string requestPathBase = _context.Request.PathBase.ToString();
+                    string requestPathBase = _context.Request.PathBase.Value;
                     _virtualPathRoot = String.IsNullOrEmpty(requestPathBase) ? "/" : requestPathBase;
                     _virtualPathRootSet = true;
                 }

--- a/test/System.Web.Http.Owin.Test/OwinHttpRequestContextTests.cs
+++ b/test/System.Web.Http.Owin.Test/OwinHttpRequestContextTests.cs
@@ -564,6 +564,30 @@ namespace System.Web.Http.Owin
             }
         }
 
+        // Regression test for #203.
+        [Fact]
+        public void VirtualPathRootGet_ReturnsUnescapedContextRequestPathBase()
+        {
+            // Arrange
+            var expectedVirtualPathRoot = "/a b";
+            var owinRequestMock = new Mock<IOwinRequest>(MockBehavior.Strict);
+            owinRequestMock
+                .Setup(r => r.PathBase)
+                .Returns(new PathString(expectedVirtualPathRoot));
+
+            var owinContext = CreateStubOwinContext(owinRequestMock.Object);
+            using (var request = CreateRequest())
+            {
+                var context = CreateProductUnderTest(owinContext, request);
+
+                // Act
+                var virtualPathRoot = context.VirtualPathRoot;
+
+                // Assert
+                Assert.Equal(expectedVirtualPathRoot, virtualPathRoot);
+            }
+        }
+
         [Theory]
         [InlineData(null)]
         [InlineData("")]

--- a/test/System.Web.Http.SelfHost.Test/SelfHostHttpRequestContextTests.cs
+++ b/test/System.Web.Http.SelfHost.Test/SelfHostHttpRequestContextTests.cs
@@ -580,6 +580,28 @@ namespace System.Web.Http.SelfHost
             }
         }
 
+        [Theory]
+        [InlineData("a b")]
+        [InlineData("/a b")]
+        [InlineData("/a%20b")]
+        public void VirtualPathRootGet_ReturnsUnescapedConfigurationVirtualPathRoot(string configurationVirtualPathRoot)
+        {
+            // Arrange
+            var expectedVirtualPathRoot = "/a b";
+            using (var serviceModelContext = CreateStubServiceModelContext())
+            using (var configuration = CreateConfiguration(configurationVirtualPathRoot))
+            using (var request = CreateRequest())
+            {
+                var context = CreateProductUnderTest(serviceModelContext, configuration, request);
+
+                // Act
+                var virtualPathRoot = context.VirtualPathRoot;
+
+                // Assert
+                Assert.Equal(expectedVirtualPathRoot, virtualPathRoot);
+            }
+        }
+
         [Fact]
         public void VirtualPathRootSet_UpdatesVirtualPathRoot()
         {

--- a/test/System.Web.Http.Test/Controllers/RequestBackedHttpRequestContextTests.cs
+++ b/test/System.Web.Http.Test/Controllers/RequestBackedHttpRequestContextTests.cs
@@ -609,7 +609,7 @@ namespace System.Web.Http.Controllers
         {
             // Arrange
             string expectedVirtualPathRoot = "/";
-            
+
             using (HttpConfiguration configuration = new HttpConfiguration(new HttpRouteCollection(
                 expectedVirtualPathRoot)))
             {
@@ -621,6 +621,28 @@ namespace System.Web.Http.Controllers
 
                 // Assert
                 Assert.Same(expectedVirtualPathRoot, virtualPathRoot);
+            }
+        }
+
+        [Theory]
+        [InlineData("a b")]
+        [InlineData("/a b")]
+        [InlineData("/a%20b")]
+        public void VirtualPathRootGet_ReturnsUnescapedConfigurationVirtualPathRoot(string configurationVirtualPathRoot)
+        {
+            // Arrange
+            var expectedVirtualPathRoot = "/a b";
+            using (var routeCollection = new HttpRouteCollection(configurationVirtualPathRoot))
+            using (var configuration = new HttpConfiguration(routeCollection))
+            {
+                var context = CreateProductUnderTest();
+                context.Configuration = configuration;
+
+                // Act
+                var virtualPathRoot = context.VirtualPathRoot;
+
+                // Assert
+                Assert.Equal(expectedVirtualPathRoot, virtualPathRoot);
             }
         }
 

--- a/test/System.Web.Http.WebHost.Test/WebHostHttpRequestContextTests.cs
+++ b/test/System.Web.Http.WebHost.Test/WebHostHttpRequestContextTests.cs
@@ -753,6 +753,31 @@ namespace System.Web.Http.WebHost
             }
         }
 
+        [Theory]
+        [InlineData("a b")]
+        [InlineData("/a b")]
+        [InlineData("/a%20b")]
+        public void VirtualPathRootGet_ReturnsUnescapedConfigurationVirtualPathRoot(string configurationVirtualPathRoot)
+        {
+            // Arrange
+            var expectedVirtualPathRoot = "/a b";
+            var webContext = CreateDummyWebContext();
+            var webRequest = CreateDummyWebRequest();
+
+            using (var request = CreateRequest())
+            using (var configuration = CreateConfiguration(configurationVirtualPathRoot))
+            {
+                var context = CreateProductUnderTest(webContext, webRequest, request);
+                context.Configuration = configuration;
+
+                // Act
+                var virtualPathRoot = context.VirtualPathRoot;
+
+                // Assert
+                Assert.Equal(expectedVirtualPathRoot, virtualPathRoot);
+            }
+        }
+
         [Fact]
         public void VirtualPathRootSet_UpdatesVirtualPathRoot()
         {


### PR DESCRIPTION
- #203
- now consistent with other overrides of this property