### PR TITLE
Enable public Azure DevOps builds

### DIFF
--- a/.codeql.yml
+++ b/.codeql.yml
@@ -6,7 +6,6 @@ parameters:
   default: true
 
 variables:
-- template: eng/common/templates/variables/pool-providers.yml
   # CG is handled in the primary CI pipeline
 - name: skipComponentGovernanceDetection
   value: true
@@ -59,7 +58,7 @@ jobs:
   - script: .\build.cmd EnableSkipStrongNames
     displayName: Windows Build - EnableSkipStrongNames
 
-  - script: .\build.cmd
+  - script: .\build.cmd Build /p:BuildPortable=true /p:Desktop=false
     displayName: Windows Build
 
   - task: CodeQL3000Finalize@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ jobs:
     ${{ else }}:
       name: NetCore1ESPool-Internal
       demands: ImageOverride -equals windows.vs2017.amd64
-  timeoutInMinutes: 90
+  timeoutInMinutes: 30
 
   strategy:
     matrix:
@@ -80,11 +80,11 @@ jobs:
     continueOnError: true
     displayName: Publish test results
     inputs:
-      configuration: $(_Configuration)
       mergeTestResults: true
       searchFolder: ./bin/$(_Configuration)/Test/TestResults/
       testResultsFiles: '*.xml'
       testRunner: xUnit
+      testRunTitle: $(_Configuration)
 
   - publish: ./artifacts/
     artifact: $(_Configuration) Logs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,92 @@
+parameters:
+  # Test only the Release build by default.
+- name: ReleaseBuildTarget
+  displayName: 'Build which target for Release?'
+  type: string
+  values: [ Build, Integration, UnitTest ]
+  default: UnitTest
+- name: OtherBuildTarget
+  displayName: 'Build which target for Debug/CodeAnalysis?'
+  type: string
+  values: [ Build, Integration, UnitTest ]
+  default: Build
+
+variables:
+- name: DOTNET_CLI_TELEMETRY_OPTOUT
+  value: 1
+  # Run CodeQL3000 tasks in a separate internal pipeline; not needed here.
+- name: Codeql.SkipTaskAutoInjection
+  value: true
+
+trigger: [main]
+pr: ['*']
+
+jobs:
+- job: build
+  displayName: Build
+  pool:
+    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      name: NetCore-Public
+      demands: ImageOverride -equals windows.vs2017.amd64.open
+    ${{ else }}:
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals windows.vs2017.amd64
+  timeoutInMinutes: 90
+
+  strategy:
+    matrix:
+      Release:
+        _BuildTarget: ${{ parameters.ReleaseBuildTarget }}
+        _Configuration: Release
+        _StyleCopEnabled: true
+        # Do CG work only in internal pipelines.
+        skipComponentGovernanceDetection: ${{ eq(variables['System.TeamProject'], 'public') }}
+      Debug:
+        _BuildTarget: ${{ parameters.OtherBuildTarget }}
+        _Configuration: Debug
+        _StyleCopEnabled: false
+        # Do not redo CG work. Configuration changes in this part of the matrix are not relevant to CG.
+        skipComponentGovernanceDetection: true
+      CodeAnalysis:
+        _BuildTarget: ${{ parameters.OtherBuildTarget }}
+        _Configuration: CodeAnalysis
+        _StyleCopEnabled: false
+        # Do not redo CG work. Configuration changes in this part of the matrix are not relevant to CG.
+        skipComponentGovernanceDetection: true
+
+  steps:
+  - checkout: self
+    clean: true
+    displayName: Checkout
+  - task: UseDotNet@2
+    displayName: Get .NET SDK
+    inputs:
+      useGlobalJson: true
+
+  - script: .\build.cmd EnableSkipStrongNames
+    displayName: Windows Build - EnableSkipStrongNames
+  - script: .\build.cmd $(_BuildTarget) /p:Desktop=false /p:BuildPortable=true ^
+      /binaryLogger:artifacts/msbuild.binlog /p:Configuration=$(_Configuration) /p:StyleCopEnabled=$(_StyleCopEnabled) ^
+      /flp:LogFile=artifacts/msbuild.log;Verbosity=Normal
+    displayName: Windows Build
+
+  - publish: ./bin/$(_Configuration)/Test/TestResults/
+    artifact: $(_Configuration) Test Results
+    condition: and(always(), ne('$(_BuildTarget)', 'Build'))
+    continueOnError: true
+    displayName: Upload test results
+  - task: PublishTestResults@2
+    condition: and(always(), ne('$(_BuildTarget)', 'Build'))
+    continueOnError: true
+    displayName: Publish test results
+    inputs:
+      configuration: $(_Configuration)
+      mergeTestResults: true
+      searchFolder: ./bin/$(_Configuration)/Test/TestResults/
+      testResultsFiles: '*.xml'
+      testRunner: xUnit
+
+  - publish: ./artifacts/
+    artifact: $(_Configuration) Logs
+    condition: always()
+    displayName: Upload logs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,11 +64,11 @@ jobs:
       useGlobalJson: true
 
   - script: .\build.cmd EnableSkipStrongNames
-    displayName: Windows Build - EnableSkipStrongNames
+    displayName: Enable SkipStrongNames
   - script: .\build.cmd $(_BuildTarget) /p:Desktop=false /p:BuildPortable=true ^
       /binaryLogger:artifacts/msbuild.binlog /p:Configuration=$(_Configuration) /p:StyleCopEnabled=$(_StyleCopEnabled) ^
       /flp:LogFile=artifacts/msbuild.log;Verbosity=Normal
-    displayName: Windows Build
+    displayName: Build
 
   - publish: ./bin/$(_Configuration)/Test/TestResults/
     artifact: $(_Configuration) Test Results

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,11 +72,11 @@ jobs:
 
   - publish: ./bin/$(_Configuration)/Test/TestResults/
     artifact: $(_Configuration) Test Results
-    condition: and(always(), ne('$(_BuildTarget)', 'Build'))
+    condition: and(always(), ne(variables._BuildTarget, 'Build'))
     continueOnError: true
     displayName: Upload test results
   - task: PublishTestResults@2
-    condition: and(always(), ne('$(_BuildTarget)', 'Build'))
+    condition: and(always(), ne(variables._BuildTarget, 'Build'))
     continueOnError: true
     displayName: Publish test results
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,7 +67,7 @@ jobs:
     displayName: Enable SkipStrongNames
   - script: .\build.cmd $(_BuildTarget) /p:Desktop=false /p:BuildPortable=true ^
       /binaryLogger:artifacts/msbuild.binlog /p:Configuration=$(_Configuration) /p:StyleCopEnabled=$(_StyleCopEnabled) ^
-      /flp:LogFile=artifacts/msbuild.log;Verbosity=Normal
+      /fileLoggerParameters:LogFile=artifacts/msbuild.log;Summary;Verbosity=minimal
     displayName: Build
 
   - publish: ./bin/$(_Configuration)/Test/TestResults/

--- a/build.cmd
+++ b/build.cmd
@@ -40,7 +40,7 @@ if exist "%InstallDir%\MSBuild\15.0\Bin\MSBuild.exe" (
 
 if "%1" == "" goto BuildDefaults
 
-%MSBuild% Runtime.msbuild /m /nr:false /t:%* /p:Platform="Any CPU" /p:Desktop=true /v:M /fl /flp:LogFile=bin\msbuild.log;Verbosity=Normal
+%MSBuild% Runtime.msbuild /m /nr:false /p:Platform="Any CPU" /p:Desktop=true /v:M /fl /flp:LogFile=bin\msbuild.log;Verbosity=Normal /t:%*
 if %ERRORLEVEL% neq 0 goto BuildFail
 goto BuildSuccess
 


### PR DESCRIPTION
- add azure-pipelines.yml
  - build about the same matrix as we have on TeamCity in Main.Integration builds
- change build.cmd to enable overrides of its command line parameters

nits:
- touch up .codeql.yml to avoid test code and include portable projects