### PR TITLE
Move `Microsoft.Owin*` packages to 4.2.2

### DIFF
--- a/src/System.Web.Http.Owin/System.Web.Http.Owin.csproj
+++ b/src/System.Web.Http.Owin/System.Web.Http.Owin.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Owin">
-      <HintPath>..\..\packages\Microsoft.Owin.2.0.2\lib\net45\Microsoft.Owin.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Owin.4.2.2\lib\net45\Microsoft.Owin.dll</HintPath>
     </Reference>
     <Reference Include="Owin">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>

--- a/src/System.Web.Http.Owin/packages.config
+++ b/src/System.Web.Http.Owin/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Owin" version="4.1.1" targetFramework="net45" />
+  <package id="Microsoft.Owin" version="4.2.2" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
 </packages>

--- a/test/System.Web.Http.Owin.Test/System.Web.Http.Owin.Test.csproj
+++ b/test/System.Web.Http.Owin.Test/System.Web.Http.Owin.Test.csproj
@@ -19,15 +19,15 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Owin">
-      <HintPath>..\..\packages\Microsoft.Owin.2.0.2\lib\net45\Microsoft.Owin.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Owin.4.2.2\lib\net45\Microsoft.Owin.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=2.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.Owin.Host.HttpListener.2.0.2\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Owin.Host.HttpListener.4.2.2\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Hosting, Version=2.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Owin.Hosting, Version=4.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.Owin.Hosting.2.0.2\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Owin.Hosting.4.2.2\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.7.142.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moq.4.7.142\lib\net45\Moq.dll</HintPath>

--- a/test/System.Web.Http.Owin.Test/packages.config
+++ b/test/System.Web.Http.Owin.Test/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
-  <package id="Microsoft.Owin" version="4.1.1" targetFramework="net452" />
-  <package id="Microsoft.Owin.Host.HttpListener" version="2.0.2" targetFramework="net452" />
-  <package id="Microsoft.Owin.Hosting" version="2.0.2" targetFramework="net452" />
+  <package id="Microsoft.Owin" version="4.2.2" targetFramework="net452" />
+  <package id="Microsoft.Owin.Host.HttpListener" version="4.2.2" targetFramework="net452" />
+  <package id="Microsoft.Owin.Hosting" version="4.2.2" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />


### PR DESCRIPTION
- follow on from #358
- use the latest versions consistently
- correct `%(Hintpath)` metadata
  - Dependabot doesn't fix this information automatically