### PR TITLE
Add Dependabot config for monthly NuGet updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      nuget:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,13 @@
 version: 2
+registries:
+  dotnet-public:
+    type: nuget-feed
+    url: https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json
 updates:
   - package-ecosystem: "nuget"
     directory: "/"
+    registries:
+      - dotnet-public
     schedule:
       interval: "monthly"
     groups:


### PR DESCRIPTION
Adds a dependabot config that updates NuGet packages monthly on `main`.