### PR TITLE
[releaes/3.2.8] Get builds working again

### DIFF
--- a/src/System.Net.Http.Formatting/Formatting/Parsers/InternetMessageFormatHeaderParser.cs
+++ b/src/System.Net.Http.Formatting/Formatting/Parsers/InternetMessageFormatHeaderParser.cs
@@ -10,8 +10,8 @@ using System.Web.Http;
 namespace System.Net.Http.Formatting.Parsers
 {
     /// <summary>
-    /// Buffer-oriented RFC 5322 style Internet Message Format parser which can be used to pass header 
-    /// fields used in HTTP and MIME message entities. 
+    /// Buffer-oriented RFC 5322 style Internet Message Format parser which can be used to pass header
+    /// fields used in HTTP and MIME message entities.
     /// </summary>
     internal class InternetMessageFormatHeaderParser
     {
@@ -76,7 +76,7 @@ namespace System.Net.Http.Formatting.Parsers
 
         /// <summary>
         /// Parse a buffer of RFC 5322 style header fields and add them to the <see cref="HttpHeaders"/> collection.
-        /// Bytes are parsed in a consuming manner from the beginning of the buffer meaning that the same bytes can not be 
+        /// Bytes are parsed in a consuming manner from the beginning of the buffer meaning that the same bytes can not be
         /// present in the buffer.
         /// </summary>
         /// <param name="buffer">Request buffer from where request is read</param>
@@ -283,7 +283,7 @@ namespace System.Net.Http.Formatting.Parsers
         }
 
         /// <summary>
-        /// Maintains information about the current header field being parsed. 
+        /// Maintains information about the current header field being parsed.
         /// </summary>
         private class CurrentHeaderFieldStore
         {
@@ -320,6 +320,10 @@ namespace System.Net.Http.Formatting.Parsers
             {
                 var name = _name.ToString();
                 var value = _value.ToString().Trim(CurrentHeaderFieldStore._linearWhiteSpace);
+                if (string.Equals("expires", name, StringComparison.OrdinalIgnoreCase))
+                {
+                    ignoreHeaderValidation = true;
+                }
 
                 if (ignoreHeaderValidation)
                 {

--- a/src/WebApiHelpPage/VB/WebApiHelpPageVB.vbproj
+++ b/src/WebApiHelpPage/VB/WebApiHelpPageVB.vbproj
@@ -11,6 +11,8 @@
     <RunCodeAnalysis>$(CodeAnalysis)</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\..\Strict.ruleset</CodeAnalysisRuleSet>
     <MyType>Windows</MyType>
+    <!-- Ignore warning about deprecated <licenseUrl> in the .nuspec. -->
+    <NoWarn Condition=" '$(MSBuildRuntimeType)' == 'core' ">$(NoWarn);NU5125</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DefineDebug>true</DefineDebug>

--- a/src/WebApiHelpPage/WebApiHelpPage.csproj
+++ b/src/WebApiHelpPage/WebApiHelpPage.csproj
@@ -13,6 +13,8 @@
     <CodeAnalysisRuleSet>..\Strict.ruleset</CodeAnalysisRuleSet>
     <DefineConstants>$(DefineConstants);ASPNETMVC</DefineConstants>
     <NoWarn>1591</NoWarn>
+    <!-- Ignore warning about deprecated <licenseUrl> in the .nuspec. -->
+    <NoWarn Condition=" '$(MSBuildRuntimeType)' == 'core' ">$(NoWarn);NU5125</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/test/Microsoft.TestCommon/PlatformInfo.cs
+++ b/test/Microsoft.TestCommon/PlatformInfo.cs
@@ -26,7 +26,7 @@ namespace Microsoft.TestCommon
         {
             if (Type.GetType(_netCore20TypeName, throwOnError: false) != null)
             {
-                // Treat .NET Core 2.0 as a .NET 4.5 superset though internal types are different.
+                // Treat .NET Core 2.1 as a .NET 4.5 superset though internal types are different.
                 return Platform.Net45;
             }
 

--- a/test/System.Net.Http.Formatting.NetStandard.Test/System.Net.Http.Formatting.NetStandard.Test.csproj
+++ b/test/System.Net.Http.Formatting.NetStandard.Test/System.Net.Http.Formatting.NetStandard.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),Runtime.sln))\tools\WebStack.settings.targets" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <RootNamespace>System.Net.Http</RootNamespace>
     <AssemblyName>System.Net.Http.Formatting.NetStandard.Test</AssemblyName>
     <OutputPath>..\..\bin\$(Configuration)\Test\</OutputPath>

--- a/test/System.Net.Http.Formatting.Test/DataSets/HttpTestData.cs
+++ b/test/System.Net.Http.Formatting.Test/DataSets/HttpTestData.cs
@@ -302,11 +302,11 @@ namespace System.Net.Http.Formatting.DataSets
                     { "This is a test 激光這兩個字是甚麼意思 string written using utf-8", "utf-8", true },
                     { "This is a test 激光這兩個字是甚麼意思 string written using utf-16", "utf-16", true },
                     { "This is a test 激光這兩個字是甚麼意思 string written using utf-32", "utf-32", false },
-#if !NETCOREAPP2_0 // shift_jis and iso-2022-kr are not supported when running on .NET Core 2.0.
+#if !NETCOREAPP // shift_jis and iso-2022-kr are not supported when running on .NET Core 2.1.
                     { "This is a test 激光這兩個字是甚麼意思 string written using shift_jis", "shift_jis", false },
 #endif
                     { "This is a test æøå string written using iso-8859-1", "iso-8859-1", false },
-#if !NETCOREAPP2_0
+#if !NETCOREAPP
                     { "This is a test 레이저 단어 뜻 string written using iso-2022-kr", "iso-2022-kr", false },
 #endif
                 };

--- a/test/System.Net.Http.Formatting.Test/Formatting/BsonMediaTypeFormatterTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/BsonMediaTypeFormatterTests.cs
@@ -415,7 +415,7 @@ namespace System.Net.Http.Formatting
             Assert.Null(readObj);
         }
 
-#if !NETCOREAPP2_0 // DBNull not serializable on .NET Core 2.0 except at top level (using BsonMediaTypeformatter special case).
+#if !NETCOREAPP // DBNull not serializable on .NET Core 2.1 except at top level (using BsonMediaTypeformatter special case).
         [Theory]
         [TestDataSet(typeof(JsonMediaTypeFormatterTests), "DBNullAsObjectTestDataCollection", TestDataVariations.AsDictionary)]
         public async Task ReadFromStreamAsync_RoundTripsWriteToStreamAsync_DBNullAsNull_Dictionary(Type variationType, object testData)

--- a/test/System.Net.Http.Formatting.Test/Formatting/DataContractJsonMediaTypeFormatterTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/DataContractJsonMediaTypeFormatterTests.cs
@@ -157,7 +157,7 @@ namespace System.Net.Http.Formatting
             }
         }
 
-#if !NETCOREAPP2_0 // DBNull not serializable on .NET Core 2.0.
+#if !NETCOREAPP // DBNull not serializable on .NET Core 2.1.
         // Test alternate null value
         [Fact]
         public async Task ReadFromStreamAsync_RoundTripsWriteToStreamAsync_DBNull()

--- a/test/System.Net.Http.Formatting.Test/Formatting/JsonMediaTypeFormatterTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/JsonMediaTypeFormatterTests.cs
@@ -374,7 +374,7 @@ namespace System.Net.Http.Formatting
             }
         }
 
-#if !NETCOREAPP2_0 // DBNull not serializable on .NET Core 2.0.
+#if !NETCOREAPP // DBNull not serializable on .NET Core 2.1.
         // Test alternate null value; always serialized as "null"
         [Theory]
         [TestDataSet(typeof(JsonMediaTypeFormatterTests), "DBNullAsObjectTestDataCollection", TestDataVariations.AllSingleInstances)]

--- a/test/System.Net.Http.Formatting.Test/Formatting/JsonNetSerializationTest.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/JsonNetSerializationTest.cs
@@ -258,7 +258,7 @@ namespace System.Net.Http.Formatting
         // low surrogate not preceded by high surrogate
         [InlineData("ABC \\udc00\\ud800 DEF", "ABC \ufffd\ufffd DEF")]
         // make sure unencoded invalid surrogate characters don't make it through
-#if NETCOREAPP2_0 // Json.NET uses its regular invalid Unicode character on .NET Core 2.0; '?' elsewhere.
+#if NETCOREAPP // Json.NET uses its regular invalid Unicode character on .NET Core 2.1; '?' elsewhere.
         [InlineData("\udc00\ud800\ud800", "\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd")]
 #else
         [InlineData("\udc00\ud800\ud800", "??????")]

--- a/test/System.Net.Http.Formatting.Test/Formatting/XmlMediaTypeFormatterTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/XmlMediaTypeFormatterTests.cs
@@ -36,7 +36,7 @@ namespace System.Net.Http.Formatting
                 Int32.MaxValue,
                 Int64.MinValue,
                 Int64.MaxValue,
-#if !NETCOREAPP2_0 // DBNull not serializable on .NET Core 2.0.
+#if !NETCOREAPP // DBNull not serializable on .NET Core 2.1.
                 DBNull.Value,
 #endif
             });
@@ -484,7 +484,7 @@ namespace System.Net.Http.Formatting
             }
         }
 
-#if !NETCOREAPP2_0 // DBNull not serializable on .NET Core 2.0.
+#if !NETCOREAPP // DBNull not serializable on .NET Core 2.1.
         [Fact]
         public async Task ReadFromStreamAsync_RoundTripsWriteToStreamAsyncUsingDataContractSerializer_DBNull()
         {

--- a/test/System.Net.Http.Formatting.Test/Internal/HttpValueCollectionTest.cs
+++ b/test/System.Net.Http.Formatting.Test/Internal/HttpValueCollectionTest.cs
@@ -14,7 +14,7 @@ namespace System.Net.Http.Internal
 {
     public class HttpValueCollectionTest
     {
-#if !NETCOREAPP2_0 // Unused on .NET Core 2.0.
+#if !NETCOREAPP // Unused on .NET Core 2.1.
         private static readonly int _maxCollectionKeys = 1000;
 #endif
 
@@ -148,7 +148,7 @@ namespace System.Net.Http.Internal
             Assert.Empty(nvc);
         }
 
-#if !NETCOREAPP2_0 // DBNull not serializable on .NET Core 2.0.
+#if !NETCOREAPP // DBNull not serializable on .NET Core 2.1.
         // This set of tests requires running on a separate appdomain so we don't
         // touch the static property MediaTypeFormatter.MaxHttpCollectionKeys.
         [Fact]

--- a/test/System.Net.Http.Formatting.Test/MultipartFileStreamProviderTests.cs
+++ b/test/System.Net.Http.Formatting.Test/MultipartFileStreamProviderTests.cs
@@ -32,6 +32,7 @@ namespace System.Net.Http
         private const int ValidBufferSize = 0x111;
         private const string ValidPath = @"c:\some\path";
 
+#if !NETCOREAPP // .NET Core does not enforce path validity in many APIs.
         public static TheoryDataSet<string> NotSupportedFilePaths
         {
             get
@@ -44,6 +45,7 @@ namespace System.Net.Http
                 };
             }
         }
+#endif
 
         public static TheoryDataSet<string> InvalidFilePaths
         {
@@ -52,15 +54,17 @@ namespace System.Net.Http
                 return new TheoryDataSet<string>
                 {
                     "",
-                    " ", 
+                    " ",
                     "  ",
-                    "\t\t \n ", 
+#if !NETCOREAPP // .NET Core does not enforce path validity in many APIs.
+                    "\t\t \n ",
                     "c:\\a<b",
                     "c:\\a>b",
                     "c:\\a\"b",
                     "c:\\a\tb",
                     "c:\\a|b",
                     "c:\\a\bb",
+#endif
                     "c:\\a\0b",
                     "c :\\a\0b",
                 };
@@ -73,12 +77,14 @@ namespace System.Net.Http
             Assert.ThrowsArgumentNull(() => { new MultipartFileStreamProvider(null); }, "rootPath");
         }
 
+#if !NETCOREAPP // .NET Core does not enforce path validity in many APIs.
         [Theory]
         [PropertyData("NotSupportedFilePaths")]
         public void Constructor_ThrowsOnNotSupportedRootPath(string notSupportedPath)
         {
             Assert.Throws<NotSupportedException>(() => new MultipartFileStreamProvider(notSupportedPath, ValidBufferSize));
         }
+#endif
 
         [Theory]
         [PropertyData("InvalidFilePaths")]


### PR DESCRIPTION
- test using netcoreapp2.1
- react to .NET Core breaking change
  - see https://docs.microsoft.com/en-us/dotnet/core/compatibility/2.1#path-apis-dont-throw-an-exception-for-invalid-characters
- suppress NU5125 warnings
  - break the build because warnings are treated as errors
- do not validate Expires header values
  - #263