### PR TITLE
Throw `PlatformNotSupportedException` in `netstandard1.3`

### DIFF
--- a/src/System.Net.Http.Formatting/Formatting/MediaTypeFormatterCollection.cs
+++ b/src/System.Net.Http.Formatting/Formatting/MediaTypeFormatterCollection.cs
@@ -255,7 +255,11 @@ namespace System.Net.Http.Formatting
             return new MediaTypeFormatter[]
             {
                 new JsonMediaTypeFormatter(),
-                new XmlMediaTypeFormatter(),
+                new XmlMediaTypeFormatter()
+#if NETSTANDARD1_3 // XsdDataContractExporter is not supported in netstandard1.3. Cannot use DCS.
+                { UseXmlSerializer = true }
+#endif
+                ,
                 new FormUrlEncodedMediaTypeFormatter()
             };
         }

--- a/src/System.Net.Http.Formatting/Formatting/XmlMediaTypeFormatter.cs
+++ b/src/System.Net.Http.Formatting/Formatting/XmlMediaTypeFormatter.cs
@@ -511,6 +511,23 @@ namespace System.Net.Http.Formatting
         private object CreateDefaultSerializer(Type type, bool throwOnError)
         {
             Contract.Assert(type != null, "type cannot be null.");
+
+#if NETSTANDARD1_3 // XsdDataContractExporter is not supported in netstandard1.3
+            if (!UseXmlSerializer)
+            {
+                if (throwOnError)
+                {
+                    throw new PlatformNotSupportedException(Error.Format(
+                        Properties.Resources.XmlMediaTypeFormatter_DCS_NotSupported,
+                        nameof(UseXmlSerializer)));
+                }
+                else
+                {
+                    return null;
+                }
+            }
+#endif
+
             Exception exception = null;
             object serializer = null;
 
@@ -522,13 +539,12 @@ namespace System.Net.Http.Formatting
                 }
                 else
                 {
-#if !NETSTANDARD1_3 // XsdDataContractExporter is not supported in netstandard1.3
-                    // REVIEW: Is there something comparable in WinRT?
+#if !NETSTANDARD1_3 // Unreachable when targeting netstandard1.3.
                     // Verify that type is a valid data contract by forcing the serializer to try to create a data contract
                     FormattingUtilities.XsdDataContractExporter.GetRootElementName(type);
-#endif
 
                     serializer = CreateDataContractSerializer(type);
+#endif
                 }
             }
             catch (Exception caught)

--- a/src/System.Net.Http.Formatting/Properties/Resources.Designer.cs
+++ b/src/System.Net.Http.Formatting/Properties/Resources.Designer.cs
@@ -391,6 +391,15 @@ namespace System.Net.Http.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Unable to validate types on this platform when {0} is &apos;true&apos;. Please reset {0} or move to a supported platform, one where the &apos;netstandard2.0&apos; assembly is usable..
+        /// </summary>
+        internal static string JsonMediaTypeFormatter_DCS_NotSupported {
+            get {
+                return ResourceManager.GetString("JsonMediaTypeFormatter_DCS_NotSupported", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to The &apos;{0}&apos; method returned null. It must return a JSON serializer instance..
         /// </summary>
         internal static string JsonSerializerFactoryReturnedNull {
@@ -765,6 +774,15 @@ namespace System.Net.Http.Properties {
         internal static string UnsupportedIndent {
             get {
                 return ResourceManager.GetString("UnsupportedIndent", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to validate types on this platform when {0} is &apos;false&apos;. Please set {0} or move to a supported platform, one where the &apos;netstandard2.0&apos; assembly is usable..
+        /// </summary>
+        internal static string XmlMediaTypeFormatter_DCS_NotSupported {
+            get {
+                return ResourceManager.GetString("XmlMediaTypeFormatter_DCS_NotSupported", resourceCulture);
             }
         }
 

--- a/src/System.Net.Http.Formatting/Properties/Resources.resx
+++ b/src/System.Net.Http.Formatting/Properties/Resources.resx
@@ -357,4 +357,10 @@
   <data name="ObjectDisposed_StreamClosed" xml:space="preserve">
     <value>Cannot access a closed stream.</value>
   </data>
+  <data name="JsonMediaTypeFormatter_DCS_NotSupported" xml:space="preserve">
+    <value>Unable to validate types on this platform when {0} is 'true'. Please reset {0} or move to a supported platform, one where the 'netstandard2.0' assembly is usable.</value>
+  </data>
+  <data name="XmlMediaTypeFormatter_DCS_NotSupported" xml:space="preserve">
+    <value>Unable to validate types on this platform when {0} is 'false'. Please set {0} or move to a supported platform, one where the 'netstandard2.0' assembly is usable.</value>
+  </data>
 </root>

--- a/test/System.Net.Http.Formatting.Test/Formatting/JsonMediaTypeFormatterTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/JsonMediaTypeFormatterTests.cs
@@ -225,6 +225,7 @@ namespace System.Net.Http.Formatting
             Assert.NotNull(formatter.InnerJsonSerializer);
         }
 
+#if !Testing_NetStandard1_3 // Cannot read or write w/ DCS in netstandard1.3.
         [Fact]
         public async Task DataContractFormatterThrowsOnWriteWhenOverridenCreateFails()
         {
@@ -309,6 +310,7 @@ namespace System.Net.Http.Formatting
             Assert.NotNull(formatter.InnerDataContractSerializer);
             Assert.Null(formatter.InnerJsonSerializer);
         }
+#endif
 
         [Fact]
         public void CanReadType_ReturnsTrueOnJtoken()

--- a/test/System.Net.Http.Formatting.Test/Formatting/MediaTypeFormatterTestBase.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/MediaTypeFormatterTestBase.cs
@@ -152,7 +152,7 @@ namespace System.Net.Http.Formatting
         }
 
         [Fact]
-        public async Task ReadFromStreamAsync_ReadsDataButDoesNotCloseStream()
+        public virtual async Task ReadFromStreamAsync_ReadsDataButDoesNotCloseStream()
         {
             // Arrange
             TFormatter formatter = CreateFormatter();
@@ -173,7 +173,7 @@ namespace System.Net.Http.Formatting
         }
 
         [Fact]
-        public async Task ReadFromStreamAsync_WhenContentLengthIsNull_ReadsDataButDoesNotCloseStream()
+        public virtual async Task ReadFromStreamAsync_WhenContentLengthIsNull_ReadsDataButDoesNotCloseStream()
         {
             // Arrange
             TFormatter formatter = CreateFormatter();
@@ -219,7 +219,7 @@ namespace System.Net.Http.Formatting
         }
 
         [Fact]
-        public async Task WriteToStreamAsync_WritesDataButDoesNotCloseStream()
+        public virtual async Task WriteToStreamAsync_WritesDataButDoesNotCloseStream()
         {
             // Arrange
             TFormatter formatter = CreateFormatter();

--- a/test/System.Net.Http.Formatting.Test/Formatting/SerializerConsistencyTests.cs
+++ b/test/System.Net.Http.Formatting.Test/Formatting/SerializerConsistencyTests.cs
@@ -4,12 +4,11 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net.Http.Formatting;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using Microsoft.TestCommon;
 
-namespace System.Net.Formatting.Tests
+namespace System.Net.Http.Formatting
 {
     // Tests for ensuring the serializers behave consistently in various cases.
     // This is important for conneg.
@@ -18,7 +17,12 @@ namespace System.Net.Formatting.Tests
         [Fact]
         public Task PartialContract()
         {
-            var c = new PartialDataContract { PropertyWithAttribute = "one", PropertyWithoutAttribute = "false" };
+            var c = new PartialDataContract {
+                PropertyWithAttribute = "one",
+#if !Testing_NetStandard1_3 // Xml formatter ignores DCS attributes but JSON one does not in netstandard1.3.
+                PropertyWithoutAttribute = "false"
+#endif
+            };
             return SerializerConsistencyHepers.TestAsync(c);
         }
 
@@ -62,6 +66,7 @@ namespace System.Net.Formatting.Tests
             return SerializerConsistencyHepers.TestAsync(source);
         }
 
+#if !Testing_NetStandard1_3 // XmlSerializer is unable to write XML for a dictionary.
         [Fact]
         public Task Dictionary()
         {
@@ -71,6 +76,7 @@ namespace System.Net.Formatting.Tests
 
             return SerializerConsistencyHepers.TestAsync(dict);
         }
+#endif
 
         [Fact]
         public Task Array()
@@ -80,6 +86,7 @@ namespace System.Net.Formatting.Tests
             return SerializerConsistencyHepers.TestAsync(array);
         }
 
+#if !Testing_NetStandard1_3 // XmlSerializer is unable to read XML for interfaces.
         [Fact]
         public async Task ArrayInterfaces()
         {
@@ -99,6 +106,7 @@ namespace System.Net.Formatting.Tests
             // So explicitly call out IEnumerable<T>
             return SerializerConsistencyHepers.TestAsync(l, typeof(IEnumerable<int>));
         }
+#endif
 
         [Fact]
         public Task StaticProps()
@@ -141,8 +149,10 @@ namespace System.Net.Formatting.Tests
         [DataMember]
         public string PropertyWithAttribute { get; set; }
 
+#if !Testing_NetStandard1_3 // Xml formatter ignores DCS attributes but JSON one does not in netstandard1.3.
         // no attribute here
         public string PropertyWithoutAttribute { get; set; }
+#endif
     }
 
     public class PrivateProperty // with private field

--- a/test/System.Net.Http.Formatting.Test/HttpClientExtensionsTest.cs
+++ b/test/System.Net.Http.Formatting.Test/HttpClientExtensionsTest.cs
@@ -66,6 +66,7 @@ namespace System.Net.Http
             Assert.ThrowsArgumentNull(() => client.PostAsXmlAsync("http://www.example.com", new object()), "client");
         }
 
+#if !Testing_NetStandard1_3 // Avoid "The configured formatter 'System.Net.Http.Formatting.XmlMediaTypeFormatter' cannot write an object of type 'Object'."
         [Fact]
         public void PostAsXmlAsync_String_WhenUriIsNull_ThrowsException()
         {
@@ -81,6 +82,7 @@ namespace System.Net.Http
             var content = Assert.IsType<ObjectContent<object>>(response.RequestMessage.Content);
             Assert.IsType<XmlMediaTypeFormatter>(content.Formatter);
         }
+#endif
 
         [Fact]
         public void PostAsync_String_WhenClientIsNull_ThrowsException()
@@ -195,6 +197,7 @@ namespace System.Net.Http
             Assert.ThrowsArgumentNull(() => client.PutAsXmlAsync("http://www.example.com", new object()), "client");
         }
 
+#if !Testing_NetStandard1_3 // Avoid "The configured formatter 'System.Net.Http.Formatting.XmlMediaTypeFormatter' cannot write an object of type 'Object'."
         [Fact]
         public void PutAsXmlAsync_String_WhenUriIsNull_ThrowsException()
         {
@@ -210,6 +213,7 @@ namespace System.Net.Http
             var content = Assert.IsType<ObjectContent<object>>(response.RequestMessage.Content);
             Assert.IsType<XmlMediaTypeFormatter>(content.Formatter);
         }
+#endif
 
         [Fact]
         public void PutAsync_String_WhenClientIsNull_ThrowsException()
@@ -324,6 +328,7 @@ namespace System.Net.Http
             Assert.ThrowsArgumentNull(() => client.PostAsXmlAsync(new Uri("http://www.example.com"), new object()), "client");
         }
 
+#if !Testing_NetStandard1_3 // Avoid "The configured formatter 'System.Net.Http.Formatting.XmlMediaTypeFormatter' cannot write an object of type 'Object'."
         [Fact]
         public void PostAsXmlAsync_Uri_WhenUriIsNull_ThrowsException()
         {
@@ -339,6 +344,7 @@ namespace System.Net.Http
             var content = Assert.IsType<ObjectContent<object>>(response.RequestMessage.Content);
             Assert.IsType<XmlMediaTypeFormatter>(content.Formatter);
         }
+#endif
 
         [Fact]
         public void PostAsync_Uri_WhenClientIsNull_ThrowsException()
@@ -453,6 +459,7 @@ namespace System.Net.Http
             Assert.ThrowsArgumentNull(() => client.PutAsXmlAsync(new Uri("http://www.example.com"), new object()), "client");
         }
 
+#if !Testing_NetStandard1_3 // Avoid "The configured formatter 'System.Net.Http.Formatting.XmlMediaTypeFormatter' cannot write an object of type 'Object'."
         [Fact]
         public void PutAsXmlAsync_Uri_WhenUriIsNull_ThrowsException()
         {
@@ -468,6 +475,7 @@ namespace System.Net.Http
             var content = Assert.IsType<ObjectContent<object>>(response.RequestMessage.Content);
             Assert.IsType<XmlMediaTypeFormatter>(content.Formatter);
         }
+#endif
 
         [Fact]
         public void PutAsync_Uri_WhenClientIsNull_ThrowsException()


### PR DESCRIPTION
- stop trying to use DCS in the JSON and XML formatters
- if `UseDataContractSerializer` or `!UseXmlSerializer`:
  - `CanReadType(...)` and `CanWriteType(...)` always return `false`
  - `ReadFromStreamAsync(...)` and `WriteToStreamAsync(...)` always `throw`
- change default XML formatter configuration to use `XmlSerializer`
- adjust and disable tests in reaction
- add tests of new `netstandard1.3` behavior
- nits:
  - correct namespace of `SerializerConsistencyTests`; was alone in previous namespace
  - s/DataContractFormatter/XmlSerializerFormatter/ to reflect actual `XmlMediaTypeFormatter` test actions