### PR TITLE
Correct `ValidateStreamForReading(...)`

### DIFF
--- a/src/System.Net.Http.Formatting/HttpContentMessageExtensions.cs
+++ b/src/System.Net.Http.Formatting/HttpContentMessageExtensions.cs
@@ -467,7 +467,8 @@ namespace System.Net.Http
                 }
             }
 
-            // If we have content headers then create an HttpContent for this Response
+            // If we have content headers then create an HttpContent for this request or response. Otherwise,
+            // provide a HttpContent instance to overwrite the null or EmptyContent value.
             if (contentHeaders != null)
             {
                 // Need to rewind the input stream to be at the position right after the HTTP header

--- a/src/System.Net.Http.Formatting/HttpMessageContent.cs
+++ b/src/System.Net.Http.Formatting/HttpMessageContent.cs
@@ -359,12 +359,21 @@ namespace System.Net.Http
 
         private void ValidateStreamForReading(Stream stream)
         {
+            // Stream is null case should be an extreme, incredibly unlikely corner case. Every HttpContent from
+            // the framework (see dotnet/runtime or .NET Framework reference source) provides a non-null Stream
+            // in the ReadAsStringAsync task's return value. Likely need a poorly-designed derived HttpContent
+            // to hit this. Mostly ignoring the fact this message doesn't make much sense for the case.
+            if (stream is null || !stream.CanRead)
+            {
+                throw Error.NotSupported(Properties.Resources.NotSupported_UnreadableStream);
+            }
+
             // If the content needs to be written to a target stream a 2nd time, then the stream must support
             // seeking (e.g. a FileStream), otherwise the stream can't be copied a second time to a target
             // stream (e.g. a NetworkStream).
             if (_contentConsumed)
             {
-                if (stream != null && stream.CanRead)
+                if (stream.CanSeek)
                 {
                     stream.Position = 0;
                 }

--- a/src/System.Net.Http.Formatting/HttpMessageContent.cs
+++ b/src/System.Net.Http.Formatting/HttpMessageContent.cs
@@ -361,7 +361,7 @@ namespace System.Net.Http
         {
             // Stream is null case should be an extreme, incredibly unlikely corner case. Every HttpContent from
             // the framework (see dotnet/runtime or .NET Framework reference source) provides a non-null Stream
-            // in the ReadAsStringAsync task's return value. Likely need a poorly-designed derived HttpContent
+            // in the ReadAsStreamAsync task's return value. Likely need a poorly-designed derived HttpContent
             // to hit this. Mostly ignoring the fact this message doesn't make much sense for the case.
             if (stream is null || !stream.CanRead)
             {

--- a/test/System.Net.Http.Formatting.Test/HttpMessageContentTests.cs
+++ b/test/System.Net.Http.Formatting.Test/HttpMessageContentTests.cs
@@ -50,7 +50,12 @@ namespace System.Net.Http
         {
             if (unBuffered)
             {
-                using var reader = new StreamReader(await content.ReadAsStreamAsync());
+                var stream = new MemoryStream();
+                await content.CopyToAsync(stream);
+                stream.Position = 0L;
+
+                // StreamReader will dispose of the Stream.
+                using var reader = new StreamReader(stream);
 
                 return await reader.ReadToEndAsync();
             }

--- a/test/System.Net.Http.Formatting.Test/HttpMessageContentTests.cs
+++ b/test/System.Net.Http.Formatting.Test/HttpMessageContentTests.cs
@@ -50,12 +50,7 @@ namespace System.Net.Http
         {
             if (unBuffered)
             {
-                var stream = new MemoryStream();
-                await content.CopyToAsync(stream);
-                stream.Position = 0L;
-
-                // StreamReader will dispose of the Stream.
-                using var reader = new StreamReader(stream);
+                using var reader = new StreamReader(await content.ReadAsStreamAsync());
 
                 return await reader.ReadToEndAsync();
             }


### PR DESCRIPTION
- fix #389
- check `Stream` before first read attempt
- check `CanRead` (not `CanSeek`) before second or later read attempts
- add lots of tests of related scenarios
- nit: correct a recent `HttpContentMessageExtensions` comment