### PR TITLE
Ease builds on CI and locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 packages
 NuGet.exe
 _[Ss]cripts
+*.binlog
 *.exe
 *.dll
 *.nupkg

--- a/Runtime.msbuild
+++ b/Runtime.msbuild
@@ -73,8 +73,8 @@
 
     <Exec Command='"$(NuGetExe)" restore "%(SolutionsToBuild.Identity)" ^
         -PackagesDirectory packages -NonInteractive ^
-        -Verbosity normal -ConfigFile "$(MsBuildThisFileDirectory)\.nuget\NuGet.Config" ^
-        -EnvironmentVariables "RestoreUseSkipNonexistentTargets=true"' />
+        -Verbosity normal -ConfigFile "$(MsBuildThisFileDirectory)\.nuget\NuGet.Config"'
+        EnvironmentVariables="RestoreUseSkipNonexistentTargets=true" />
   </Target>
 
   <!-- Pick the right Microsoft.Web.FxCop package to use and copy it to a standard location. -->

--- a/Runtime.msbuild
+++ b/Runtime.msbuild
@@ -64,29 +64,38 @@
   </Target>
 
   <Target Name="RestorePackages" DependsOnTargets="DownloadNuGet">
+    <ItemGroup>
+      <_NuGetPackagesAndSolutions Include="src\System.Net.Http.Formatting.NetCore\packages.config;
+          test\System.Net.Http.Formatting.NetCore.Test\packages.config;
+          Runtime.sln" />
+
+      <!-- Avoid restoring RuntimePortable.sln directly. -->
+      <_NuGetPackagesAndSolutions Include="src\System.Net.Http.Formatting.NetCore\packages.config;
+          test\System.Net.Http.Formatting.NetCore.Test\packages.config"
+        Condition=" '$(BuildPortable)' == 'true' " />
+      <_ProjectsToRestore Include="src\System.Net.Http.Formatting.NetStandard\System.Net.Http.Formatting.NetStandard.csproj;
+          test\System.Net.Http.Formatting.NetStandard.Test\System.Net.Http.Formatting.NetStandard.Test.csproj"
+        Condition=" '$(BuildPortable)' == 'true' " />
+    </ItemGroup>
+
     <Message Text="Restoring NuGet packages..." Importance="High" />
-
-    <!-- NuGet.exe attempts to read src\System.Net.Http.Formatting.NetCore\System.Net.Http.Formatting.NetCore.csproj and imports fails without packages. -->
-    <Exec Command='"$(NuGetExe)" restore "src\System.Net.Http.Formatting.NetCore\packages.config" ^
+    <Exec Command='"$(NuGetExe)" restore "%(_NuGetPackagesAndSolutions.Identity)" ^
         -PackagesDirectory packages -NonInteractive ^
-        -Verbosity quiet -ConfigFile "$(MsBuildThisFileDirectory)\.nuget\NuGet.Config"' />
-
-    <Exec Command='"$(NuGetExe)" restore "%(SolutionsToBuild.Identity)" ^
-        -PackagesDirectory packages -NonInteractive ^
-        -Verbosity normal -ConfigFile "$(MsBuildThisFileDirectory)\.nuget\NuGet.Config"'
-        EnvironmentVariables="RestoreUseSkipNonexistentTargets=true" />
+        -Verbosity normal -ConfigFile "$(MSBuildThisFileDirectory)\.nuget\NuGet.Config"' />
+    <MSBuild Projects="@(_ProjectsToRestore)" Targets="Restore" Properties="Configuration=$(Configuration)"
+      Condition=" '$(BuildPortable)' == 'true' " />
   </Target>
 
   <!-- Pick the right Microsoft.Web.FxCop package to use and copy it to a standard location. -->
   <Target Name="BuildTools">
     <PropertyGroup>
-        <FxCopProjectLocation>$(MsBuildThisFileDirectory)tools\src\Microsoft.Web.FxCop\</FxCopProjectLocation>
-        <CustomFxCopRulesPath>$(MsBuildThisFileDirectory)packages\CustomFxCopRules</CustomFxCopRulesPath>
+        <FxCopProjectLocation>$(MSBuildThisFileDirectory)tools\src\Microsoft.Web.FxCop\</FxCopProjectLocation>
+        <CustomFxCopRulesPath>$(MSBuildThisFileDirectory)packages\CustomFxCopRules</CustomFxCopRulesPath>
     </PropertyGroup>
-    <MsBuild
-          Condition=" '$(CodeAnalysis)' == 'true' "
-          Projects="$(FxCopProjectLocation)\Microsoft.Web.FxCop.csproj"
-          Properties="Configuration=Release;OutputPath=$(CustomFxCopRulesPath)" />
+    <MSBuild
+        Condition=" '$(CodeAnalysis)' == 'true' "
+        Projects="$(FxCopProjectLocation)\Microsoft.Web.FxCop.csproj"
+        Properties="Configuration=Release;OutputPath=$(CustomFxCopRulesPath)" />
   </Target>
 
   <Target Name="Build" DependsOnTargets="RestorePackages;BuildTools">
@@ -94,11 +103,11 @@
     <Error Condition=" '$(CodeAnalysis)' == 'true' and '$(Configuration)' == 'Release' " Text="Unable to run code analysis in Release configuration. Release assemblies do not include SuppressMessage attributes (so code analysis would always fail with the errors that are normally suppressed)." />
     <MakeDir Directories="bin\$(Configuration)" />
     <MSBuild
-          Projects="@(SolutionsToBuild)"
-          BuildInParallel="%(SolutionsToBuild.BuildInParallel)"
-          Targets="Build"
-          Condition=" '%(SolutionsToBuild.Portable)' != 'true' or '$(BuildPortable)' == 'true' "
-          Properties="Configuration=$(Configuration);CodeAnalysis=$(CodeAnalysis);StyleCopEnabled=$(StyleCopEnabled);VisualStudioVersion=$(VisualStudioVersion)" />
+        Projects="@(SolutionsToBuild)"
+        BuildInParallel="%(SolutionsToBuild.BuildInParallel)"
+        Targets="Build"
+        Condition=" '%(SolutionsToBuild.Portable)' != 'true' or '$(BuildPortable)' == 'true' "
+        Properties="Configuration=$(Configuration);CodeAnalysis=$(CodeAnalysis);StyleCopEnabled=$(StyleCopEnabled);VisualStudioVersion=$(VisualStudioVersion)" />
   </Target>
 
   <Target Name="UnitTest" DependsOnTargets="CheckSkipStrongNames;Build">

--- a/Runtime.msbuild
+++ b/Runtime.msbuild
@@ -67,9 +67,14 @@
     <Message Text="Restoring NuGet packages..." Importance="High" />
 
     <!-- NuGet.exe attempts to read src\System.Net.Http.Formatting.NetCore\System.Net.Http.Formatting.NetCore.csproj and imports fails without packages. -->
-    <Exec Command='"$(NuGetExe)" restore "src\System.Net.Http.Formatting.NetCore\packages.config" -PackagesDirectory packages -NonInteractive -Verbosity quiet -ConfigFile "$(MsBuildThisFileDirectory)\.nuget\NuGet.Config"' />
+    <Exec Command='"$(NuGetExe)" restore "src\System.Net.Http.Formatting.NetCore\packages.config"
+        -PackagesDirectory packages -NonInteractive
+        -Verbosity quiet -ConfigFile "$(MsBuildThisFileDirectory)\.nuget\NuGet.Config"' />
 
-    <Exec Command='"$(NuGetExe)" restore "%(SolutionsToBuild.Identity)" -PackagesDirectory packages -NonInteractive -Verbosity quiet -ConfigFile "$(MsBuildThisFileDirectory)\.nuget\NuGet.Config"' />
+    <Exec Command='"$(NuGetExe)" restore "%(SolutionsToBuild.Identity)"
+        -PackagesDirectory packages -NonInteractive
+        -Verbosity normal -ConfigFile "$(MsBuildThisFileDirectory)\.nuget\NuGet.Config"
+        -EnvironmentVariables "RestoreUseSkipNonexistentTargets=true"' />
   </Target>
 
   <!-- Pick the right Microsoft.Web.FxCop package to use and copy it to a standard location. -->

--- a/Runtime.msbuild
+++ b/Runtime.msbuild
@@ -67,13 +67,13 @@
     <Message Text="Restoring NuGet packages..." Importance="High" />
 
     <!-- NuGet.exe attempts to read src\System.Net.Http.Formatting.NetCore\System.Net.Http.Formatting.NetCore.csproj and imports fails without packages. -->
-    <Exec Command='"$(NuGetExe)" restore "src\System.Net.Http.Formatting.NetCore\packages.config"
-        -PackagesDirectory packages -NonInteractive
+    <Exec Command='"$(NuGetExe)" restore "src\System.Net.Http.Formatting.NetCore\packages.config" ^
+        -PackagesDirectory packages -NonInteractive ^
         -Verbosity quiet -ConfigFile "$(MsBuildThisFileDirectory)\.nuget\NuGet.Config"' />
 
-    <Exec Command='"$(NuGetExe)" restore "%(SolutionsToBuild.Identity)"
-        -PackagesDirectory packages -NonInteractive
-        -Verbosity normal -ConfigFile "$(MsBuildThisFileDirectory)\.nuget\NuGet.Config"
+    <Exec Command='"$(NuGetExe)" restore "%(SolutionsToBuild.Identity)" ^
+        -PackagesDirectory packages -NonInteractive ^
+        -Verbosity normal -ConfigFile "$(MsBuildThisFileDirectory)\.nuget\NuGet.Config" ^
         -EnvironmentVariables "RestoreUseSkipNonexistentTargets=true"' />
   </Target>
 

--- a/build.cmd
+++ b/build.cmd
@@ -26,7 +26,9 @@ if not exist %vswhere% (
 )
 
 set InstallDir=
-for /f "usebackq tokens=*" %%i in (`%vswhere% -version ^[15^,16^) -latest -prerelease -products * -requires Microsoft.Component.MSBuild -property installationPath`) do (
+for /f "usebackq tokens=*" %%i in (`%vswhere% -version ^[15^,16^) -latest -prerelease -products * ^
+    -requires Microsoft.Component.MSBuild -requires Microsoft.Net.Core.Component.SDK.2.1 ^
+    -property installationPath`) do (
   set InstallDir=%%i
 )
 if exist "%InstallDir%\MSBuild\15.0\Bin\MSBuild.exe" (

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "2.1.523"
+    "version": "2.1.500",
+    "rollForward": "latestPatch"
   }
 }

--- a/src/CodeAnalysisDictionary.xml
+++ b/src/CodeAnalysisDictionary.xml
@@ -55,6 +55,13 @@
             <Word>ModelName</Word>
             <Word>BSON</Word>
             <Word>Untyped</Word>
+            <Word>Behavior</Word>
+            <Word>Callback</Word>
+            <Word>Canceled</Word>
+            <Word>Color</Word>
+            <Word>Fallback</Word>
+            <Word>Markup</Word>
+            <Word>Preflight</Word>
         </Recognized>
         <Compound>
             <Term CompoundAlternate="WebPage">WebPage</Term>

--- a/src/System.Net.Http.Formatting.NetStandard/System.Net.Http.Formatting.NetStandard.csproj
+++ b/src/System.Net.Http.Formatting.NetStandard/System.Net.Http.Formatting.NetStandard.csproj
@@ -41,7 +41,7 @@
       <Link>Common\UriQueryUtility.cs</Link>
     </Compile>
 
-    <Compile Include="..\System.Net.Http.Formatting\**\*.cs">
+    <Compile Include="..\System.Net.Http.Formatting\**\*.cs" Exclude="..\System.Net.Http.Formatting\obj\**\*.cs">
       <Link>%(RecursiveDir)\%(Filename).cs</Link>
     </Compile>
   </ItemGroup>

--- a/test/System.Net.Http.Formatting.NetStandard.Test/System.Net.Http.Formatting.NetStandard.Test.csproj
+++ b/test/System.Net.Http.Formatting.NetStandard.Test/System.Net.Http.Formatting.NetStandard.Test.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\System.Net.Http.Formatting.Test\**\*.cs">
+    <Compile Include="..\System.Net.Http.Formatting.Test\**\*.cs" Exclude="..\System.Net.Http.Formatting.Test\obj\**\*.cs">
       <Link>%(RecursiveDir)\%(Filename).cs</Link>
     </Compile>
   </ItemGroup>

--- a/test/System.Web.Http.Integration.Test/Tracing/TracingTest.cs
+++ b/test/System.Web.Http.Integration.Test/Tracing/TracingTest.cs
@@ -380,12 +380,24 @@ namespace System.Web.Http.ModelBinding
                 // artifact specific to testing in VS. (Attempting to load all types from xunit.runner.visualstudio.testadapter.dll
                 // fails with recent xUnit.net packages. The assembly references Microsoft.VisualStudio.TestPlatform.ObjectModel.dll
                 // which is not available with xUnit.net 2.0.x.)
+                //
+                // Similarly, ignore records for the same exception to allow test to succeed when using the xUnit MSBuild runner.
+                // In that case, missing types may come from System.Web and Microsoft.Build.Utilities.v4.0 as well as xunit.runner.msbuild.net452.
                 if (actualRecord.Operation == null &&
                     actualRecord.Exception is ReflectionTypeLoadException &&
                     actualRecord.Message != null &&
-                    actualRecord.Message.StartsWith(
-                        "Exception thrown while getting types from 'xunit.runner.visualstudio.testadapter, ",
-                        StringComparison.Ordinal))
+                    (actualRecord.Message.StartsWith(
+                         "Exception thrown while getting types from 'xunit.runner.visualstudio.testadapter, ",
+                         StringComparison.Ordinal) ||
+                     actualRecord.Message.StartsWith(
+                         "Exception thrown while getting types from 'xunit.runner.msbuild.",
+                         StringComparison.Ordinal) ||
+                     actualRecord.Message.StartsWith(
+                         "Exception thrown while getting types from 'System.Web, ",
+                         StringComparison.Ordinal) ||
+                     actualRecord.Message.StartsWith(
+                         "Exception thrown while getting types from 'Microsoft.Build.Utilities.",
+                         StringComparison.Ordinal)))
                 {
                     continue;
                 }
@@ -397,8 +409,8 @@ namespace System.Web.Http.ModelBinding
 
                 if (expectedTrace == null)
                 {
-                    unexpected.Add(string.Format("kind={0} category={1}, operator={2}, operation={3}",
-                                    actualRecord.Kind, actualRecord.Category, actualRecord.Operator, actualRecord.Operation));
+                    unexpected.Add(string.Format("kind={0} category={1}, operator={2}, operation={3}, message={4}",
+                        actualRecord.Kind, actualRecord.Category, actualRecord.Operator, actualRecord.Operation, actualRecord.Message));
                 }
             }
 
@@ -422,14 +434,26 @@ namespace System.Web.Http.ModelBinding
                 // artifact specific to testing in VS. (Attempting to load all types from xunit.runner.visualstudio.testadapter.dll
                 // fails with recent xUnit.net packages. The assembly references Microsoft.VisualStudio.TestPlatform.ObjectModel.dll
                 // which is not available with xUnit.net 2.0.x.)
+                //
+                // Similarly, ignore records for the same exception to allow test to succeed when using the xUnit MSBuild runner.
+                // In that case, missing types may come from System.Web and Microsoft.Build.Utilities.v4.0 as well as xunit.runner.msbuild.net452.
                 var actualRecord = actualRecords.ElementAtOrDefault(traceBeginPos);
-                if (actualRecord != null &&
+                while (actualRecord != null &&
                     actualRecord.Operation == null &&
                     actualRecord.Exception is ReflectionTypeLoadException &&
                     actualRecord.Message != null &&
-                    actualRecord.Message.StartsWith(
-                        "Exception thrown while getting types from 'xunit.runner.visualstudio.testadapter, ",
-                        StringComparison.Ordinal))
+                    (actualRecord.Message.StartsWith(
+                         "Exception thrown while getting types from 'xunit.runner.visualstudio.testadapter, ",
+                         StringComparison.Ordinal) ||
+                     actualRecord.Message.StartsWith(
+                         "Exception thrown while getting types from 'xunit.runner.msbuild.",
+                         StringComparison.Ordinal) ||
+                     actualRecord.Message.StartsWith(
+                         "Exception thrown while getting types from 'System.Web, ",
+                         StringComparison.Ordinal) ||
+                     actualRecord.Message.StartsWith(
+                         "Exception thrown while getting types from 'Microsoft.Build.Utilities.",
+                         StringComparison.Ordinal)))
                 {
                     traceBeginPos++;
                     actualRecord = actualRecords.ElementAtOrDefault(traceBeginPos);

--- a/test/System.Web.Http.Owin.Test/HttpMessageHandlerAdapterTest.cs
+++ b/test/System.Web.Http.Owin.Test/HttpMessageHandlerAdapterTest.cs
@@ -429,7 +429,7 @@ namespace System.Web.Http.Owin
         [InlineData(@"-_.~+""<>^`{|}")]
         // random unicode characters
         [InlineData("激光這")]
-        [InlineData("%24")]
+        [InlineData("%24", Skip="Decoded to '$' at the moment. !!! Investigate !!!")]
         [InlineData("?#")]
         public async Task Invoke_CreatesUri_ThatGeneratesCorrectlyDecodedStrings(string decodedId)
         {

--- a/test/System.Web.Http.Owin.Test/HttpMessageHandlerAdapterTest.cs
+++ b/test/System.Web.Http.Owin.Test/HttpMessageHandlerAdapterTest.cs
@@ -429,7 +429,6 @@ namespace System.Web.Http.Owin
         [InlineData(@"-_.~+""<>^`{|}")]
         // random unicode characters
         [InlineData("激光這")]
-        [InlineData("%24", Skip="Decoded to '$' at the moment. !!! Investigate !!!")]
         [InlineData("?#")]
         public async Task Invoke_CreatesUri_ThatGeneratesCorrectlyDecodedStrings(string decodedId)
         {
@@ -445,6 +444,27 @@ namespace System.Web.Http.Owin
 
             Assert.NotNull(routeData);
             Assert.Equal(decodedId, routeData.Values["id"]);
+        }
+
+        [Theory]
+        [InlineData("%24", "$")]
+        [InlineData("%28%29", "()")]
+        [InlineData("%5B%5D", "[]")]
+        [InlineData("%7B%7D", "{}")]
+        public async Task Invoke_CreatesUri_ContainingCorrectlyDecodedStrings(string encoded, string decoded)
+        {
+            var handler = CreateOKHandlerStub();
+            var bufferPolicySelector = CreateBufferPolicySelector(bufferInput: false, bufferOutput: false);
+            var environment = CreateOwinEnvironment("GET", "http", "localhost", "/vroot", "/api/customers/" + encoded);
+            var options = CreateValidOptions(handler, bufferPolicySelector);
+            var adapter = CreateProductUnderTest(options);
+            var route = new HttpRoute("api/customers/{id}");
+
+            await adapter.Invoke(new OwinContext(environment));
+            IHttpRouteData routeData = route.GetRouteData("/vroot", handler.Request);
+
+            Assert.NotNull(routeData);
+            Assert.Equal(decoded, routeData.Values["id"]);
         }
 
         [Fact]


### PR DESCRIPTION
- react to a smallish breaking change in newer Owin packages
- gather more information when restoring RuntimePortable.sln
  - use `$(RestoreUseSkipNonexistentTargets)` as well
- ignore binary logs
- ensure the .NET Core 2.1 VS component is installed
  - allow use of any 2.1.5xx .NET SDK
- add a few words to code analysis dictionary
- exclude files generated for `net45` legacy projects don't cause problems when compiling for `netstandard2.0`
- handle additional `ReflectionTypeLoadException`s when using the xUnit `msbuild` runner