### PR TITLE
Do not fail tests immediately

### DIFF
--- a/Runtime.msbuild
+++ b/Runtime.msbuild
@@ -11,7 +11,7 @@
     <BuildPortable Condition=" '$(BuildPortable)' == '' ">true</BuildPortable>
     <BuildInParallel Condition=" '$(BuildInParallel)' == '' And $(MSBuildNodeCount) &gt; 1 ">true</BuildInParallel>
     <BuildInParallel Condition=" '$(BuildInParallel)' == '' ">false</BuildInParallel>
-    <TestInParallel Condition=" '$(TestInParallel)' == '' ">$(BuildInParallel)</TestInParallel>
+    <TestInParallel Condition=" '$(TestInParallel)' == '' ">false</TestInParallel>
     <TestResultsDirectory>$(MSBuildThisFileDirectory)bin\$(Configuration)\test\TestResults\</TestResultsDirectory>
     <SkipStrongNamesExe>$(MSBuildThisFileDirectory)packages\Microsoft.Web.SkipStrongNames.1.0.0\tools\SkipStrongNames.exe</SkipStrongNamesExe>
     <SkipStrongNamesXml>$(MSBuildThisFileDirectory)tools\SkipStrongNames.xml</SkipStrongNamesXml>
@@ -65,25 +65,24 @@
 
   <Target Name="RestorePackages" DependsOnTargets="DownloadNuGet">
     <ItemGroup>
-      <_NuGetPackagesAndSolutions Include="src\System.Net.Http.Formatting.NetCore\packages.config;
-          test\System.Net.Http.Formatting.NetCore.Test\packages.config;
-          Runtime.sln" />
+      <_NuGetPackagesAndSolutions Include="Runtime.sln" />
 
       <!-- Avoid restoring RuntimePortable.sln directly. -->
       <_NuGetPackagesAndSolutions Include="src\System.Net.Http.Formatting.NetCore\packages.config;
           test\System.Net.Http.Formatting.NetCore.Test\packages.config"
         Condition=" '$(BuildPortable)' == 'true' " />
-      <_ProjectsToRestore Include="src\System.Net.Http.Formatting.NetStandard\System.Net.Http.Formatting.NetStandard.csproj;
-          test\System.Net.Http.Formatting.NetStandard.Test\System.Net.Http.Formatting.NetStandard.Test.csproj"
+      <_ProjectsToRestore Include="test\System.Net.Http.Formatting.NetStandard.Test\System.Net.Http.Formatting.NetStandard.Test.csproj"
         Condition=" '$(BuildPortable)' == 'true' " />
     </ItemGroup>
 
     <Message Text="Restoring NuGet packages..." Importance="High" />
     <Exec Command='"$(NuGetExe)" restore "%(_NuGetPackagesAndSolutions.Identity)" ^
         -PackagesDirectory packages -NonInteractive ^
-        -Verbosity normal -ConfigFile "$(MSBuildThisFileDirectory)\.nuget\NuGet.Config"' />
-    <MSBuild Projects="@(_ProjectsToRestore)" Targets="Restore" Properties="Configuration=$(Configuration)"
-      Condition=" '$(BuildPortable)' == 'true' " />
+        -Verbosity quiet -ConfigFile "$(MSBuildThisFileDirectory)\.nuget\NuGet.Config"' />
+    <MSBuild Projects="@(_ProjectsToRestore)" Targets="Restore"
+      BuildInParallel="$(BuildInParallel)"
+      Condition=" '$(BuildPortable)' == 'true' "
+      Properties="Configuration=$(Configuration);CodeAnalysis=$(CodeAnalysis);StyleCopEnabled=$(StyleCopEnabled);VisualStudioVersion=$(VisualStudioVersion)" />
   </Target>
 
   <!-- Pick the right Microsoft.Web.FxCop package to use and copy it to a standard location. -->
@@ -110,9 +109,7 @@
         Properties="Configuration=$(Configuration);CodeAnalysis=$(CodeAnalysis);StyleCopEnabled=$(StyleCopEnabled);VisualStudioVersion=$(VisualStudioVersion)" />
   </Target>
 
-  <Target Name="UnitTest" DependsOnTargets="CheckSkipStrongNames;Build">
-    <CallTarget Targets="RunTests;PrintTestRunSummary" RunEachTargetSeparately="True" />
-  </Target>
+  <Target Name="UnitTest" DependsOnTargets="Build;PrintTestRunSummary" />
 
   <Target Name="RunTests" DependsOnTargets="CheckSkipStrongNames">
     <ItemGroup>
@@ -128,7 +125,9 @@
     <RemoveDir Directories="$(TestResultsDirectory)" />
     <MakeDir Directories="$(TestResultsDirectory)" />
 
-    <MSBuild Projects="@(_XunitProject)" BuildInParallel="$(TestInParallel)" Targets="Xunit" />
+    <MSBuild Projects="@(_XunitProject)" BuildInParallel="$(TestInParallel)" Targets="Xunit">
+      <Output TaskParameter="TargetOutputs" ItemName="_ExitCodes" />
+    </MSBuild>
 
     <!-- Failures in this project will fail build. But, results will not be included in test run summary. -->
     <MSBuild
@@ -145,7 +144,11 @@
     <Error Text="Unit tests will not run correctly unless SkipStrongNames is Enabled. Current status: $(Status). Run build.cmd EnableSkipStrongNames to fix this problem." Condition="'$(Status)' != 'Enabled'" />
   </Target>
 
-  <Target Name="PrintTestRunSummary">
+  <Target Name="PrintTestRunSummary" DependsOnTargets="RunTests">
     <PrintTestRunSummary TestResultsDirectory="$(TestResultsDirectory)" />
+
+    <!-- PrintTestRunSummary stops MSBuild if tests failed. But the Xunit target may fail for other reasons... -->
+    <Error Text="Testing failed with exit code '%(Code)':%0A@(_ExitCodes -> '  %(Identity)', '%0A')"
+        Condition=" '%(Code)' != '0' " />
   </Target>
 </Project>

--- a/build.cmd
+++ b/build.cmd
@@ -40,12 +40,14 @@ if exist "%InstallDir%\MSBuild\15.0\Bin\MSBuild.exe" (
 
 if "%1" == "" goto BuildDefaults
 
-%MSBuild% Runtime.msbuild /m /nr:false /p:Platform="Any CPU" /p:Desktop=true /v:M /fl /flp:LogFile=bin\msbuild.log;Verbosity=Normal /t:%*
+%MSBuild% Runtime.msbuild /m /nr:false /p:Platform="Any CPU" /p:Desktop=true /v:M ^
+    /fl /fileLoggerParameters:LogFile=bin\msbuild.log;Verbosity=Normal /consoleLoggerParameters:Summary /t:%*
 if %ERRORLEVEL% neq 0 goto BuildFail
 goto BuildSuccess
 
 :BuildDefaults
-%MSBuild% Runtime.msbuild /m /nr:false /p:Platform="Any CPU" /p:Desktop=true /v:M /fl /flp:LogFile=bin\msbuild.log;Verbosity=Normal
+%MSBuild% Runtime.msbuild /m /nr:false /p:Platform="Any CPU" /p:Desktop=true /v:M ^
+    /fl /fileLoggerParameters:LogFile=bin\msbuild.log;Verbosity=Normal /consoleLoggerParameters:Summary
 if %ERRORLEVEL% neq 0 goto BuildFail
 goto BuildSuccess
 

--- a/src/Common/CollectionExtensions.cs
+++ b/src/Common/CollectionExtensions.cs
@@ -27,7 +27,7 @@ namespace System.Collections.Generic
         }
 
         /// <summary>
-        /// Return the enumerable as an Array, copying if required. Optimized for common case where it is an Array. 
+        /// Return the enumerable as an Array, copying if required. Optimized for common case where it is an Array.
         /// Avoid mutating the return value.
         /// </summary>
         public static T[] AsArray<T>(this IEnumerable<T> values)
@@ -43,7 +43,7 @@ namespace System.Collections.Generic
         }
 
         /// <summary>
-        /// Return the enumerable as a Collection of T, copying if required. Optimized for the common case where it is 
+        /// Return the enumerable as a Collection of T, copying if required. Optimized for the common case where it is
         /// a Collection of T and avoiding a copy if it implements IList of T. Avoid mutating the return value.
         /// </summary>
         public static Collection<T> AsCollection<T>(this IEnumerable<T> enumerable)
@@ -78,9 +78,9 @@ namespace System.Collections.Generic
             }
             return new List<T>(enumerable);
         }
-        
+
         /// <summary>
-        /// Return the enumerable as a List of T, copying if required. Optimized for common case where it is an List of T 
+        /// Return the enumerable as a List of T, copying if required. Optimized for common case where it is an List of T
         /// or a ListWrapperCollection of T. Avoid mutating the return value.
         /// </summary>
         public static List<T> AsList<T>(this IEnumerable<T> enumerable)

--- a/src/Common/CommonWebApiResources.Designer.cs
+++ b/src/Common/CommonWebApiResources.Designer.cs
@@ -24,15 +24,15 @@ namespace System.Web.Http.Properties {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class CommonWebApiResources {
-        
+
         private static global::System.Resources.ResourceManager resourceMan;
-        
+
         private static global::System.Globalization.CultureInfo resourceCulture;
-        
+
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal CommonWebApiResources() {
         }
-        
+
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
@@ -59,7 +59,7 @@ namespace System.Web.Http.Properties {
                 return resourceMan;
             }
         }
-        
+
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
@@ -73,7 +73,7 @@ namespace System.Web.Http.Properties {
                 resourceCulture = value;
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Relative URI values are not supported: &apos;{0}&apos;. The URI must be absolute..
         /// </summary>
@@ -82,7 +82,7 @@ namespace System.Web.Http.Properties {
                 return ResourceManager.GetString("ArgumentInvalidAbsoluteUri", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Unsupported URI scheme: &apos;{0}&apos;. The URI scheme must be either &apos;{1}&apos; or &apos;{2}&apos;..
         /// </summary>
@@ -91,7 +91,7 @@ namespace System.Web.Http.Properties {
                 return ResourceManager.GetString("ArgumentInvalidHttpUriScheme", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Value must be greater than or equal to {0}..
         /// </summary>
@@ -100,7 +100,7 @@ namespace System.Web.Http.Properties {
                 return ResourceManager.GetString("ArgumentMustBeGreaterThanOrEqualTo", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Value must be less than or equal to {0}..
         /// </summary>
@@ -109,7 +109,7 @@ namespace System.Web.Http.Properties {
                 return ResourceManager.GetString("ArgumentMustBeLessThanOrEqualTo", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The argument &apos;{0}&apos; is null or empty..
         /// </summary>
@@ -118,7 +118,7 @@ namespace System.Web.Http.Properties {
                 return ResourceManager.GetString("ArgumentNullOrEmpty", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to URI must not contain a query component or a fragment identifier..
         /// </summary>
@@ -127,7 +127,7 @@ namespace System.Web.Http.Properties {
                 return ResourceManager.GetString("ArgumentUriHasQueryOrFragment", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The value of argument &apos;{0}&apos; ({1}) is invalid for Enum type &apos;{2}&apos;..
         /// </summary>

--- a/src/Common/Error.cs
+++ b/src/Common/Error.cs
@@ -74,7 +74,7 @@ namespace System.Web.Http
         }
 
         /// <summary>
-        /// Creates an <see cref="ArgumentException"/> with a message saying that the argument must be an absolute URI 
+        /// Creates an <see cref="ArgumentException"/> with a message saying that the argument must be an absolute URI
         /// without a query or fragment identifier and then logs it with <see cref="F:TraceLevel.Error"/>.
         /// </summary>
         /// <param name="parameterName">The name of the parameter that caused the current exception.</param>

--- a/src/System.Net.Http.Formatting/ByteRangeStreamContent.cs
+++ b/src/System.Net.Http.Formatting/ByteRangeStreamContent.cs
@@ -13,8 +13,8 @@ namespace System.Net.Http
 {
     /// <summary>
     /// <see cref="HttpContent"/> implementation which provides a byte range view over a stream used to generate HTTP
-    /// 206 (Partial Content) byte range responses. The <see cref="ByteRangeStreamContent"/> supports one or more 
-    /// byte ranges regardless of whether the ranges are consecutive or not. If there is only one range then a 
+    /// 206 (Partial Content) byte range responses. The <see cref="ByteRangeStreamContent"/> supports one or more
+    /// byte ranges regardless of whether the ranges are consecutive or not. If there is only one range then a
     /// single partial response body containing a Content-Range header is generated. If there are more than one
     /// ranges then a multipart/byteranges response is generated where each body part contains a range indicated
     /// by the associated Content-Range header field.
@@ -33,9 +33,9 @@ namespace System.Net.Http
 
         /// <summary>
         /// <see cref="HttpContent"/> implementation which provides a byte range view over a stream used to generate HTTP
-        /// 206 (Partial Content) byte range responses. If none of the requested ranges overlap with the current extend 
-        /// of the selected resource represented by the <paramref name="content"/> parameter then an 
-        /// <see cref="InvalidByteRangeException"/> is thrown indicating the valid Content-Range of the content. 
+        /// 206 (Partial Content) byte range responses. If none of the requested ranges overlap with the current extend
+        /// of the selected resource represented by the <paramref name="content"/> parameter then an
+        /// <see cref="InvalidByteRangeException"/> is thrown indicating the valid Content-Range of the content.
         /// </summary>
         /// <param name="content">The stream over which to generate a byte range view.</param>
         /// <param name="range">The range or ranges, typically obtained from the Range HTTP request header field.</param>
@@ -47,9 +47,9 @@ namespace System.Net.Http
 
         /// <summary>
         /// <see cref="HttpContent"/> implementation which provides a byte range view over a stream used to generate HTTP
-        /// 206 (Partial Content) byte range responses. If none of the requested ranges overlap with the current extend 
-        /// of the selected resource represented by the <paramref name="content"/> parameter then an 
-        /// <see cref="InvalidByteRangeException"/> is thrown indicating the valid Content-Range of the content. 
+        /// 206 (Partial Content) byte range responses. If none of the requested ranges overlap with the current extend
+        /// of the selected resource represented by the <paramref name="content"/> parameter then an
+        /// <see cref="InvalidByteRangeException"/> is thrown indicating the valid Content-Range of the content.
         /// </summary>
         /// <param name="content">The stream over which to generate a byte range view.</param>
         /// <param name="range">The range or ranges, typically obtained from the Range HTTP request header field.</param>
@@ -62,9 +62,9 @@ namespace System.Net.Http
 
         /// <summary>
         /// <see cref="HttpContent"/> implementation which provides a byte range view over a stream used to generate HTTP
-        /// 206 (Partial Content) byte range responses. If none of the requested ranges overlap with the current extend 
-        /// of the selected resource represented by the <paramref name="content"/> parameter then an 
-        /// <see cref="InvalidByteRangeException"/> is thrown indicating the valid Content-Range of the content. 
+        /// 206 (Partial Content) byte range responses. If none of the requested ranges overlap with the current extend
+        /// of the selected resource represented by the <paramref name="content"/> parameter then an
+        /// <see cref="InvalidByteRangeException"/> is thrown indicating the valid Content-Range of the content.
         /// </summary>
         /// <param name="content">The stream over which to generate a byte range view.</param>
         /// <param name="range">The range or ranges, typically obtained from the Range HTTP request header field.</param>
@@ -76,9 +76,9 @@ namespace System.Net.Http
 
         /// <summary>
         /// <see cref="HttpContent"/> implementation which provides a byte range view over a stream used to generate HTTP
-        /// 206 (Partial Content) byte range responses. If none of the requested ranges overlap with the current extend 
-        /// of the selected resource represented by the <paramref name="content"/> parameter then an 
-        /// <see cref="InvalidByteRangeException"/> is thrown indicating the valid Content-Range of the content. 
+        /// 206 (Partial Content) byte range responses. If none of the requested ranges overlap with the current extend
+        /// of the selected resource represented by the <paramref name="content"/> parameter then an
+        /// <see cref="InvalidByteRangeException"/> is thrown indicating the valid Content-Range of the content.
         /// </summary>
         /// <param name="content">The stream over which to generate a byte range view.</param>
         /// <param name="range">The range or ranges, typically obtained from the Range HTTP request header field.</param>

--- a/src/System.Net.Http.Formatting/Formatting/BufferedMediaTypeFormatter.cs
+++ b/src/System.Net.Http.Formatting/Formatting/BufferedMediaTypeFormatter.cs
@@ -13,7 +13,7 @@ using System.Web.Http;
 namespace System.Net.Http.Formatting
 {
     /// <summary>
-    /// Base class for writing a synchronous formatter on top of the asynchronous formatter infrastructure. 
+    /// Base class for writing a synchronous formatter on top of the asynchronous formatter infrastructure.
     /// This does not guarantee non-blocking threads. The only way to guarantee that we don't block a thread on IO is
     /// to use the asynchronous <see cref="MediaTypeFormatter"/>.
     /// </summary>
@@ -219,13 +219,13 @@ namespace System.Net.Http.Formatting
         {
             Contract.Assert(innerStream != null);
 
-            // We wrap the inner stream in a non-closing delegating stream so that we allow the user 
+            // We wrap the inner stream in a non-closing delegating stream so that we allow the user
             // to use the using (...) pattern yet not break the contract of formatters not closing
             // the inner stream.
             Stream nonClosingStream = new NonClosingDelegatingStream(innerStream);
 
-            // This uses a naive buffering. BufferedStream() will block the thread while it drains the buffer. 
-            // We can explore a smarter implementation that async drains the buffer. 
+            // This uses a naive buffering. BufferedStream() will block the thread while it drains the buffer.
+            // We can explore a smarter implementation that async drains the buffer.
             return new BufferedStream(nonClosingStream, bufferSize);
         }
     }

--- a/src/System.Net.Http.Formatting/Formatting/DefaultContentNegotiator.cs
+++ b/src/System.Net.Http.Formatting/Formatting/DefaultContentNegotiator.cs
@@ -95,7 +95,7 @@ namespace System.Net.Http.Formatting
 
         /// <summary>
         /// Determine how well each formatter matches by associating a <see cref="MediaTypeFormatterMatchRanking"/> value
-        /// with the formatter. Then associate the quality of the match based on q-factors and other parameters. The result of this 
+        /// with the formatter. Then associate the quality of the match based on q-factors and other parameters. The result of this
         /// method is a collection of the matches found categorized and assigned a quality value.
         /// </summary>
         /// <param name="type">The type to be serialized.</param>
@@ -123,7 +123,7 @@ namespace System.Net.Http.Formatting
             // Go through each formatter to find how well it matches.
             ListWrapperCollection<MediaTypeFormatterMatch> matches = new ListWrapperCollection<MediaTypeFormatterMatch>();
             MediaTypeFormatter[] writingFormatters = GetWritingFormatters(formatters);
-            for (int i = 0; i < writingFormatters.Length; i++) 
+            for (int i = 0; i < writingFormatters.Length; i++)
             {
                 MediaTypeFormatter formatter = writingFormatters[i];
                 MediaTypeFormatterMatch match = null;
@@ -161,7 +161,7 @@ namespace System.Net.Http.Formatting
                     continue;
                 }
 
-                // Check whether we should match on type or stop the matching process. 
+                // Check whether we should match on type or stop the matching process.
                 // The latter is used to generate 406 (Not Acceptable) status codes.
                 bool shouldMatchOnType = ShouldMatchOnType(sortedAcceptValues);
 
@@ -459,7 +459,7 @@ namespace System.Net.Http.Formatting
         /// <summary>
         /// Determine whether to match on type or not. This is used to determine whether to
         /// generate a 406 response or use the default media type formatter in case there
-        /// is no match against anything in the request. If ExcludeMatchOnTypeOnly is true 
+        /// is no match against anything in the request. If ExcludeMatchOnTypeOnly is true
         /// then we don't match on type unless there are no accept headers.
         /// </summary>
         /// <param name="sortedAcceptValues">The sorted accept header values to match.</param>
@@ -504,7 +504,7 @@ namespace System.Net.Http.Formatting
         }
 
         /// <summary>
-        /// Sort Accept header values and related header field values with similar syntax rules 
+        /// Sort Accept header values and related header field values with similar syntax rules
         /// (if more than 1) in descending order based on q-factor.
         /// </summary>
         /// <param name="headerValues">The header values to sort.</param>
@@ -529,7 +529,7 @@ namespace System.Net.Http.Formatting
         }
 
         /// <summary>
-        /// Sort Accept-Charset, Accept-Encoding, Accept-Language and related header field values with similar syntax rules 
+        /// Sort Accept-Charset, Accept-Encoding, Accept-Language and related header field values with similar syntax rules
         /// (if more than 1) in descending order based on q-factor.
         /// </summary>
         /// <param name="headerValues">The header values to sort.</param>
@@ -554,7 +554,7 @@ namespace System.Net.Http.Formatting
         }
 
         /// <summary>
-        /// Evaluates whether a match is better than the current match and if so returns the replacement; otherwise returns the 
+        /// Evaluates whether a match is better than the current match and if so returns the replacement; otherwise returns the
         /// current match.
         /// </summary>
         protected virtual MediaTypeFormatterMatch UpdateBestMatch(MediaTypeFormatterMatch current, MediaTypeFormatterMatch potentialReplacement)

--- a/src/System.Net.Http.Formatting/Formatting/FormDataCollection.cs
+++ b/src/System.Net.Http.Formatting/Formatting/FormDataCollection.cs
@@ -21,9 +21,9 @@ namespace System.Net.Http.Formatting
 {
     /// <summary>
     /// Represent the form data.
-    /// - This has 100% fidelity (including ordering, which is important for deserializing ordered array). 
-    /// - using interfaces allows us to optimize the implementation. E.g., we can avoid eagerly string-splitting a 10gb file. 
-    /// - This also provides a convenient place to put extension methods. 
+    /// - This has 100% fidelity (including ordering, which is important for deserializing ordered array).
+    /// - using interfaces allows us to optimize the implementation. E.g., we can avoid eagerly string-splitting a 10gb file.
+    /// - This also provides a convenient place to put extension methods.
     /// </summary>
 #if NETFX_CORE
     internal
@@ -37,8 +37,8 @@ namespace System.Net.Http.Formatting
         private NameValueCollection _nameValueCollection;
 
         /// <summary>
-        /// Initialize a form collection around incoming data. 
-        /// The key value enumeration should be immutable. 
+        /// Initialize a form collection around incoming data.
+        /// The key value enumeration should be immutable.
         /// </summary>
         /// <param name="pairs">incoming set of key value pairs. Ordering is preserved.</param>
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "This is the convention for representing FormData")]
@@ -52,8 +52,8 @@ namespace System.Net.Http.Formatting
         }
 
         /// <summary>
-        /// Initialize a form collection from a query string. 
-        /// Uri and FormURl body have the same schema. 
+        /// Initialize a form collection from a query string.
+        /// Uri and FormURl body have the same schema.
         /// </summary>
         public FormDataCollection(Uri uri)
         {
@@ -136,7 +136,7 @@ namespace System.Net.Http.Formatting
         }
 
         /// <summary>
-        /// Get values associated with a given key. If there are multiple values, they're concatenated. 
+        /// Get values associated with a given key. If there are multiple values, they're concatenated.
         /// </summary>
         public string Get(string key)
         {
@@ -144,7 +144,7 @@ namespace System.Net.Http.Formatting
         }
 
         /// <summary>
-        /// Get a value associated with a given key. 
+        /// Get a value associated with a given key.
         /// </summary>
         public string[] GetValues(string key)
         {

--- a/src/System.Net.Http.Formatting/Formatting/FormUrlEncodedJson.cs
+++ b/src/System.Net.Http.Formatting/Formatting/FormUrlEncodedJson.cs
@@ -13,9 +13,9 @@ using Newtonsoft.Json.Linq;
 namespace System.Net.Http.Formatting
 {
     /// <summary>
-    /// This class provides a low-level API for parsing HTML form URL-encoded data, also known as <c>application/x-www-form-urlencoded</c> 
-    /// data. The output of the parser is a <see cref="JObject"/> instance. 
-    /// <remarks>This is a low-level API intended for use by other APIs. It has been optimized for performance and 
+    /// This class provides a low-level API for parsing HTML form URL-encoded data, also known as <c>application/x-www-form-urlencoded</c>
+    /// data. The output of the parser is a <see cref="JObject"/> instance.
+    /// <remarks>This is a low-level API intended for use by other APIs. It has been optimized for performance and
     /// is not intended to be called directly from user code.</remarks>
     /// </summary>
     internal static class FormUrlEncodedJson
@@ -31,7 +31,7 @@ namespace System.Net.Http.Formatting
         /// <summary>
         /// Parses a collection of query string values as a <see cref="JObject"/>.
         /// </summary>
-        /// <remarks>This is a low-level API intended for use by other APIs. It has been optimized for performance and 
+        /// <remarks>This is a low-level API intended for use by other APIs. It has been optimized for performance and
         /// is not intended to be called directly from user code.</remarks>
         /// <param name="nameValuePairs">The collection of query string name-value pairs parsed in lexical order. Both names
         /// and values must be un-escaped so that they don't contain any <see cref="Uri"/> encoding.</param>
@@ -44,7 +44,7 @@ namespace System.Net.Http.Formatting
         /// <summary>
         /// Parses a collection of query string values as a <see cref="JObject"/>.
         /// </summary>
-        /// <remarks>This is a low-level API intended for use by other APIs. It has been optimized for performance and 
+        /// <remarks>This is a low-level API intended for use by other APIs. It has been optimized for performance and
         /// is not intended to be called directly from user code.</remarks>
         /// <param name="nameValuePairs">The collection of query string name-value pairs parsed in lexical order. Both names
         /// and values must be un-escaped so that they don't contain any <see cref="Uri"/> encoding.</param>
@@ -58,7 +58,7 @@ namespace System.Net.Http.Formatting
         /// <summary>
         /// Parses a collection of query string values as a <see cref="JObject"/>.
         /// </summary>
-        /// <remarks>This is a low-level API intended for use by other APIs. It has been optimized for performance and 
+        /// <remarks>This is a low-level API intended for use by other APIs. It has been optimized for performance and
         /// is not intended to be called directly from user code.</remarks>
         /// <param name="nameValuePairs">The collection of query string name-value pairs parsed in lexical order. Both names
         /// and values must be un-escaped so that they don't contain any <see cref="Uri"/> encoding.</param>
@@ -72,7 +72,7 @@ namespace System.Net.Http.Formatting
         /// <summary>
         /// Parses a collection of query string values as a <see cref="JObject"/>.
         /// </summary>
-        /// <remarks>This is a low-level API intended for use by other APIs. It has been optimized for performance and 
+        /// <remarks>This is a low-level API intended for use by other APIs. It has been optimized for performance and
         /// is not intended to be called directly from user code.</remarks>
         /// <param name="nameValuePairs">The collection of query string name-value pairs parsed in lexical order. Both names
         /// and values must be un-escaped so that they don't contain any <see cref="Uri"/> encoding.</param>
@@ -87,7 +87,7 @@ namespace System.Net.Http.Formatting
         /// <summary>
         /// Parses a collection of query string values as a <see cref="JObject"/>.
         /// </summary>
-        /// <remarks>This is a low-level API intended for use by other APIs. It has been optimized for performance and 
+        /// <remarks>This is a low-level API intended for use by other APIs. It has been optimized for performance and
         /// is not intended to be called directly from user code.</remarks>
         /// <param name="nameValuePairs">The collection of query string name-value pairs parsed in lexical order. Both names
         /// and values must be un-escaped so that they don't contain any <see cref="Uri"/> encoding.</param>
@@ -112,7 +112,7 @@ namespace System.Net.Http.Formatting
                 string key = nameValuePair.Key;
                 string value = nameValuePair.Value;
 
-                // value is preserved, even if it's null, "undefined", "null", String.Empty, etc when converting to JToken. 
+                // value is preserved, even if it's null, "undefined", "null", String.Empty, etc when converting to JToken.
 
                 if (key == null)
                 {

--- a/src/System.Net.Http.Formatting/Formatting/FormUrlEncodedMediaTypeFormatter.cs
+++ b/src/System.Net.Http.Formatting/Formatting/FormUrlEncodedMediaTypeFormatter.cs
@@ -13,7 +13,7 @@ using System.Web.Http;
 namespace System.Net.Http.Formatting
 {
     /// <summary>
-    /// <see cref="MediaTypeFormatter"/> class for handling HTML form URL-ended data, also known as <c>application/x-www-form-urlencoded</c>. 
+    /// <see cref="MediaTypeFormatter"/> class for handling HTML form URL-ended data, also known as <c>application/x-www-form-urlencoded</c>.
     /// </summary>
     public class FormUrlEncodedMediaTypeFormatter : MediaTypeFormatter
     {
@@ -119,7 +119,7 @@ namespace System.Net.Http.Formatting
                 throw Error.ArgumentNull("type");
             }
 
-            // Can't read arbitrary types. 
+            // Can't read arbitrary types.
             return type == typeof(FormDataCollection) || FormattingUtilities.IsJTokenType(type);
         }
 
@@ -193,7 +193,7 @@ namespace System.Net.Http.Formatting
         }
 
         /// <summary>
-        /// Reads all name-value pairs encoded as HTML Form URL encoded data and add them to 
+        /// Reads all name-value pairs encoded as HTML Form URL encoded data and add them to
         /// a collection as UNescaped URI strings.
         /// </summary>
         /// <param name="input">Stream to read from.</param>

--- a/src/System.Net.Http.Formatting/Formatting/JsonMediaTypeFormatter.cs
+++ b/src/System.Net.Http.Formatting/Formatting/JsonMediaTypeFormatter.cs
@@ -95,7 +95,7 @@ namespace System.Net.Http.Formatting
 #endif
 
         /// <summary>
-        /// Gets or sets a value indicating whether to indent elements when writing data. 
+        /// Gets or sets a value indicating whether to indent elements when writing data.
         /// </summary>
         public bool Indent { get; set; }
 

--- a/src/System.Net.Http.Formatting/Formatting/MediaTypeFormatter.cs
+++ b/src/System.Net.Http.Formatting/Formatting/MediaTypeFormatter.cs
@@ -79,7 +79,7 @@ namespace System.Net.Http.Formatting
         }
 
         /// <summary>
-        /// Gets or sets the maximum number of keys stored in a NameValueCollection. 
+        /// Gets or sets the maximum number of keys stored in a NameValueCollection.
         /// </summary>
         public static int MaxHttpCollectionKeys
         {
@@ -117,7 +117,7 @@ namespace System.Net.Http.Formatting
         /// <summary>
         /// Gets the mutable collection of character encodings supported by
         /// this <see cref="MediaTypeFormatter"/> instance. The encodings are
-        /// used when reading or writing data. 
+        /// used when reading or writing data.
         /// </summary>
         public Collection<Encoding> SupportedEncodings { get; private set; }
 

--- a/src/System.Net.Http.Formatting/Formatting/MediaTypeHeaderValueExtensions.cs
+++ b/src/System.Net.Http.Formatting/Formatting/MediaTypeHeaderValueExtensions.cs
@@ -17,8 +17,8 @@ namespace System.Net.Http.Formatting
         /// <summary>
         /// Determines whether two <see cref="MediaTypeHeaderValue"/> instances match. The instance
         /// <paramref name="mediaType1"/> is said to match <paramref name="mediaType2"/> if and only if
-        /// <paramref name="mediaType1"/> is a strict subset of the values and parameters of <paramref name="mediaType2"/>. 
-        /// That is, if the media type and media type parameters of <paramref name="mediaType1"/> are all present 
+        /// <paramref name="mediaType1"/> is a strict subset of the values and parameters of <paramref name="mediaType2"/>.
+        /// That is, if the media type and media type parameters of <paramref name="mediaType1"/> are all present
         /// and match those of <paramref name="mediaType2"/> then it is a match even though <paramref name="mediaType2"/> may have additional
         /// parameters.
         /// </summary>
@@ -34,8 +34,8 @@ namespace System.Net.Http.Formatting
         /// <summary>
         /// Determines whether two <see cref="MediaTypeHeaderValue"/> instances match. The instance
         /// <paramref name="mediaType1"/> is said to match <paramref name="mediaType2"/> if and only if
-        /// <paramref name="mediaType1"/> is a strict subset of the values and parameters of <paramref name="mediaType2"/>. 
-        /// That is, if the media type and media type parameters of <paramref name="mediaType1"/> are all present 
+        /// <paramref name="mediaType1"/> is a strict subset of the values and parameters of <paramref name="mediaType2"/>.
+        /// That is, if the media type and media type parameters of <paramref name="mediaType1"/> are all present
         /// and match those of <paramref name="mediaType2"/> then it is a match even though <paramref name="mediaType2"/> may have additional
         /// parameters.
         /// </summary>
@@ -75,12 +75,12 @@ namespace System.Net.Http.Formatting
                 }
             }
 
-            // So far we either have a full match or a subset match. Now check that all of 
+            // So far we either have a full match or a subset match. Now check that all of
             // mediaType1's parameters are present and equal in mediatype2
             // Optimize for the common case where the parameters inherit from Collection<T> and cache the count which is faster for Collection<T>.
             Collection<NameValueHeaderValue> parameters1 = mediaType1.Parameters.AsCollection();
             int parameterCount1 = parameters1.Count;
-            Collection<NameValueHeaderValue> parameters2 = mediaType2.Parameters.AsCollection(); 
+            Collection<NameValueHeaderValue> parameters2 = mediaType2.Parameters.AsCollection();
             int parameterCount2 = parameters2.Count;
             for (int i = 0; i < parameterCount1; i++)
             {

--- a/src/System.Net.Http.Formatting/Formatting/MediaTypeWithQualityHeaderValueComparer.cs
+++ b/src/System.Net.Http.Formatting/Formatting/MediaTypeWithQualityHeaderValueComparer.cs
@@ -8,7 +8,7 @@ using System.Net.Http.Headers;
 namespace System.Net.Http.Formatting
 {
     /// Implementation of <see cref="IComparer{T}"/> that can compare accept media type header fields
-    /// based on their quality values (a.k.a q-values). See 
+    /// based on their quality values (a.k.a q-values). See
     /// <see cref="StringWithQualityHeaderValueComparer"/> for a comparer for other content negotiation
     /// header field q-values.
     internal class MediaTypeWithQualityHeaderValueComparer : IComparer<MediaTypeWithQualityHeaderValue>
@@ -26,8 +26,8 @@ namespace System.Net.Http.Formatting
 
         /// <summary>
         /// Compares two <see cref="MediaTypeWithQualityHeaderValue"/> based on their quality value (a.k.a their "q-value").
-        /// Values with identical q-values are considered equal (i.e the result is 0) with the exception that sub-type wild-cards are 
-        /// considered less than specific media types and full wild-cards are considered less than sub-type wild-cards. This allows to 
+        /// Values with identical q-values are considered equal (i.e the result is 0) with the exception that sub-type wild-cards are
+        /// considered less than specific media types and full wild-cards are considered less than sub-type wild-cards. This allows to
         /// sort a sequence of <see cref="StringWithQualityHeaderValue"/> following their q-values in the order of specific media types,
         /// sub-type wildcards, and last any full wild-cards.
         /// </summary>

--- a/src/System.Net.Http.Formatting/Formatting/ParsedMediaTypeHeaderValue.cs
+++ b/src/System.Net.Http.Formatting/Formatting/ParsedMediaTypeHeaderValue.cs
@@ -40,14 +40,14 @@ namespace System.Net.Http.Formatting
             }
         }
 
-        public bool IsAllMediaRange 
-        { 
-            get { return _isAllMediaRange; } 
+        public bool IsAllMediaRange
+        {
+            get { return _isAllMediaRange; }
         }
 
-        public bool IsSubtypeMediaRange 
-        { 
-            get { return _isSubtypeMediaRange; } 
+        public bool IsSubtypeMediaRange
+        {
+            get { return _isSubtypeMediaRange; }
         }
 
         public bool TypesEqual(ref ParsedMediaTypeHeaderValue other)

--- a/src/System.Net.Http.Formatting/Formatting/Parsers/FormUrlEncodedParser.cs
+++ b/src/System.Net.Http.Formatting/Formatting/Parsers/FormUrlEncodedParser.cs
@@ -11,7 +11,7 @@ using System.Web.Http;
 namespace System.Net.Http.Formatting.Parsers
 {
     /// <summary>
-    /// Buffer-oriented parsing of HTML form URL-ended, also known as <c>application/x-www-form-urlencoded</c>, data. 
+    /// Buffer-oriented parsing of HTML form URL-ended, also known as <c>application/x-www-form-urlencoded</c>, data.
     /// </summary>
     internal class FormUrlEncodedParser
     {
@@ -54,7 +54,7 @@ namespace System.Net.Http.Formatting.Parsers
 
         /// <summary>
         /// Parse a buffer of URL form-encoded name-value pairs and add them to the collection.
-        /// Bytes are parsed in a consuming manner from the beginning of the buffer meaning that the same bytes can not be 
+        /// Bytes are parsed in a consuming manner from the beginning of the buffer meaning that the same bytes can not be
         /// present in the buffer.
         /// </summary>
         /// <param name="buffer">Buffer from where data is read</param>
@@ -243,7 +243,7 @@ namespace System.Net.Http.Formatting.Parsers
         }
 
         /// <summary>
-        /// Maintains information about the current header field being parsed. 
+        /// Maintains information about the current header field being parsed.
         /// </summary>
         private class CurrentNameValuePair
         {

--- a/src/System.Net.Http.Formatting/Formatting/Parsers/HttpRequestLineParser.cs
+++ b/src/System.Net.Http.Formatting/Formatting/Parsers/HttpRequestLineParser.cs
@@ -56,8 +56,8 @@ namespace System.Net.Http.Formatting.Parsers
         }
 
         /// <summary>
-        /// Parse an HTTP request line. 
-        /// Bytes are parsed in a consuming manner from the beginning of the request buffer meaning that the same bytes can not be 
+        /// Parse an HTTP request line.
+        /// Bytes are parsed in a consuming manner from the beginning of the request buffer meaning that the same bytes can not be
         /// present in the request buffer.
         /// </summary>
         /// <param name="buffer">Request buffer from where request is read</param>

--- a/src/System.Net.Http.Formatting/Formatting/Parsers/HttpStatusLineParser.cs
+++ b/src/System.Net.Http.Formatting/Formatting/Parsers/HttpStatusLineParser.cs
@@ -58,8 +58,8 @@ namespace System.Net.Http.Formatting.Parsers
         }
 
         /// <summary>
-        /// Parse an HTTP status line. 
-        /// Bytes are parsed in a consuming manner from the beginning of the response buffer meaning that the same bytes can not be 
+        /// Parse an HTTP status line.
+        /// Bytes are parsed in a consuming manner from the beginning of the response buffer meaning that the same bytes can not be
         /// present in the response buffer.
         /// </summary>
         /// <param name="buffer">Response buffer from where response is read</param>

--- a/src/System.Net.Http.Formatting/Formatting/Parsers/MimeMultipartBodyPartParser.cs
+++ b/src/System.Net.Http.Formatting/Formatting/Parsers/MimeMultipartBodyPartParser.cs
@@ -11,7 +11,7 @@ using System.Web.Http;
 namespace System.Net.Http.Formatting.Parsers
 {
     /// <summary>
-    /// Complete MIME multipart parser that combines <see cref="MimeMultipartParser"/> for parsing the MIME message into individual body parts 
+    /// Complete MIME multipart parser that combines <see cref="MimeMultipartParser"/> for parsing the MIME message into individual body parts
     /// and <see cref="InternetMessageFormatHeaderParser"/> for parsing each body part into a MIME header and a MIME body. The caller of the parser is returned
     /// the resulting MIME bodies which can then be written to some output.
     /// </summary>
@@ -104,7 +104,7 @@ namespace System.Net.Http.Formatting.Parsers
         }
 
         /// <summary>
-        /// Parses the data provided and generates parsed MIME body part bodies in the form of <see cref="ArraySegment{T}"/> which are ready to 
+        /// Parses the data provided and generates parsed MIME body part bodies in the form of <see cref="ArraySegment{T}"/> which are ready to
         /// write to the output stream.
         /// </summary>
         /// <param name="data">The data to parse</param>
@@ -116,11 +116,11 @@ namespace System.Net.Http.Formatting.Parsers
             bool isFinal = false;
 
             // There's a special case here - if we've reached the end of the message and there's no optional
-            // CRLF, then we're out of bytes to read, but we have finished the message. 
+            // CRLF, then we're out of bytes to read, but we have finished the message.
             //
-            // If IsWaitingForEndOfMessage is true and we're at the end of the stream, then we're going to 
-            // call into the parser again with an empty array as the buffer to signal the end of the parse. 
-            // Then the final boundary segment will be marked as complete. 
+            // If IsWaitingForEndOfMessage is true and we're at the end of the stream, then we're going to
+            // call into the parser again with an empty array as the buffer to signal the end of the parse.
+            // Then the final boundary segment will be marked as complete.
             if (bytesRead == 0 && !_mimeParser.IsWaitingForEndOfMessage)
             {
                 CleanupCurrentBodyPart();
@@ -195,7 +195,7 @@ namespace System.Net.Http.Formatting.Parsers
                 }
                 else
                 {
-                    // Otherwise return what we have 
+                    // Otherwise return what we have
                     yield return _currentBodyPart;
                 }
             }

--- a/src/System.Net.Http.Formatting/Formatting/Parsers/MimeMultipartParser.cs
+++ b/src/System.Net.Http.Formatting/Formatting/Parsers/MimeMultipartParser.cs
@@ -122,7 +122,7 @@ namespace System.Net.Http.Formatting.Parsers
             /// </summary>
             DataTooBig,
         }
-        
+
         public bool CanParseMore(int bytesRead, int bytesConsumed)
         {
             if (bytesConsumed < bytesRead)
@@ -147,7 +147,7 @@ namespace System.Net.Http.Formatting.Parsers
 
         /// <summary>
         /// Parse a MIME multipart message. Bytes are parsed in a consuming
-        /// manner from the beginning of the request buffer meaning that the same bytes can not be 
+        /// manner from the beginning of the request buffer meaning that the same bytes can not be
         /// present in the request buffer.
         /// </summary>
         /// <param name="buffer">Request buffer from where request is read</param>
@@ -156,7 +156,7 @@ namespace System.Net.Http.Formatting.Parsers
         /// <param name="remainingBodyPart">Any body part that was considered as a potential MIME multipart boundary but which was in fact part of the body.</param>
         /// <param name="bodyPart">The bulk of the body part.</param>
         /// <param name="isFinalBodyPart">Indicates whether the final body part has been found.</param>
-        /// <remarks>In order to get the complete body part, the caller is responsible for concatenating the contents of the 
+        /// <remarks>In order to get the complete body part, the caller is responsible for concatenating the contents of the
         /// <paramref name="remainingBodyPart"/> and <paramref name="bodyPart"/> out parameters.</remarks>
         /// <returns>State of the parser.</returns>
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Exception is translated to parse state.")]
@@ -375,7 +375,7 @@ namespace System.Net.Http.Formatting.Parsers
                             goto quit;
                         }
                     }
-                    
+
                     if (bytesConsumed > segmentStart)
                     {
                         if (!currentBodyPart.AppendBoundary(buffer, segmentStart, bytesConsumed - segmentStart))
@@ -391,7 +391,7 @@ namespace System.Net.Http.Formatting.Parsers
                 case BodyPartState.AfterBoundary:
 
                     // This state means that we just saw the end of a boundary. It might by a 'normal' boundary, in which
-                    // case it's followed by optional whitespace and a CRLF. Or it might be the 'final' boundary and will 
+                    // case it's followed by optional whitespace and a CRLF. Or it might be the 'final' boundary and will
                     // be followed by '--', optional whitespace and an optional CRLF.
                     if (buffer[bytesConsumed] == MimeMultipartParser.Dash && !currentBodyPart.IsFinal)
                     {
@@ -456,13 +456,13 @@ namespace System.Net.Http.Formatting.Parsers
                     {
                         currentBodyPart.AppendBoundary(MimeMultipartParser.Dash);
                         bytesConsumed++;
-                        
+
                         if (currentBodyPart.IsBoundaryComplete())
                         {
                             Debug.Assert(currentBodyPart.IsFinal);
 
-                            // If we get in here, it means we've see the trailing '--' of the last boundary - in order to consume all of the 
-                            // remaining bytes, we don't mark the parse as complete again - wait until this method is called again with the 
+                            // If we get in here, it means we've see the trailing '--' of the last boundary - in order to consume all of the
+                            // remaining bytes, we don't mark the parse as complete again - wait until this method is called again with the
                             // empty buffer to do that.
                             bodyPartState = BodyPartState.AfterBoundary;
                             parseStatus = State.NeedMoreData;
@@ -658,9 +658,9 @@ namespace System.Net.Http.Formatting.Parsers
             /// <param name="count">The number of bytes to append.</param>
             public bool AppendBoundary(byte[] data, int offset, int count)
             {
-                // Check that potential boundary is not bigger than our reference boundary. 
-                // Allow for 2 extra characters to include the final boundary which ends with 
-                // an additional "--" sequence + plus up to 4 LWS characters (which are allowed). 
+                // Check that potential boundary is not bigger than our reference boundary.
+                // Allow for 2 extra characters to include the final boundary which ends with
+                // an additional "--" sequence + plus up to 4 LWS characters (which are allowed).
                 if (_boundaryLength + count > _referenceBoundaryLength + 6)
                 {
                     return false;
@@ -753,7 +753,7 @@ namespace System.Net.Http.Formatting.Parsers
                 {
                     return false;
                 }
-                
+
                 if (_boundaryLength < _referenceBoundaryLength)
                 {
                     return false;
@@ -797,9 +797,9 @@ namespace System.Net.Http.Formatting.Parsers
                 var boundary = Encoding.UTF8.GetString(_boundary, 0, _boundaryLength);
 
                 return String.Format(
-                    CultureInfo.InvariantCulture, 
-                    "Expected: {0} *** Current: {1}", 
-                    referenceBoundary, 
+                    CultureInfo.InvariantCulture,
+                    "Expected: {0} *** Current: {1}",
+                    referenceBoundary,
                     boundary);
             }
         }

--- a/src/System.Net.Http.Formatting/Formatting/RequestHeaderMapping.cs
+++ b/src/System.Net.Http.Formatting/Formatting/RequestHeaderMapping.cs
@@ -23,9 +23,9 @@ namespace System.Net.Http.Formatting
         /// <param name="headerName">Name of the header to match.</param>
         /// <param name="headerValue">The header value to match.</param>
         /// <param name="valueComparison">The value comparison to use when matching <paramref name="headerValue"/>.</param>
-        /// <param name="isValueSubstring">if set to <c>true</c> then <paramref name="headerValue"/> is 
+        /// <param name="isValueSubstring">if set to <c>true</c> then <paramref name="headerValue"/> is
         /// considered a match if it matches a substring of the actual header value.</param>
-        /// <param name="mediaType">The media type to use if <paramref name="headerName"/> and <paramref name="headerValue"/> 
+        /// <param name="mediaType">The media type to use if <paramref name="headerName"/> and <paramref name="headerValue"/>
         /// is considered a match.</param>
         public RequestHeaderMapping(string headerName, string headerValue, StringComparison valueComparison, bool isValueSubstring, string mediaType)
             : base(mediaType)
@@ -39,9 +39,9 @@ namespace System.Net.Http.Formatting
         /// <param name="headerName">Name of the header to match.</param>
         /// <param name="headerValue">The header value to match.</param>
         /// <param name="valueComparison">The <see cref="StringComparison"/> to use when matching <paramref name="headerValue"/>.</param>
-        /// <param name="isValueSubstring">if set to <c>true</c> then <paramref name="headerValue"/> is 
+        /// <param name="isValueSubstring">if set to <c>true</c> then <paramref name="headerValue"/> is
         /// considered a match if it matches a substring of the actual header value.</param>
-        /// <param name="mediaType">The <see cref="MediaTypeHeaderValue"/> to use if <paramref name="headerName"/> and <paramref name="headerValue"/> 
+        /// <param name="mediaType">The <see cref="MediaTypeHeaderValue"/> to use if <paramref name="headerName"/> and <paramref name="headerValue"/>
         /// is considered a match.</param>
         public RequestHeaderMapping(string headerName, string headerValue, StringComparison valueComparison, bool isValueSubstring, MediaTypeHeaderValue mediaType)
             : base(mediaType)
@@ -65,7 +65,7 @@ namespace System.Net.Http.Formatting
         public StringComparison HeaderValueComparison { get; private set; }
 
         /// <summary>
-        /// Gets a value indicating whether <see cref="HeaderValue"/> is 
+        /// Gets a value indicating whether <see cref="HeaderValue"/> is
         /// a matched as a substring of the actual header value.
         /// this instance is value substring.
         /// </summary>

--- a/src/System.Net.Http.Formatting/Formatting/StringWithQualityHeaderValueComparer.cs
+++ b/src/System.Net.Http.Formatting/Formatting/StringWithQualityHeaderValueComparer.cs
@@ -9,9 +9,9 @@ namespace System.Net.Http.Formatting
 {
     /// <summary>
     /// Implementation of <see cref="IComparer{T}"/> that can compare content negotiation header fields
-    /// based on their quality values (a.k.a q-values). This applies to values used in accept-charset, 
-    /// accept-encoding, accept-language and related header fields with similar syntax rules. See 
-    /// <see cref="MediaTypeWithQualityHeaderValueComparer"/> for a comparer for media type 
+    /// based on their quality values (a.k.a q-values). This applies to values used in accept-charset,
+    /// accept-encoding, accept-language and related header fields with similar syntax rules. See
+    /// <see cref="MediaTypeWithQualityHeaderValueComparer"/> for a comparer for media type
     /// q-values.
     /// </summary>
     internal class StringWithQualityHeaderValueComparer : IComparer<StringWithQualityHeaderValue>

--- a/src/System.Net.Http.Formatting/Formatting/XmlMediaTypeFormatter.cs
+++ b/src/System.Net.Http.Formatting/Formatting/XmlMediaTypeFormatter.cs
@@ -67,8 +67,8 @@ namespace System.Net.Http.Formatting
         /// </summary>
         /// <value>
         /// <remarks>
-        /// The default media type does not have any <c>charset</c> parameter as 
-        /// the <see cref="Encoding"/> can be configured on a per <see cref="XmlMediaTypeFormatter"/> 
+        /// The default media type does not have any <c>charset</c> parameter as
+        /// the <see cref="Encoding"/> can be configured on a per <see cref="XmlMediaTypeFormatter"/>
         /// instance basis.
         /// </remarks>
         /// Because <see cref="MediaTypeHeaderValue"/> is mutable, the value
@@ -89,7 +89,7 @@ namespace System.Net.Http.Formatting
         public bool UseXmlSerializer { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to indent elements when writing data. 
+        /// Gets or sets a value indicating whether to indent elements when writing data.
         /// </summary>
         public bool Indent
         {

--- a/src/System.Net.Http.Formatting/FormattingUtilities.cs
+++ b/src/System.Net.Http.Formatting/FormattingUtilities.cs
@@ -18,7 +18,7 @@ namespace System.Net.Http
     internal static class FormattingUtilities
     {
         // Supported date formats for input.
-        private static readonly string[] dateFormats = new string[] 
+        private static readonly string[] dateFormats = new string[]
         {
             // "r", // RFC 1123, required output format but too strict for input
             "ddd, d MMM yyyy H:m:s 'GMT'", // RFC 1123 (r, except it allows both 1 and 01 for date and time)
@@ -134,7 +134,7 @@ namespace System.Net.Http
         }
 
         /// <summary>
-        /// Creates an empty <see cref="HttpContentHeaders"/> instance. The only way is to get it from a dummy 
+        /// Creates an empty <see cref="HttpContentHeaders"/> instance. The only way is to get it from a dummy
         /// <see cref="HttpContent"/> instance.
         /// </summary>
         /// <returns>The created instance.</returns>

--- a/src/System.Net.Http.Formatting/Handlers/ProgressStream.cs
+++ b/src/System.Net.Http.Formatting/Handlers/ProgressStream.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 namespace System.Net.Http.Handlers
 {
     /// <summary>
-    /// This implementation of <see cref="DelegatingStream"/> registers how much data has been 
+    /// This implementation of <see cref="DelegatingStream"/> registers how much data has been
     /// read (received) versus written (sent) for a particular HTTP operation. The implementation
     /// is client side in that the total bytes to send is taken from the request and the total
     /// bytes to read is taken from the response. In a server side scenario, it would be the

--- a/src/System.Net.Http.Formatting/HttpContentFormDataExtensions.cs
+++ b/src/System.Net.Http.Formatting/HttpContentFormDataExtensions.cs
@@ -15,7 +15,7 @@ using NameValueCollection = System.Net.Http.Formatting.HttpValueCollection;
 namespace System.Net.Http
 {
     /// <summary>
-    /// Extension methods to allow HTML form URL-encoded data, also known as <c>application/x-www-form-urlencoded</c>, 
+    /// Extension methods to allow HTML form URL-encoded data, also known as <c>application/x-www-form-urlencoded</c>,
     /// to be read from <see cref="HttpContent"/> instances.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/System.Net.Http.Formatting/HttpContentMessageExtensions.cs
+++ b/src/System.Net.Http.Formatting/HttpContentMessageExtensions.cs
@@ -126,7 +126,7 @@ namespace System.Net.Http
         /// Read the <see cref="HttpContent"/> as an <see cref="HttpRequestMessage"/>.
         /// </summary>
         /// <param name="content">The content to read.</param>
-        /// <param name="uriScheme">The URI scheme to use for the request URI (the 
+        /// <param name="uriScheme">The URI scheme to use for the request URI (the
         /// URI scheme is not actually part of the HTTP Request URI and so must be provided externally).</param>
         /// <param name="bufferSize">Size of the buffer.</param>
         /// <returns>A task object representing reading the content as an <see cref="HttpRequestMessage"/>.</returns>
@@ -140,7 +140,7 @@ namespace System.Net.Http
         /// Read the <see cref="HttpContent"/> as an <see cref="HttpRequestMessage"/>.
         /// </summary>
         /// <param name="content">The content to read.</param>
-        /// <param name="uriScheme">The URI scheme to use for the request URI (the 
+        /// <param name="uriScheme">The URI scheme to use for the request URI (the
         /// URI scheme is not actually part of the HTTP Request URI and so must be provided externally).</param>
         /// <param name="bufferSize">Size of the buffer.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
@@ -157,7 +157,7 @@ namespace System.Net.Http
         /// Read the <see cref="HttpContent"/> as an <see cref="HttpRequestMessage"/>.
         /// </summary>
         /// <param name="content">The content to read.</param>
-        /// <param name="uriScheme">The URI scheme to use for the request URI (the 
+        /// <param name="uriScheme">The URI scheme to use for the request URI (the
         /// URI scheme is not actually part of the HTTP Request URI and so must be provided externally).</param>
         /// <param name="bufferSize">Size of the buffer.</param>
         /// <param name="maxHeaderSize">The max length of the HTTP header.</param>
@@ -174,7 +174,7 @@ namespace System.Net.Http
         /// Read the <see cref="HttpContent"/> as an <see cref="HttpRequestMessage"/>.
         /// </summary>
         /// <param name="content">The content to read.</param>
-        /// <param name="uriScheme">The URI scheme to use for the request URI (the 
+        /// <param name="uriScheme">The URI scheme to use for the request URI (the
         /// URI scheme is not actually part of the HTTP Request URI and so must be provided externally).</param>
         /// <param name="bufferSize">Size of the buffer.</param>
         /// <param name="maxHeaderSize">The max length of the HTTP header.</param>

--- a/src/System.Net.Http.Formatting/HttpContentMultipartExtensions.cs
+++ b/src/System.Net.Http.Formatting/HttpContentMultipartExtensions.cs
@@ -41,9 +41,9 @@ namespace System.Net.Http
         }
 
         /// <summary>
-        /// Determines whether the specified content is MIME multipart content with the 
+        /// Determines whether the specified content is MIME multipart content with the
         /// specified subtype. For example, the subtype <c>mixed</c> would match content
-        /// with a content type of <c>multipart/mixed</c>. 
+        /// with a content type of <c>multipart/mixed</c>.
         /// </summary>
         /// <param name="content">The content.</param>
         /// <param name="subtype">The MIME multipart subtype to match.</param>
@@ -91,7 +91,7 @@ namespace System.Net.Http
 
         /// <summary>
         /// Reads all body parts within a MIME multipart message using the provided <see cref="MultipartStreamProvider"/> instance
-        /// to determine where the contents of each body part is written. 
+        /// to determine where the contents of each body part is written.
         /// </summary>
         /// <typeparam name="T">The <see cref="MultipartStreamProvider"/> with which to process the data.</typeparam>
         /// <param name="content">An existing <see cref="HttpContent"/> instance to use for the object's content.</param>
@@ -104,7 +104,7 @@ namespace System.Net.Http
 
         /// <summary>
         /// Reads all body parts within a MIME multipart message using the provided <see cref="MultipartStreamProvider"/> instance
-        /// to determine where the contents of each body part is written. 
+        /// to determine where the contents of each body part is written.
         /// </summary>
         /// <typeparam name="T">The <see cref="MultipartStreamProvider"/> with which to process the data.</typeparam>
         /// <param name="content">An existing <see cref="HttpContent"/> instance to use for the object's content.</param>

--- a/src/System.Net.Http.Formatting/HttpMessageContent.cs
+++ b/src/System.Net.Http.Formatting/HttpMessageContent.cs
@@ -357,7 +357,7 @@ namespace System.Net.Http
         private void ValidateStreamForReading(Stream stream)
         {
             // If the content needs to be written to a target stream a 2nd time, then the stream must support
-            // seeking (e.g. a FileStream), otherwise the stream can't be copied a second time to a target 
+            // seeking (e.g. a FileStream), otherwise the stream can't be copied a second time to a target
             // stream (e.g. a NetworkStream).
             if (_contentConsumed)
             {

--- a/src/System.Net.Http.Formatting/Internal/HttpValueCollection.cs
+++ b/src/System.Net.Http.Formatting/Internal/HttpValueCollection.cs
@@ -40,7 +40,7 @@ namespace System.Net.Http.Formatting.Internal
         internal readonly List<KeyValuePair<string, string>> List = new List<KeyValuePair<string, string>>();
 
         /// <summary>
-        /// Creates a new <see cref="System.Net.Http.Formatting.HttpValueCollection"/> instance 
+        /// Creates a new <see cref="System.Net.Http.Formatting.HttpValueCollection"/> instance
         /// </summary>
         public HttpValueCollection()
         {

--- a/src/System.Net.Http.Formatting/MimeBodyPart.cs
+++ b/src/System.Net.Http.Formatting/MimeBodyPart.cs
@@ -39,8 +39,8 @@ namespace System.Net.Http
             Segments = new List<ArraySegment<byte>>(2);
             _headers = FormattingUtilities.CreateEmptyContentHeaders();
             HeaderParser = new InternetMessageFormatHeaderParser(
-                _headers, 
-                maxBodyPartHeaderSize, 
+                _headers,
+                maxBodyPartHeaderSize,
                 ignoreHeaderValidation: true);
         }
 

--- a/src/System.Net.Http.Formatting/MultipartRelatedStreamProvider.cs
+++ b/src/System.Net.Http.Formatting/MultipartRelatedStreamProvider.cs
@@ -24,7 +24,7 @@ namespace System.Net.Http
         private HttpContent _parent;
 
         /// <summary>
-        /// Gets the <see cref="HttpContent"/> instance that has been marked as the <c>root</c> content in the 
+        /// Gets the <see cref="HttpContent"/> instance that has been marked as the <c>root</c> content in the
         /// MIME multipart related message using the <c>start</c> parameter. If no <c>start</c> parameter is
         /// present then pick the first of the children.
         /// </summary>
@@ -71,7 +71,7 @@ namespace System.Net.Http
         {
             Contract.Assert(children != null);
 
-            // Find 'start' parameter from parent content type. The value is used 
+            // Find 'start' parameter from parent content type. The value is used
             // to identify the MIME body with the corresponding Content-ID header value.
             NameValueHeaderValue startNameValue = FindMultipartRelatedParameter(parent, StartParameter);
             if (startNameValue == null)

--- a/src/System.Net.Http.Formatting/Properties/Resources.Designer.cs
+++ b/src/System.Net.Http.Formatting/Properties/Resources.Designer.cs
@@ -11,7 +11,7 @@
 namespace System.Net.Http.Properties {
     using System;
     using System.Reflection;
-    
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -23,15 +23,15 @@ namespace System.Net.Http.Properties {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
-        
+
         private static global::System.Resources.ResourceManager resourceMan;
-        
+
         private static global::System.Globalization.CultureInfo resourceCulture;
-        
+
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal Resources() {
         }
-        
+
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
@@ -50,7 +50,7 @@ namespace System.Net.Http.Properties {
                 return resourceMan;
             }
         }
-        
+
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
@@ -64,7 +64,7 @@ namespace System.Net.Http.Properties {
                 resourceCulture = value;
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Async Callback threw an exception..
         /// </summary>
@@ -73,7 +73,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("AsyncResult_CallbackThrewException", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The IAsyncResult implementation &apos;{0}&apos; tried to complete a single operation multiple times. This could be caused by an incorrect application IAsyncResult implementation or other extensibility code, such as an IAsyncResult that returns incorrect CompletedSynchronously values or invokes the AsyncCallback multiple times..
         /// </summary>
@@ -82,7 +82,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("AsyncResult_MultipleCompletes", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to End cannot be called twice on an AsyncResult..
         /// </summary>
@@ -91,7 +91,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("AsyncResult_MultipleEnds", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to An incorrect IAsyncResult was provided to an &apos;End&apos; method. The IAsyncResult object passed to &apos;End&apos; must be the one returned from the matching &apos;Begin&apos; or passed to the callback provided to &apos;Begin&apos;..
         /// </summary>
@@ -100,7 +100,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("AsyncResult_ResultMismatch", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Found zero byte ranges. There must be at least one byte range provided..
         /// </summary>
@@ -109,7 +109,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("ByteRangeStreamContentNoRanges", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The range unit &apos;{0}&apos; is not valid. The range must have a unit of &apos;{1}&apos;..
         /// </summary>
@@ -118,7 +118,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("ByteRangeStreamContentNotBytesRange", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The stream over which &apos;{0}&apos; provides a range view must have a length greater than or equal to 1..
         /// </summary>
@@ -127,7 +127,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("ByteRangeStreamEmpty", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The &apos;From&apos; value of the range must be less than or equal to {0}..
         /// </summary>
@@ -136,7 +136,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("ByteRangeStreamInvalidFrom", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to An attempt was made to move the position before the beginning of the stream..
         /// </summary>
@@ -145,7 +145,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("ByteRangeStreamInvalidOffset", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to None of the requested ranges ({0}) overlap with the current extent of the selected resource..
         /// </summary>
@@ -154,7 +154,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("ByteRangeStreamNoneOverlap", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The requested range ({0}) does not overlap with the current extent of the selected resource..
         /// </summary>
@@ -163,7 +163,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("ByteRangeStreamNoOverlap", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The stream over which &apos;{0}&apos; provides a range view must be seekable..
         /// </summary>
@@ -172,7 +172,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("ByteRangeStreamNotSeekable", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to This is a read-only stream..
         /// </summary>
@@ -181,7 +181,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("ByteRangeStreamReadOnly", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to A null &apos;{0}&apos; is not valid..
         /// </summary>
@@ -190,7 +190,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("CannotHaveNullInList", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The &apos;{0}&apos; of &apos;{1}&apos; cannot be used as a supported media type because it is a media range..
         /// </summary>
@@ -199,7 +199,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("CannotUseMediaRangeForSupportedMediaType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The &apos;{0}&apos; type cannot accept a null value for the value type &apos;{1}&apos;..
         /// </summary>
@@ -208,7 +208,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("CannotUseNullValueType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The specified value is not a valid cookie name..
         /// </summary>
@@ -217,7 +217,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("CookieInvalidName", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Cookie cannot be null..
         /// </summary>
@@ -226,7 +226,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("CookieNull", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The &apos;{0}&apos; list is invalid because it contains one or more null items..
         /// </summary>
@@ -235,7 +235,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("DelegatingHandlerArrayContainsNullItem", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The &apos;{0}&apos; list is invalid because the property &apos;{1}&apos; of &apos;{2}&apos; is not null..
         /// </summary>
@@ -244,7 +244,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("DelegatingHandlerArrayHasNonNullInnerHandler", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Error reading HTML form URL-encoded data stream..
         /// </summary>
@@ -253,7 +253,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("ErrorReadingFormUrlEncodedStream", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Mismatched types at node &apos;{0}&apos;..
         /// </summary>
@@ -262,7 +262,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("FormUrlEncodedMismatchingTypes", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Error parsing HTML form URL-encoded data, byte {0}..
         /// </summary>
@@ -271,7 +271,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("FormUrlEncodedParseError", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Invalid HTTP status code: &apos;{0}&apos;. The status code must be between {1} and {2}..
         /// </summary>
@@ -280,7 +280,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("HttpInvalidStatusCode", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Invalid HTTP version: &apos;{0}&apos;. The version must start with the characters &apos;{1}&apos;..
         /// </summary>
@@ -289,7 +289,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("HttpInvalidVersion", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The &apos;{0}&apos; of the &apos;{1}&apos; has already been read..
         /// </summary>
@@ -298,7 +298,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("HttpMessageContentAlreadyRead", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The &apos;{0}&apos; must be seekable in order to create an &apos;{1}&apos; instance containing an entity body.  .
         /// </summary>
@@ -307,7 +307,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("HttpMessageContentStreamMustBeSeekable", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Error reading HTTP message..
         /// </summary>
@@ -316,7 +316,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("HttpMessageErrorReading", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Invalid &apos;{0}&apos; instance provided. It does not have a content type header with a value of &apos;{1}&apos;..
         /// </summary>
@@ -325,7 +325,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("HttpMessageInvalidMediaType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to HTTP Request URI cannot be an empty string..
         /// </summary>
@@ -334,7 +334,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("HttpMessageParserEmptyUri", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Error parsing HTTP message header byte {0} of message {1}..
         /// </summary>
@@ -343,7 +343,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("HttpMessageParserError", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to An invalid number of &apos;{0}&apos; header fields were present in the HTTP Request. It must contain exactly one &apos;{0}&apos; header field but found {1}..
         /// </summary>
@@ -352,7 +352,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("HttpMessageParserInvalidHostCount", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Invalid URI scheme: &apos;{0}&apos;. The URI scheme must be a valid &apos;{1}&apos; scheme..
         /// </summary>
@@ -361,7 +361,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("HttpMessageParserInvalidUriScheme", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Invalid array at node &apos;{0}&apos;..
         /// </summary>
@@ -370,7 +370,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("InvalidArrayInsert", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Traditional style array without &apos;[]&apos; is not supported with nested object at location {0}..
         /// </summary>
@@ -379,7 +379,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("JQuery13CompatModeNotSupportNestedJson", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The &apos;{0}&apos; method returned null. It must return a JSON serializer instance..
         /// </summary>
@@ -388,7 +388,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("JsonSerializerFactoryReturnedNull", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The &apos;{0}&apos; method threw an exception when attempting to create a JSON serializer..
         /// </summary>
@@ -397,7 +397,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("JsonSerializerFactoryThrew", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The maximum read depth ({0}) has been exceeded because the form url-encoded data being read has more levels of nesting than is allowed..
         /// </summary>
@@ -406,7 +406,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("MaxDepthExceeded", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The number of keys in a NameValueCollection has exceeded the limit of &apos;{0}&apos;. You can adjust it by modifying the MaxHttpCollectionKeys property on the &apos;{1}&apos; class..
         /// </summary>
@@ -415,7 +415,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("MaxHttpCollectionKeyLimitReached", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Error parsing BSON data; unable to read content as a {0}..
         /// </summary>
@@ -424,7 +424,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("MediaTypeFormatter_BsonParseError_MissingData", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Error parsing BSON data; unexpected dictionary content: {0} entries, first key &apos;{1}&apos;..
         /// </summary>
@@ -433,7 +433,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("MediaTypeFormatter_BsonParseError_UnexpectedData", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The &apos;{0}&apos; method returned null. It must return a JSON reader instance..
         /// </summary>
@@ -442,7 +442,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("MediaTypeFormatter_JsonReaderFactoryReturnedNull", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The &apos;{0}&apos; method returned null. It must return a JSON writer instance..
         /// </summary>
@@ -451,7 +451,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("MediaTypeFormatter_JsonWriterFactoryReturnedNull", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The media type formatter of type &apos;{0}&apos; does not support reading because it does not implement the ReadFromStreamAsync method..
         /// </summary>
@@ -460,7 +460,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("MediaTypeFormatterCannotRead", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The media type formatter of type &apos;{0}&apos; does not support reading because it does not implement the ReadFromStream method..
         /// </summary>
@@ -469,7 +469,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("MediaTypeFormatterCannotReadSync", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The media type formatter of type &apos;{0}&apos; does not support writing because it does not implement the WriteToStreamAsync method..
         /// </summary>
@@ -478,7 +478,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("MediaTypeFormatterCannotWrite", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The media type formatter of type &apos;{0}&apos; does not support writing because it does not implement the WriteToStream method..
         /// </summary>
@@ -487,7 +487,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("MediaTypeFormatterCannotWriteSync", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to No encoding found for media type formatter &apos;{0}&apos;. There must be at least one supported encoding registered in order for the media type formatter to read or write content..
         /// </summary>
@@ -496,7 +496,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("MediaTypeFormatterNoEncoding", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to MIME multipart boundary cannot end with an empty space..
         /// </summary>
@@ -505,7 +505,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("MimeMultipartParserBadBoundary", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Did not find required &apos;{0}&apos; header field in MIME multipart body part..
         /// </summary>
@@ -514,7 +514,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("MultipartFormDataStreamProviderNoContentDisposition", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Could not determine a valid local file name for the multipart body part..
         /// </summary>
@@ -523,7 +523,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("MultipartStreamProviderInvalidLocalFileName", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Nested bracket is not valid for &apos;{0}&apos; data at position {1}..
         /// </summary>
@@ -532,7 +532,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("NestedBracketNotValid", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to A non-null request URI must be provided to determine if a &apos;{0}&apos; matches a given request or response message..
         /// </summary>
@@ -541,7 +541,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("NonNullUriRequiredForMediaTypeMapping", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to No MediaTypeFormatter is available to read an object of type &apos;{0}&apos; from content with media type &apos;{1}&apos;..
         /// </summary>
@@ -550,7 +550,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("NoReadSerializerAvailable", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to An object of type &apos;{0}&apos; cannot be used with a type parameter of &apos;{1}&apos;..
         /// </summary>
@@ -559,7 +559,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("ObjectAndTypeDisagree", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The configured formatter &apos;{0}&apos; cannot write an object of type &apos;{1}&apos;..
         /// </summary>
@@ -568,7 +568,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("ObjectContent_FormatterCannotWriteType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Query string name cannot be null..
         /// </summary>
@@ -577,7 +577,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("QueryStringNameShouldNotNull", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Unexpected end of HTTP message stream. HTTP message is not complete..
         /// </summary>
@@ -586,7 +586,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("ReadAsHttpMessageUnexpectedTermination", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Invalid &apos;{0}&apos; instance provided. It does not have a &apos;{1}&apos; content-type header with a &apos;{2}&apos; parameter..
         /// </summary>
@@ -595,7 +595,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("ReadAsMimeMultipartArgumentNoBoundary", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Invalid &apos;{0}&apos; instance provided. It does not have a content-type header value. &apos;{0}&apos; instances must have a content-type header starting with &apos;{1}&apos;..
         /// </summary>
@@ -604,7 +604,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("ReadAsMimeMultipartArgumentNoContentType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Invalid &apos;{0}&apos; instance provided. It does not have a content type header starting with &apos;{1}&apos;..
         /// </summary>
@@ -613,7 +613,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("ReadAsMimeMultipartArgumentNoMultipart", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Error reading MIME multipart body part..
         /// </summary>
@@ -622,7 +622,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("ReadAsMimeMultipartErrorReading", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Error writing MIME multipart body part to output stream..
         /// </summary>
@@ -631,7 +631,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("ReadAsMimeMultipartErrorWriting", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Error parsing MIME multipart body part header byte {0} of data segment {1}..
         /// </summary>
@@ -640,7 +640,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("ReadAsMimeMultipartHeaderParseError", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Error parsing MIME multipart message byte {0} of data segment {1}..
         /// </summary>
@@ -649,7 +649,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("ReadAsMimeMultipartParseError", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The stream provider of type &apos;{0}&apos; threw an exception..
         /// </summary>
@@ -658,7 +658,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("ReadAsMimeMultipartStreamProviderException", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The stream provider of type &apos;{0}&apos; returned null. It must return a writable &apos;{1}&apos; instance..
         /// </summary>
@@ -667,7 +667,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("ReadAsMimeMultipartStreamProviderNull", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The stream provider of type &apos;{0}&apos; returned a read-only stream. It must return a writable &apos;{1}&apos; instance..
         /// </summary>
@@ -676,7 +676,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("ReadAsMimeMultipartStreamProviderReadOnly", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Unexpected end of MIME multipart stream. MIME multipart message is not complete..
         /// </summary>
@@ -685,7 +685,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("ReadAsMimeMultipartUnexpectedTermination", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The &apos;{0}&apos; method in &apos;{1}&apos; returned null. It must return a RemoteStreamResult instance containing a writable stream and a valid URL..
         /// </summary>
@@ -694,7 +694,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("RemoteStreamInfoCannotBeNull", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The &apos;{0}&apos; serializer cannot serialize the type &apos;{1}&apos;..
         /// </summary>
@@ -703,7 +703,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("SerializerCannotSerializeType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to There is an unmatched opened bracket for the &apos;{0}&apos; at position {1}..
         /// </summary>
@@ -712,7 +712,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("UnMatchedBracketNotValid", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Indentation is not supported by &apos;{0}&apos;..
         /// </summary>
@@ -721,7 +721,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("UnsupportedIndent", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The object of type &apos;{0}&apos; returned by {1} must be an instance of either XmlObjectSerializer or XmlSerializer..
         /// </summary>
@@ -730,7 +730,7 @@ namespace System.Net.Http.Properties {
                 return ResourceManager.GetString("XmlMediaTypeFormatter_InvalidSerializerType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The object returned by {0} must not be a null value..
         /// </summary>

--- a/test/System.Web.WebPages.Test/ApplicationParts/ApplicationPartTest.cs
+++ b/test/System.Web.WebPages.Test/ApplicationParts/ApplicationPartTest.cs
@@ -70,7 +70,7 @@ namespace System.Web.WebPages.Test
             var moduleName = "my-module";
             var path = "foo.baz";
 
-            // Act 
+            // Act
             var name = ApplicationPart.GetResourceNameFromVirtualPath(moduleName, path);
 
             // Assert
@@ -84,7 +84,7 @@ namespace System.Web.WebPages.Test
             var moduleName = "my-module";
             var path = "/bar/foo";
 
-            // Act 
+            // Act
             var name = ApplicationPart.GetResourceNameFromVirtualPath(moduleName, path);
 
             // Assert
@@ -98,7 +98,7 @@ namespace System.Web.WebPages.Test
             var moduleName = "my-module";
             var path = "/program files/data files/my file .foo";
 
-            // Act 
+            // Act
             var name = ApplicationPart.GetResourceNameFromVirtualPath(moduleName, path);
 
             // Assert

--- a/tools/WebStack.tasks.targets
+++ b/tools/WebStack.tasks.targets
@@ -30,6 +30,7 @@
                 if (!Version.TryParse(MinimumVersion, out minimumRequiredVersion))
                 {
                     Log.LogError("MinimumVersion '{0}' is not a valid Version.", MinimumVersion);
+                    return false;
                 }
 
                 try
@@ -74,61 +75,9 @@
 
                     if (!File.Exists(OutputFileName))
                     {
-                        Log.LogMessage("Downloading latest version of NuGet.exe...");
+                        Log.LogMessage(MessageImportance.High, "Downloading latest version of NuGet.exe...");
                         WebClient webClient = new WebClient();
                         webClient.DownloadFile("https://dist.nuget.org/win-x86-commandline/latest/nuget.exe", OutputFileName);
-                    }
-
-                    return true;
-                }
-                catch (Exception ex)
-                {
-                    Log.LogErrorFromException(ex);
-                    return false;
-                }
-            ]]>
-      </Code>
-    </Task>
-  </UsingTask>
-
-  <UsingTask TaskName="RegexReplace" TaskFactory="CodeTaskFactory" AssemblyFile="$(CodeTaskFactoryAssemblyFile)">
-    <ParameterGroup>
-      <Files ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
-      <Find ParameterType="System.String" Required="true" />
-      <Replace ParameterType="System.String" Required="true" />
-      <WarnOnNoMatch ParameterType="System.Boolean" Required="false" />
-    </ParameterGroup>
-    <Task>
-      <Using Namespace="System" />
-      <Using Namespace="System.IO" />
-      <Using Namespace="System.Text" />
-      <Using Namespace="System.Text.RegularExpressions" />
-      <Using Namespace="Microsoft.Build.Framework" />
-      <Using Namespace="Microsoft.Build.Utilities" />
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[
-                try
-                {
-                    Regex regex = new Regex(Find, RegexOptions.Multiline | RegexOptions.Compiled);
-
-                    foreach (ITaskItem file in Files)
-                    {
-                        string fullPath = Path.GetFullPath(file.ItemSpec);
-                        string originalText = File.ReadAllText(fullPath);
-                        bool matched = regex.IsMatch(originalText);
-
-                        if (!matched)
-                        {
-                            if (WarnOnNoMatch)
-                            {
-                                Log.LogWarning("No matches for '{0}' in '{1}'.", Find, fullPath);
-                            }
-                        }
-                        else
-                        {
-                            File.SetAttributes(fullPath, File.GetAttributes(fullPath) & ~FileAttributes.ReadOnly);
-                            File.WriteAllText(fullPath, regex.Replace(originalText, Replace), Encoding.UTF8);
-                        }
                     }
 
                     return true;
@@ -154,13 +103,18 @@
       <Using Namespace="System.Collections.Generic" />
       <Using Namespace="System.IO" />
       <Using Namespace="System.Linq" />
+      <Using Namespace="System.Text" />
+      <Using Namespace="System.Text.RegularExpressions" />
       <Using Namespace="System.Xml.Linq" />
+      <Using Namespace="Microsoft.Build.Framework" />
+      <Using Namespace="Microsoft.Build.Utilities" />
       <Code Type="Fragment" Language="cs">
         <![CDATA[
                 try
                 {
                     string[] testResultFiles = Directory.GetFiles(TestResultsDirectory);
-
+                    Regex regex = new Regex("&#x(?<char>[0-9A-Fa-f]+);",
+                        RegexOptions.Multiline | RegexOptions.Compiled);
                     int testsPassed = 0;
                     int testsFailed = 0;
                     int testsSkipped = 0;
@@ -169,8 +123,20 @@
 
                     foreach (string testResultFile in testResultFiles)
                     {
+                        // Replace potentially illegal escaped characters (if they get through validations done during Save).
+                        string fullPath = Path.GetFullPath(testResultFile);
+                        string originalText = File.ReadAllText(fullPath);
+                        bool matched = regex.IsMatch(originalText);
+
+                        if (matched)
+                        {
+                            File.SetAttributes(fullPath, File.GetAttributes(fullPath) & ~FileAttributes.ReadOnly);
+                            File.WriteAllText(fullPath, regex.Replace(originalText, "\0x${char}"), Encoding.UTF8);
+                        }
+
+                        // Collect test failure information from results file.
                         XElement xml;
-                        using (FileStream fileStream = File.OpenRead(testResultFile))
+                        using (FileStream fileStream = File.OpenRead(fullPath))
                         {
                             xml = XElement.Load(fileStream);
                         }
@@ -213,23 +179,32 @@
                         }
                     }
 
+                    // Log all test failures.
                     if (testFailures.Count > 0)
                     {
-                        Console.WriteLine();
-                        Console.WriteLine("  Test Failures:");
-                        ConsoleColor originalColor = Console.ForegroundColor;
-                        Console.ForegroundColor = ConsoleColor.Red;
+                        Log.LogMessage(MessageImportance.High, string.Empty);
+                        Log.LogError("Tests failed...");
                         foreach (string testFailure in testFailures)
                         {
-                            Console.WriteLine("  " + testFailure);
+                            // Provide the list of failed tests but don't repeat it in the build summary. List
+                            // is usually less helpful than errors from tests themselves (which are repeated)
+                            // because those errors include the exact failure locations. On the other hand,
+                            // this is more compact.
+                            Log.LogMessage(MessageImportance.High, testFailure);
                         }
-                        Console.ForegroundColor = originalColor;
                     }
 
-                    Console.WriteLine();
-                    Console.WriteLine("  Tests passed: {0}, Tests failed: {1}, Tests skipped: {2}", testsPassed, testsFailed, testsSkipped);
-                    Console.WriteLine("  Time spent running tests: {0} seconds", timeSpent);
-                    return true;
+                    // Log summary of all results.
+                    Log.LogMessage(MessageImportance.High, string.Empty);
+                    Log.LogMessage(MessageImportance.High,
+                        "Tests passed: {0}, Tests failed: {1}, Tests skipped: {2}",
+                        testsPassed,
+                        testsFailed,
+                        testsSkipped);
+                    Log.LogMessage(MessageImportance.High,
+                        "Time spent running tests: {0} seconds", timeSpent);
+
+                    return !Log.HasLoggedErrors;
                 }
                 catch (Exception ex)
                 {

--- a/tools/WebStack.xunit.targets
+++ b/tools/WebStack.xunit.targets
@@ -1,18 +1,17 @@
 <Project ToolsVersion="4.0" DefaultTargets="Xunit" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="WebStack.tasks.targets"/>
+  <!--
+    This is a separate MSBuild file so that we can survive upgrades of the xunit NuGet package
+    and also still work with NuGet Package Restore.
+  -->
+  <Import Project="..\packages\**\xunit.runner.msbuild.props"/>
 
-    <!-- This is a separate MSBuild file so that we can survive upgrades of the xunit NuGet package
-         and also still work with NuGet Package Restore. -->
-    <Import Project="..\packages\**\xunit.runner.msbuild.props"/>
+  <Target Name="Xunit" Returns="@(_ExitCodes)">
+    <xunit Assemblies="$(TestAssembly)" Xml="$(XmlPath)" IgnoreFailures="true">
+      <Output TaskParameter="ExitCode" PropertyName="_ExitCode" />
+    </xunit>
 
-    <Target Name="Xunit">
-        <xunit Assemblies="$(TestAssembly)" Xml="$(XmlPath)"/>
-
-        <!-- Replace potentially illegal escaped characters (if they get through validations done during Save). -->
-        <RegexReplace
-            Files="$(XmlPath)"
-            Find="&amp;#x(?&lt;char&gt;[0-9A-Fa-f]+);"
-            Replace="\0x${char}"
-            WarnOnNoMatch="false"/>
-    </Target>
+    <ItemGroup>
+      <_ExitCodes Include="$(TestAssembly)" Code="$(_ExitCode)" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
- combine `RegexReplace` into `PrintTestRunSummary` task
  - remove unused `WarnOnNoMatch` parameter; inline other parameters
  - capture test summary in `msbuild` logs
    - avoid `System.Console` use in the task
  - fail task if any tests fail
- collect `xunit` task exit codes in case of catastrophic problems (not test failures)
  - fail build if `PrintTestRunSummary` doesn't but errors occurred

also:
- do not test assemblies in parallel; reduce port contention issues
- avoid `CallTarget` task

nits:
- clean some trailing whitespace in C# sources
  - mostly files I expect to update soon
- reduce `NuGet.exe restore` verbosity; no longer debugging that
- add console summary when using build.cmd
- reduce duplication in `RestorePackages` target
  - only restore NetCore projects when `$(BuildPortable)` is `true`
  - restore src NetStandard project transitively through NetStandard.Test project
- pass more properties w/ `Restore` target invocation