### PR TITLE
Use latest 2.1.x .NET SDK

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,8 @@ parameters:
 variables:
 - name: DOTNET_CLI_TELEMETRY_OPTOUT
   value: 1
+- name: DOTNET_NOLOGO
+  value: 1
   # Run CodeQL3000 tasks in a separate internal pipeline; not needed here.
 - name: Codeql.SkipTaskAutoInjection
   value: true

--- a/build.cmd
+++ b/build.cmd
@@ -35,6 +35,10 @@ for /f "usebackq tokens=*" %%i in (`%vswhere% -version 16 -latest -prerelease -p
   set InstallDir="%%i"
 )
 
+if not DEFINED InstallDir (
+  echo "Could not find a VS2019 installation with the necessary components (MSBuild, .NET Core 2.1 Runtime, .NET SDK). Please install VS2019 or the missing components."
+)
+
 if exist %InstallDir%\MSBuild\Current\Bin\MSBuild.exe (
   set MSBuild=%InstallDir%\MSBuild\Current\Bin\MSBuild.exe
 ) else (

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "2.1.500",
+    "version": "2.1.818",
     "rollForward": "major"
   }
 }

--- a/src/System.Net.Http.Formatting/Handlers/ProgressStream.cs
+++ b/src/System.Net.Http.Formatting/Handlers/ProgressStream.cs
@@ -67,6 +67,7 @@ namespace System.Net.Http.Handlers
             ReportBytesReceived(readCount, userState: null);
             return readCount;
         }
+
 #if !NETFX_CORE // BeginX and EndX are not supported on streams in portable libraries
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
         {


### PR DESCRIPTION
- noticed CI builds were using old 2.1.500
  - `UseDotNet@2` seems to ignore `rollForward` when using global.json :frown:
- nits:
  - quiet `dotnet` in CI (where `dotnet` is always new)
  - complain about all potentially missing components when VS isn't found
  - add a missing blank line