### PR TITLE
Ignore header validation for etag

### DIFF
--- a/src/System.Net.Http.Formatting/Formatting/Parsers/InternetMessageFormatHeaderParser.cs
+++ b/src/System.Net.Http.Formatting/Formatting/Parsers/InternetMessageFormatHeaderParser.cs
@@ -320,7 +320,7 @@ namespace System.Net.Http.Formatting.Parsers
             {
                 var name = _name.ToString();
                 var value = _value.ToString().Trim(CurrentHeaderFieldStore._linearWhiteSpace);
-                if (string.Equals("expires", name, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals("expires", name, StringComparison.OrdinalIgnoreCase) || string.Equals("etag", name, StringComparison.OrdinalIgnoreCase))
                 {
                     ignoreHeaderValidation = true;
                 }


### PR DESCRIPTION
Header validation for `Expires` was deactivated (#313) because it caused issues in CacheCow. 

There is a similar issue for `ETag` and this PR also skips validation for ETag.

https://github.com/aliostad/CacheCow/issues/213#issuecomment-1399695558