### PR TITLE
Support `DBNull` in `netstandard1.3` assembly

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,7 +79,7 @@ jobs:
     displayName: Build
 
   - publish: ./bin/$(_Configuration)/Test/TestResults/
-    artifact: $(_Configuration) Test Results
+    artifact: $(_Configuration) Test Results $(System.JobId)
     condition: and(always(), ne(variables._BuildTarget, 'Build'))
     continueOnError: true
     displayName: Upload test results
@@ -95,6 +95,6 @@ jobs:
       testRunTitle: $(_Configuration)
 
   - publish: ./artifacts/
-    artifact: $(_Configuration) Logs
+    artifact: $(_Configuration) Logs $(System.JobId)
     condition: always()
     displayName: Upload logs

--- a/src/System.Net.Http.Formatting.ns1_3/System.Net.Http.Formatting.ns1_3.csproj
+++ b/src/System.Net.Http.Formatting.ns1_3/System.Net.Http.Formatting.ns1_3.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.EventBasedAsync" Version="4.3.0" />
+    <PackageReference Include="System.Data.Common" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Runtime.Serialization.Json" Version="4.3.0" />

--- a/src/System.Net.Http.Formatting/Formatting/BsonMediaTypeFormatter.cs
+++ b/src/System.Net.Http.Formatting/Formatting/BsonMediaTypeFormatter.cs
@@ -73,7 +73,6 @@ namespace System.Net.Http.Formatting
             }
         }
 
-#if !NETSTANDARD1_3 // DBNull not supported in netstandard1.3; no need to override there
         /// <inheritdoc />
         public override Task<object> ReadFromStreamAsync(Type type, Stream readStream, HttpContent content, IFormatterLogger formatterLogger)
         {
@@ -101,7 +100,6 @@ namespace System.Net.Http.Formatting
                 return base.ReadFromStreamAsync(type, readStream, content, formatterLogger);
             }
         }
-#endif
 
         /// <inheritdoc />
         public override object ReadFromStream(Type type, Stream readStream, Encoding effectiveEncoding,
@@ -234,14 +232,13 @@ namespace System.Net.Http.Formatting
 
             if (value == null)
             {
-                // Cannot serialize null at the top level.  Json.Net throws Newtonsoft.Json.JsonWriterException : Error
-                // writing Null value. BSON must start with an Object or Array. Path ''.  Fortunately
+                // Cannot serialize null at the top level. Json.Net throws Newtonsoft.Json.JsonWriterException : Error
+                // writing Null value. BSON must start with an Object or Array. Path ''. Fortunately
                 // BaseJsonMediaTypeFormatter.ReadFromStream(Type, Stream, HttpContent, IFormatterLogger) treats zero-
                 // length content as null or the default value of a struct.
                 return;
             }
 
-#if !NETSTANDARD1_3 // DBNull not supported in netstandard1.3
             if (value == DBNull.Value)
             {
                 // ReadFromStreamAsync() override above converts null to DBNull.Value if given Type is DBNull; normally
@@ -252,7 +249,6 @@ namespace System.Net.Http.Formatting
                 // rather than null, and not meet the receiver's expectations.
                 return;
             }
-#endif
 
             // See comments in ReadFromStream() above about this special case and the need to include byte[] in it.
             // Using runtime type here because Json.Net will throw during serialization whenever it cannot handle the

--- a/test/System.Net.Http.Formatting.Test/Formatting/BsonMediaTypeFormatterTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/BsonMediaTypeFormatterTests.cs
@@ -392,7 +392,6 @@ namespace System.Net.Http.Formatting
             }
         }
 
-#if !Testing_NetStandard1_3 // DBNull not supported in netstandard1.3
         // Test alternate null value
         [Theory]
         [TestDataSet(typeof(JsonMediaTypeFormatterTests), "DBNullAsObjectTestDataCollection", TestDataVariations.AllSingleInstances)]
@@ -408,7 +407,7 @@ namespace System.Net.Http.Formatting
             Assert.Null(readObj);
         }
 
-#if !NETCOREAPP // DBNull not serializable on .NET Core 2.1 except at top level (using BsonMediaTypeformatter special case).
+#if !NETCOREAPP2_1 // DBNull not serializable on .NET Core 2.1 except at top level (using BsonMediaTypeformatter special case).
         [Theory]
         [TestDataSet(typeof(JsonMediaTypeFormatterTests), "DBNullAsObjectTestDataCollection", TestDataVariations.AsDictionary)]
         public async Task ReadFromStreamAsync_RoundTripsWriteToStreamAsync_DBNullAsNull_Dictionary(Type variationType, object testData)
@@ -512,7 +511,6 @@ namespace System.Net.Http.Formatting
             // Only BSON case where DBNull.Value round-trips
             Assert.Equal(testData, readObj);
         }
-#endif
 
         private class TestBsonMediaTypeFormatter : BsonMediaTypeFormatter
         {

--- a/test/System.Net.Http.Formatting.Test/Formatting/DataContractJsonMediaTypeFormatterTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/DataContractJsonMediaTypeFormatterTests.cs
@@ -159,7 +159,7 @@ namespace System.Net.Http.Formatting
             }
         }
 
-#if !NETCOREAPP // DBNull not serializable on .NET Core 2.1.
+#if !NETCOREAPP2_1 // DBNull not serializable on .NET Core 2.1.
         // Test alternate null value
         [Fact]
         public async Task ReadFromStreamAsync_RoundTripsWriteToStreamAsync_DBNull()

--- a/test/System.Net.Http.Formatting.Test/Formatting/JsonMediaTypeFormatterTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/JsonMediaTypeFormatterTests.cs
@@ -367,7 +367,7 @@ namespace System.Net.Http.Formatting
             }
         }
 
-#if !NETCOREAPP // DBNull not serializable on .NET Core 2.1.
+#if !NETCOREAPP2_1 // DBNull not serializable on .NET Core 2.1.
         // Test alternate null value; always serialized as "null"
         [Theory]
         [TestDataSet(typeof(JsonMediaTypeFormatterTests), "DBNullAsObjectTestDataCollection", TestDataVariations.AllSingleInstances)]

--- a/test/System.Net.Http.Formatting.Test/Formatting/XmlMediaTypeFormatterTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/XmlMediaTypeFormatterTests.cs
@@ -36,7 +36,7 @@ namespace System.Net.Http.Formatting
                 Int32.MaxValue,
                 Int64.MinValue,
                 Int64.MaxValue,
-#if !NETCOREAPP // DBNull not serializable on .NET Core 2.1.
+#if !NETCOREAPP2_1 // DBNull not serializable on .NET Core 2.1.
                 DBNull.Value,
 #endif
             });
@@ -478,7 +478,7 @@ namespace System.Net.Http.Formatting
             }
         }
 
-#if !NETCOREAPP // DBNull not serializable on .NET Core 2.1.
+#if !NETCOREAPP2_1 // DBNull not serializable on .NET Core 2.1.
         [Fact]
         public async Task ReadFromStreamAsync_RoundTripsWriteToStreamAsyncUsingDataContractSerializer_DBNull()
         {

--- a/test/System.Net.Http.Formatting.Test/Internal/HttpValueCollectionTest.cs
+++ b/test/System.Net.Http.Formatting.Test/Internal/HttpValueCollectionTest.cs
@@ -12,7 +12,7 @@ namespace System.Net.Http.Internal
 {
     public class HttpValueCollectionTest
     {
-#if !NETCOREAPP // Unused on .NET Core 2.1.
+#if !NETCOREAPP // Unused on .NET Core.
         private static readonly int _maxCollectionKeys = 1000;
 #endif
 
@@ -21,7 +21,7 @@ namespace System.Net.Http.Internal
             return HttpValueCollection.Create();
         }
 
-#if !NETCOREAPP
+#if !NETCOREAPP // Unsupported on .NET Core.
         private static void RunInIsolation(Action action)
         {
             AppDomainUtils.RunInSeparateAppDomain(action);
@@ -132,7 +132,7 @@ namespace System.Net.Http.Internal
             Assert.Empty(nvc);
         }
 
-#if !NETCOREAPP // DBNull not serializable on .NET Core 2.1.
+#if !NETCOREAPP // Able to run on a separate AppDomain only on .NET Framework.
         // This set of tests requires running on a separate appdomain so we don't
         // touch the static property MediaTypeFormatter.MaxHttpCollectionKeys.
         [Fact]


### PR DESCRIPTION
- available from the System.Data.Common package
- extend `DBNull` testing to include `net6.0`
  - s/NETCOREAPP/NETCOREAPP2_1/ where possible
- fix comments in `HttpValueCollectionTest`
  - comments about `DBNull` there were incorrect