### PR TITLE
Replace link to outdated repo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ASP.NET MVC, Web API, Web Pages, and Razor
 
 AppVeyor: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/aspnet/aspnetwebstack?branch=master&svg=true)](https://ci.appveyor.com/project/aspnetci/aspnetwebstack/branch/master)
 
-## Note: This repo is for ASP.NET MVC 5.x, Web API 2.x, and Web Pages 3.x. For ASP.NET Core MVC, check the [MVC repo](https://github.com/aspnet/Mvc).
+## Note: This repo is for ASP.NET MVC 5.x, Web API 2.x, and Web Pages 3.x. For ASP.NET Core MVC, check the [AspNetCore repo](https://github.com/aspnet/AspNetCore).
 
 ASP.NET MVC is a web framework that gives you a powerful, patterns-based way to build dynamic websites and Web APIs. ASP.NET MVC enables a clean separation of concerns and gives you full control over markup.
 


### PR DESCRIPTION
The readme.md for the repo https://github.com/aspnet/Mvc says "This GitHub project has been archived. Ongoing development on this project can be found in https://github.com/aspnet/AspNetCore."