### PR TITLE
Configure max request line size limits to be the same as maxHeaderSize

### DIFF
--- a/src/System.Net.Http.Formatting/HttpContentMessageExtensions.cs
+++ b/src/System.Net.Http.Formatting/HttpContentMessageExtensions.cs
@@ -223,7 +223,7 @@ namespace System.Net.Http
 
             HttpUnsortedRequest httpRequest = new HttpUnsortedRequest();
             HttpRequestHeaderParser parser = new HttpRequestHeaderParser(httpRequest,
-                HttpRequestHeaderParser.DefaultMaxRequestLineSize, maxHeaderSize);
+                maxHeaderSize, maxHeaderSize);
             ParserState parseStatus;
 
             byte[] buffer = new byte[bufferSize];

--- a/src/System.Net.Http.Formatting/HttpContentMessageExtensions.cs
+++ b/src/System.Net.Http.Formatting/HttpContentMessageExtensions.cs
@@ -223,7 +223,7 @@ namespace System.Net.Http
 
             HttpUnsortedRequest httpRequest = new HttpUnsortedRequest();
             HttpRequestHeaderParser parser = new HttpRequestHeaderParser(httpRequest,
-                maxHeaderSize, maxHeaderSize);
+                Math.Max(HttpRequestHeaderParser.DefaultMaxRequestLineSize, maxHeaderSize), maxHeaderSize);
             ParserState parseStatus;
 
             byte[] buffer = new byte[bufferSize];


### PR DESCRIPTION
As part of ReadAsHttpRequestMessageAsync, the parsing of the HTTP request line is limited
by a non-configurable 2k limit. The size does not affect buffer sizes, only the maximum allowed length.

This PR updates the ReadAsHttpRequestMessageAsync API to use the same limits for HTTP request line
as the HTTP header line, the latter which is configurable by user code.
In the default case, this means the HTTP request line size now supports a 16k limit before it throws.

Fixes https://github.com/aspnet/AspNetWebStack/issues/307