### PR TITLE
Address a few more nits

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,5 +9,8 @@
       analyzers, which run during build. Refer to https://aka.ms/fxcopanalyzers to migrate to FxCop analyzers."
     -->
     <SuppressLegacyCodeAnalysisDeprecatedWarning>true</SuppressLegacyCodeAnalysisDeprecatedWarning>
+    <!-- Workaround continued use of netcoreapp2.1; suppress the NETSDK1138 warning. -->
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
+
 </Project>

--- a/tools/WebStack.tasks.targets
+++ b/tools/WebStack.tasks.targets
@@ -48,6 +48,11 @@
                         if (versionInfo != null && versionInfo.ProductVersion != null)
                         {
                             toParse = versionInfo.ProductVersion;
+                            int index = toParse.IndexOfAny(new[] {'-', '+'});
+                            if (index > 0)
+                            {
+                                toParse = toParse.Substring(0, index);
+                            }
                         }
                         else
                         {


### PR DESCRIPTION
- avoid repeated NuGet.exe downloads
  - remove extra bits in modern file versions before parsing
- suppress warnings about targeting `netcoreapp2.1`