### PR TITLE
Use Newtonsoft.Json.Bson except in NetCore projects

### DIFF
--- a/src/System.Net.Http.Formatting.NetStandard/System.Net.Http.Formatting.NetStandard.csproj
+++ b/src/System.Net.Http.Formatting.NetStandard/System.Net.Http.Formatting.NetStandard.csproj
@@ -7,7 +7,7 @@
     <OutputPath>$(OutputPath)NetStandard\</OutputPath>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <RunCodeAnalysis>false</RunCodeAnalysis>
-    <DefineConstants>$(DefineConstants);ASPNETMVC;NEWTONSOFTJSON10</DefineConstants>
+    <DefineConstants>$(DefineConstants);ASPNETMVC</DefineConstants>
     <NoWarn>1591</NoWarn>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Configurations>$(Configurations);CodeAnalysis</Configurations>

--- a/src/System.Net.Http.Formatting/Formatting/BsonMediaTypeFormatter.cs
+++ b/src/System.Net.Http.Formatting/Formatting/BsonMediaTypeFormatter.cs
@@ -11,11 +11,11 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Web.Http;
 using Newtonsoft.Json;
-#if NEWTONSOFTJSON10
+#if NETFX_CORE
+using Newtonsoft.Json.Bson;
+#else
 using BsonReader = Newtonsoft.Json.Bson.BsonDataReader;
 using BsonWriter = Newtonsoft.Json.Bson.BsonDataWriter;
-#else
-using Newtonsoft.Json.Bson;
 #endif
 
 namespace System.Net.Http.Formatting
@@ -200,11 +200,11 @@ namespace System.Net.Http.Formatting
                 throw Error.ArgumentNull("effectiveEncoding");
             }
 
-#if !NEWTONSOFTJSON10
+#if NETFX_CORE
 #pragma warning disable CS0618 // Type or member is obsolete
 #endif
             BsonReader reader = new BsonReader(new BinaryReader(readStream, effectiveEncoding));
-#if !NEWTONSOFTJSON10
+#if NETFX_CORE
 #pragma warning restore CS0618 // Type or member is obsolete
 #endif
 
@@ -303,11 +303,11 @@ namespace System.Net.Http.Formatting
                 throw Error.ArgumentNull("effectiveEncoding");
             }
 
-#if !NEWTONSOFTJSON10
+#if NETFX_CORE
 #pragma warning disable CS0618 // Type or member is obsolete
 #endif
             return new BsonWriter(new BinaryWriter(writeStream, effectiveEncoding));
-#if !NEWTONSOFTJSON10
+#if NETFX_CORE
 #pragma warning restore CS0618 // Type or member is obsolete
 #endif
         }

--- a/src/System.Net.Http.Formatting/System.Net.Http.Formatting.csproj
+++ b/src/System.Net.Http.Formatting/System.Net.Http.Formatting.csproj
@@ -20,6 +20,11 @@
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json.Bson, Version=1.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.Bson.1.0.2\lib\net45\Newtonsoft.Json.Bson.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />

--- a/src/System.Net.Http.Formatting/packages.config
+++ b/src/System.Net.Http.Formatting/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json.Bson" version="1.0.2" targetFramework="net45" />
 </packages>

--- a/test/System.Net.Http.Formatting.NetStandard.Test/System.Net.Http.Formatting.NetStandard.Test.csproj
+++ b/test/System.Net.Http.Formatting.NetStandard.Test/System.Net.Http.Formatting.NetStandard.Test.csproj
@@ -5,7 +5,6 @@
     <RootNamespace>System.Net.Http</RootNamespace>
     <AssemblyName>System.Net.Http.Formatting.NetStandard.Test</AssemblyName>
     <OutputPath>..\..\bin\$(Configuration)\Test\</OutputPath>
-    <DefineConstants>$(DefineConstants);NEWTONSOFTJSON10</DefineConstants>
     <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/test/System.Net.Http.Formatting.Test/Formatting/BsonMediaTypeFormatterTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/BsonMediaTypeFormatterTests.cs
@@ -262,10 +262,10 @@ namespace System.Net.Http.Formatting
             BsonMediaTypeFormatter formatter = new BsonMediaTypeFormatter();
             HttpContent content = new StringContent(String.Empty);
             MemoryStream stream = new MemoryStream();
-#if NEWTONSOFTJSON10 // Json.NET 10's Bson package calculates the path in some exceptions differently.
-            string expectedPath = "Value";
-#else
+#if NETFX_CORE // Separate Bson package (not yet used in NETCore project) calculates the path in exceptions differently
             string expectedPath = string.Empty;
+#else
+            string expectedPath = "Value";
 #endif
             string expectedMessage = string.Format(
                 "Value is too large to fit in a signed 32 bit integer. BSON does not support unsigned values. Path '{0}'.",

--- a/test/System.Net.Http.Formatting.Test/System.Net.Http.Formatting.Test.csproj
+++ b/test/System.Net.Http.Formatting.Test/System.Net.Http.Formatting.Test.csproj
@@ -26,6 +26,10 @@
       <HintPath>..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json.Bson, Version=1.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.Bson.1.0.2\lib\net45\Newtonsoft.Json.Bson.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />

--- a/test/System.Net.Http.Formatting.Test/packages.config
+++ b/test/System.Net.Http.Formatting.Test/packages.config
@@ -3,6 +3,7 @@
   <package id="Castle.Core" version="4.2.1" targetFramework="net452" />
   <package id="Moq" version="4.7.142" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json.Bson" version="1.0.2" targetFramework="net452" />
   <package id="xunit" version="2.3.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
   <package id="xunit.analyzers" version="0.7.0" targetFramework="net452" />


### PR DESCRIPTION
- avoid obsolete `BsonReader` and `BsonWriter` classes
  - use `NETFX_CORE` for remaining legacy case (for now)
- remove `NEWTONSOFTJSON10` define; need only `NETFX_CORE` now